### PR TITLE
keep uniq IRIS versions images, skip platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
     needs: 
       - prepare
     strategy:
+      fail-fast: false
       matrix: 
         image: ${{ fromJson(needs.prepare.outputs.images) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           images=""
           for n in $name; do
-            tags=$(curl -su ":" https://containers.intersystems.com/v2/intersystems/${n}/tags/list | jq -r '.tags[]')
+            tags=$(curl -su ":" https://containers.intersystems.com/v2/intersystems/${n}/tags/list | jq -r '.tags[]' | cut -d '-' -f1 | uniq)
             for tag in $tags; do images+='"'${n}:${tag}'",'; done
           done;
           echo ::set-output name=images::"[${images%?}]"


### PR DESCRIPTION
<img width="802" alt="image" src="https://user-images.githubusercontent.com/1212251/218036349-d926294b-50a2-4ed8-a648-d0e7c9751f45.png">
This change will skip testing on images with platforms (`-linux-amd64` and `-linux-arm64v8`) suffixes