### PR TITLE
Set the ^UnitTestRoot node when building the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,5 @@ ARG REGISTRY=https://pm.community.intersystems.com
 
 RUN --mount=type=bind,src=.,dst=/home/irisowner/zpm/ \
   iris start iris && \
-  iris session iris "##class(%SYSTEM.OBJ).Load(\"/home/irisowner/zpm/Installer.cls\",\"ck\")" && \
-  iris session iris "##class(%ZPM.Installer).setup(\"/home/irisowner/zpm/\",3)" && \
-  iris session iris "##class(%ZPM.PackageManager).Shell(\"install vscode-per-namespace-settings\")" && \
+	iris session IRIS < /home/irisowner/zpm/iris.script && \
   iris stop iris quietly

--- a/iris.script
+++ b/iris.script
@@ -1,0 +1,6 @@
+  zn "%SYS"
+  do ##class(%SYSTEM.OBJ).Load("/home/irisowner/zpm/Installer.cls","ck")
+  do ##class(%ZPM.Installer).setup("/home/irisowner/zpm/",3)
+  do ##class(%ZPM.PackageManager).Shell("install vscode-per-namespace-settings")
+  set ^UnitTestRoot="/usr/irissys/.vscode/%SYS/UnitTestRoot"
+  halt


### PR DESCRIPTION
This is a follow-up to #415. It switches to using an `iris.script` file for the sequence of ObjectScript commands that need to be run when the container is being built, and adds the one that completes integration of InterSystems Testing Manager.