### PR TITLE
Run on fewer container versions

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           images=""
           for n in $name; do
-            tags=$(curl -su ":" https://containers.intersystems.com/v2/intersystems/${n}/tags/list | jq -r '.tags[]' | awk '!/(-linux)|([1-4]-preview)|(-em)|(-cd)/' | awk '!/\.[1-4]\./' | uniq)
+            tags=$(curl -su ":" https://containers.intersystems.com/v2/intersystems/${n}/tags/list | jq -r '.tags[]' | awk '!/(-linux)|([1-4]-preview)|(-em)|(-cd)/' | awk '!/\.[1-4]\./' | sort | uniq)
             for tag in $tags
             do
               # Skip irishealth-community due to bad interaction with ZPM document type

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -11,8 +11,8 @@ on:
 
 env:
   name: |
-    irishealth-community
     iris-community
+    irishealth-community
  
 jobs:
   images:
@@ -26,8 +26,16 @@ jobs:
         run: |
           images=""
           for n in $name; do
-            tags=$(curl -su ":" https://containers.intersystems.com/v2/intersystems/${n}/tags/list | jq -r '.tags[]' | awk '!/(-linux)|([1-4]-preview)/' | awk '!/\.[1-4]\.0\./' | uniq)
-            for tag in $tags; do images+='"'${n}:${tag}'",'; done
+            tags=$(curl -su ":" https://containers.intersystems.com/v2/intersystems/${n}/tags/list | jq -r '.tags[]' | awk '!/(-linux)|([1-4]-preview)|(-em)|(-cd)/' | awk '!/\.[1-4]\./' | uniq)
+            for tag in $tags
+            do
+              # Skip irishealth-community due to bad interaction with ZPM document type
+              if test "$n" = "irishealth-community" && test "$tag" = "2023.3"
+                then
+                  continue
+              fi
+              images+='"'${n}:${tag}'",';
+            done
           done;
           echo images="[${images%?}]" >> $GITHUB_OUTPUT
           echo main=${images%%,*} >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HSIEO-9430: Module definition should not expose DisplayName + deprecate DisplayNameInternal as it will not be used anymore
 - HSIEO-9924: RunDev needs to do complete installation of component and dependencies via ignoreInstalled, so adding ignoreInstalledModules checker in syncLoadDependencies
 - HSIEO-10267: Bug Fix - Resource name should be the fifth argument of CreateDatabase
+- #451: (CI) Run on fewer versions to minimize overhead and Community Edition expiration issues
+- #451: Avoid compliation errors due to storage location conflict on IRIS for Health prior to 2024.1
 
 ### Security
 -

--- a/src/cls/IPM/ExtensionBase/UniversalSettings.cls
+++ b/src/cls/IPM/ExtensionBase/UniversalSettings.cls
@@ -6,6 +6,9 @@ Parameter DEFAULTGLOBAL = "^IPM.ExtensionBase.UniSettings";
 /// A string to show in the grouping of settings for this class.
 Parameter DESCRIPTION = "Universal source control options";
 
+/// Other classes may reasonably also map to this global, so don't complain about it.
+Parameter MANAGEDEXTENT As INTEGER [ Constraint = "0,1", Flags = ENUM ] = 0;
+
 /// An inherited IDKey index on this property means that the default value is
 /// used as a subscript under <DataLocation> in the storage definition.
 Property Key As %String [ InitialExpression = {$classname()}, ReadOnly ];


### PR DESCRIPTION
This will make CI faster and still provide sufficient coverage of relevant versions. We now only run on the major.minor container tags (latest maint release) and latest-preview. This skips over a bunch we were trying before that had expired community edition licenses.

This change partially addresses #451 but doesn't provide the entire solution.