### PR TITLE
fix: IPM works with delimited identifiers disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HSIEO-9430: Module definition should not expose DisplayName + deprecate DisplayNameInternal as it will not be used anymore
 - HSIEO-9924: RunDev needs to do complete installation of component and dependencies via ignoreInstalled, so adding ignoreInstalledModules checker in syncLoadDependencies
 - HSIEO-10267: Bug Fix - Resource name should be the fifth argument of CreateDatabase
+- #440: IPM works with delimited identifiers disabled
 
 ### Security
 -

--- a/src/cls/IPM/ExtensionBase/Utils.cls
+++ b/src/cls/IPM/ExtensionBase/Utils.cls
@@ -117,7 +117,7 @@ ClassMethod FindHomeModule(pInternalName As %String, Output pResourceName As %St
 		// Try to find in specific resources
 		Set tProcessorClass = "LegacyLocalizedMessages"
 		Set tProcessorClassFullForm = $$$DefaultProcessorPackageDot_tProcessorClass
-		Set tQuery = "SELECT ID, Name, ""Module"" FROM %IPM_Storage.ResourceReference "_
+		Set tQuery = "SELECT ID, Name, _Module FROM %IPM_Storage.ResourceReference "_
 			"WHERE ProcessorClass = '"_tProcessorClass_"' "_
 			"OR ProcessorClass = '"_tProcessorClassFullForm_"'"
 		#dim tResultSet As %SQL.StatementResult
@@ -145,7 +145,7 @@ ClassMethod FindHomeModule(pInternalName As %String, Output pResourceName As %St
 				// Found matching module so return
 				Set pResourceReference = tReference
 				Set pResourceName = tResultSet.%Get("Name")
-				Return ##class(%IPM.Storage.Module).%OpenId(tResultSet.%Get("Module"))
+				Return ##class(%IPM.Storage.Module).%OpenId(tResultSet.%Get("_Module"))
 			}
 		}
 		$$$ThrowOnError(tSC)

--- a/src/cls/IPM/ExtensionBase/Utils.cls
+++ b/src/cls/IPM/ExtensionBase/Utils.cls
@@ -117,7 +117,7 @@ ClassMethod FindHomeModule(pInternalName As %String, Output pResourceName As %St
 		// Try to find in specific resources
 		Set tProcessorClass = "LegacyLocalizedMessages"
 		Set tProcessorClassFullForm = $$$DefaultProcessorPackageDot_tProcessorClass
-		Set tQuery = "SELECT ID, Name, _Module FROM %IPM_Storage.ResourceReference "_
+		Set tQuery = "SELECT ID, Name, ModuleItem FROM %IPM_Storage.ResourceReference "_
 			"WHERE ProcessorClass = '"_tProcessorClass_"' "_
 			"OR ProcessorClass = '"_tProcessorClassFullForm_"'"
 		#dim tResultSet As %SQL.StatementResult
@@ -145,7 +145,7 @@ ClassMethod FindHomeModule(pInternalName As %String, Output pResourceName As %St
 				// Found matching module so return
 				Set pResourceReference = tReference
 				Set pResourceName = tResultSet.%Get("Name")
-				Return ##class(%IPM.Storage.Module).%OpenId(tResultSet.%Get("_Module"))
+				Return ##class(%IPM.Storage.Module).%OpenId(tResultSet.%Get("ModuleItem"))
 			}
 		}
 		$$$ThrowOnError(tSC)

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1819,12 +1819,12 @@ ClassMethod ShowModulesForRepository(pRepoName As %String, pShowRepo As %Boolean
 
 Query SourceControlClasses() As %SQLQuery(ROWSPEC = "ID:%String,Name:%String") [ SqlProc ]
 {
-	select Name as "ID",Name from %Dictionary.ClassDefinition_SubclassOf('%IPM.ExtensionBase.SourceControl.Interface')
+	select Name as ID,Name from %Dictionary.ClassDefinition_SubclassOf('%IPM.ExtensionBase.SourceControl.Interface')
 }
 
 Query ServerMenuExtensionClasses() As %SQLQuery(ROWSPEC = "ID:%String,Name:%String") [ SqlProc ]
 {
-	select Name as "ID",Name from %Dictionary.ClassDefinition_SubclassOf('%IPM.ExtensionBase.ServerMenu.Interface')
+	select Name as ID,Name from %Dictionary.ClassDefinition_SubclassOf('%IPM.ExtensionBase.ServerMenu.Interface')
 }
 
 ClassMethod LoadFromRepo(tDirectoryName, ByRef tParams) [ Internal ]

--- a/src/cls/IPM/Storage/InvokeReference.cls
+++ b/src/cls/IPM/Storage/InvokeReference.cls
@@ -11,13 +11,13 @@ Property Method As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE") [ Required
 
 Property Phase As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE") [ InitialExpression = "Configure" ];
 
-Property When As %String(MAXLEN = 255, VALUELIST = ",Before,After", XMLPROJECTION = "ATTRIBUTE") [ InitialExpression = "After" ];
+Property When As %String(MAXLEN = 255, VALUELIST = ",Before,After", XMLPROJECTION = "ATTRIBUTE") [ InitialExpression = "After", SqlFieldName = _WHEN ];
 
 Property CheckStatus As %Boolean(XMLPROJECTION = "ATTRIBUTE") [ InitialExpression = 0 ];
 
 Property Arg As list Of %String(MAXLEN = 255, XMLNAME = "Arg", XMLPROJECTION = "ELEMENT");
 
-Relationship Module As %IPM.Storage.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Invokes ];
+Relationship Module As %IPM.Storage.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Invokes, SqlFieldName = _MODULE ];
 
 Method GetArgsArray(pParams, Output args) As %Status
 {

--- a/src/cls/IPM/Storage/InvokeReference.cls
+++ b/src/cls/IPM/Storage/InvokeReference.cls
@@ -17,7 +17,7 @@ Property CheckStatus As %Boolean(XMLPROJECTION = "ATTRIBUTE") [ InitialExpressio
 
 Property Arg As list Of %String(MAXLEN = 255, XMLNAME = "Arg", XMLPROJECTION = "ELEMENT");
 
-Relationship Module As %IPM.Storage.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Invokes, SqlFieldName = _MODULE ];
+Relationship Module As %IPM.Storage.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Invokes, SqlFieldName = ModuleItem ];
 
 Method GetArgsArray(pParams, Output args) As %Status
 {

--- a/src/cls/IPM/Storage/MappingReference.cls
+++ b/src/cls/IPM/Storage/MappingReference.cls
@@ -10,7 +10,7 @@ Property Name As %String(MAXLEN = 2048, XMLPROJECTION = "attribute") [ Required 
 /// Name index is unique per namespace.
 Index ResourceName On (Name, Source);
 
-Relationship Module As %IPM.Storage.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Mappings, SqlFieldName = _MODULE ];
+Relationship Module As %IPM.Storage.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Mappings, SqlFieldName = ModuleItem ];
 
 /// Database from which it is mapped or copied
 Property Source As %String(MAXLEN = 64, XMLPROJECTION = "ATTRIBUTE");

--- a/src/cls/IPM/Storage/MappingReference.cls
+++ b/src/cls/IPM/Storage/MappingReference.cls
@@ -10,7 +10,7 @@ Property Name As %String(MAXLEN = 2048, XMLPROJECTION = "attribute") [ Required 
 /// Name index is unique per namespace.
 Index ResourceName On (Name, Source);
 
-Relationship Module As %IPM.Storage.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Mappings ];
+Relationship Module As %IPM.Storage.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Mappings, SqlFieldName = _MODULE ];
 
 /// Database from which it is mapped or copied
 Property Source As %String(MAXLEN = 64, XMLPROJECTION = "ATTRIBUTE");

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -1390,10 +1390,10 @@ Method Lock() As %Status
 
 Query VersionRequirements(pOfModuleName As %String, pExcludeModuleNames As %List = "") As %SQLQuery [ SqlProc ]
 {
-	select distinct %exact Dependencies_VersionString "Version",%DLIST("ModuleItem"->Name) "Names"
+	select distinct %exact Dependencies_VersionString As Version,%DLIST(ModuleItem->Name) As ModuleNames
 	from %IPM_Storage.ModuleItem_Dependencies
 	where Dependencies_Name = :pOfModuleName and
-		(:pExcludeModuleNames is null or "ModuleItem"->Name not %INLIST :pExcludeModuleNames)
+		(:pExcludeModuleNames is null or ModuleItem->Name not %INLIST :pExcludeModuleNames)
 	group by Dependencies_VersionString
 }
 
@@ -1413,14 +1413,15 @@ Method %Evaluate(pAttrValue As %String, ByRef pParams) As %String [ Internal ]
 		Return tAttrValue
 	}
 	Merge tParams = pParams
-	Do ##class(%IPM.Storage.ModuleSetting.Default).GetCustomParameters(.customParams, ..NameOpen(..Name), .tParams)
+	Do ##class(%IPM.Storage.ModuleSetting.Default).GetCustomParameters(.customParams, $this, .tParams)
 	Set root = ..Root
 	If (root '= "") {
 		Set root = ##class(%Library.File).NormalizeDirectory(root)
 	}
 	Set customParams("root") = root
-  Set customParams("packagename") = ..Name
-  Set customParams("version") = ..VersionString
+	Set customParams("packagename") = ..Name
+	Set customParams("version") = ..VersionString
+	Set customParams("verbose") = +$Get(pParams("Verbose"))
 	Set tAttrValue = ##class(%IPM.Storage.ModuleSetting.Default).EvaluateAttribute(tAttrValue,.customParams)
 	Set attrValue = ##class(%IPM.Utils.Module).%EvaluateSystemExpression(tAttrValue)
 	

--- a/src/cls/IPM/Storage/ResourceReference.cls
+++ b/src/cls/IPM/Storage/ResourceReference.cls
@@ -14,7 +14,7 @@ Property Name As %String(MAXLEN = 255, XMLPROJECTION = "attribute") [ Required ]
 /// Name index is unique per namespace.
 Index ResourceName On UniqueName [ Unique ];
 
-Relationship Module As %IPM.Storage.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Resources ];
+Relationship Module As %IPM.Storage.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Resources, SqlFieldName = _MODULE ];
 
 /// Restrict the scope in which this resource is included. Default is "all scopes"
 Property Scope As %String(VALUELIST = ",test,verify", XMLPROJECTION = "ATTRIBUTE");
@@ -437,7 +437,7 @@ Trigger OnChange [ Event = INSERT/UPDATE, Foreach = row/object, Time = AFTER ]
 		If $Data($$$ZPMDeferModifyResources) {
 			Quit
 		}
-		Set tModule = ##class(%IPM.Storage.Module).%OpenId({Module},,.tSC)
+		Set tModule = ##class(%IPM.Storage.Module).%OpenId({_Module},,.tSC)
 		If $$$ISERR(tSC) {
 			Quit
 		}

--- a/src/cls/IPM/Storage/ResourceReference.cls
+++ b/src/cls/IPM/Storage/ResourceReference.cls
@@ -14,7 +14,7 @@ Property Name As %String(MAXLEN = 255, XMLPROJECTION = "attribute") [ Required ]
 /// Name index is unique per namespace.
 Index ResourceName On UniqueName [ Unique ];
 
-Relationship Module As %IPM.Storage.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Resources, SqlFieldName = _MODULE ];
+Relationship Module As %IPM.Storage.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Resources, SqlFieldName = ModuleItem ];
 
 /// Restrict the scope in which this resource is included. Default is "all scopes"
 Property Scope As %String(VALUELIST = ",test,verify", XMLPROJECTION = "ATTRIBUTE");
@@ -437,7 +437,7 @@ Trigger OnChange [ Event = INSERT/UPDATE, Foreach = row/object, Time = AFTER ]
 		If $Data($$$ZPMDeferModifyResources) {
 			Quit
 		}
-		Set tModule = ##class(%IPM.Storage.Module).%OpenId({_Module},,.tSC)
+		Set tModule = ##class(%IPM.Storage.Module).%OpenId({ModuleItem},,.tSC)
 		If $$$ISERR(tSC) {
 			Quit
 		}

--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -489,7 +489,7 @@ ClassMethod GetRequiredVersionExpression(pModuleName As %String, pExcludeModules
 			Set tVersion = tResult.%Get("Version")
 			$$$ThrowOnError(##class(%IPM.General.SemanticVersionExpression).FromString(tVersion,.tVersionExpr))
 			Set pExpression = pExpression.And(tVersionExpr)
-			Set pSourceList = pSourceList_$ListBuild($ListToString(tResult.%Get("Names"),", ")_": "_tVersion)
+			Set pSourceList = pSourceList_$ListBuild($ListToString(tResult.%Get("ModuleNames"),", ")_": "_tVersion)
 		}
 		$$$ThrowOnError(tSC)
 	} Catch e {


### PR DESCRIPTION
Also picks up a fix for a stray failing unit test - ${verbose} / {$verbose} weren't working in expression evaluation

Fixes #440 