### PR TITLE
Set up for `intersystems-community.testingmanager` VS Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "intersystems.language-server",
+    "intersystems-community.testingmanager",
+    "intersystems-community.vscode-objectscript",
+    "ms-azuretools.vscode-docker"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,6 @@
     "username": "_system",
     "password": "SYS",
     "ns": "%SYS"
-  }
-
+  },
+  "intersystems.testingManager.client.relativeTestRoot": "tests/unit_tests"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN --mount=type=bind,src=.,dst=/home/irisowner/zpm/ \
   iris start iris && \
   iris session iris "##class(%SYSTEM.OBJ).Load(\"/home/irisowner/zpm/Installer.cls\",\"ck\")" && \
   iris session iris "##class(%ZPM.Installer).setup(\"/home/irisowner/zpm/\",3)" && \
+  iris session iris "##class(%ZPM.PackageManager).Shell(\"install vscode-per-namespace-settings\")" && \
   iris stop iris quietly


### PR DESCRIPTION
This PR configures the IRIS container so the project's unit tests can be run directly from the VS Code testing view, thanks to the [InterSystems Testing Manager](https://marketplace.visualstudio.com/items?itemName=intersystems-community.testingmanager) extension.

One manual step is still currently required after the container has been (re)built:

```
%SYS>set ^UnitTestRoot="/usr/irissys/.vscode/%SYS/UnitTestRoot"
```

When PR #414 has been merged it should be easy to automate this step.