### PR TITLE
Properly interpret ROBOCOPY return codes

### DIFF
--- a/src/%ZPM/PackageManager/Developer/File.cls
+++ b/src/%ZPM/PackageManager/Developer/File.cls
@@ -42,7 +42,7 @@ ClassMethod RemoveDirectoryTree(pRoot As %String) As %Status
 				Set stdout=""
 				Set tCmd = $ListBuild("ROBOCOPY",tEmptyDir,pRoot,"/MIR")
 				Set tSC = ##class(%ZPM.PackageManager.Developer.Utils).RunCommand(, tCmd,.stdout,,.retCode)
-				if $$$ISERR(tSC),$Get(retCode)=1||($Get(retCode)=2) set tSC=$$$OK
+				if $$$ISERR(tSC),$Get(retCode)<8 set tSC=$$$OK
         
 			} Catch e {
 				Set tSC = e.AsStatus()
@@ -104,7 +104,7 @@ ClassMethod CopyDir(pSource As %String, pDest As %String, pDeleteFirst As %Boole
 	        Set stdout = ""
 	      }
 		  Set tSC = ##class(%ZPM.PackageManager.Developer.Utils).RunCommand(, tCmd,.stdout,,.retCode)
-		  if $$$ISERR(tSC),$Get(retCode)=1||($Get(retCode)=2) set tSC=$$$OK
+		  if $$$ISERR(tSC),$Get(retCode)<8 set tSC=$$$OK
 		}
 	} Catch e {
 		Set tSC = $$$EMBEDSC(tBadSC,e.AsStatus())


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/troubleshoot/windows-server/backup-and-storage/return-codes-used-robocopy-utility

Fixes #357 