### PR TITLE
fix: also look for % items in folder with % stripped

### DIFF
--- a/src/%ZPM/PackageManager/Developer/Processor/Default/Document.cls
+++ b/src/%ZPM/PackageManager/Developer/Processor/Default/Document.cls
@@ -82,6 +82,7 @@ Method OnPhase(pPhase As %String, ByRef pParams, Output pResourceHandled As %Boo
       Set tListNames = tListNames _ $ListBuild(tName)
       Set tListNames = tListNames _ $ListBuild($Translate(tName, "%", "_"))
       Set tListNames = tListNames _ $ListBuild($Translate(tName, "_", ""))
+      Set tListNames = tListNames _ $ListBuild($Translate(tName, "%", ""))
 
       Set ptrn = 0
       While $ListNext(tListNames, ptrn, tName) {
@@ -603,3 +604,4 @@ Method OnGetUniqueName(Output pUniqueName)
 }
 
 }
+


### PR DESCRIPTION
This provides advance support for something v0.9.0 needs.

Fixes #449 