### PR TITLE
fix: truly support multiple registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HSIEO-9484: Add additional argument to buildDepsGraph to allow putting in an additional list element of dependency's DisplayName
 - HSIEO-9484: Add additional property DisplayName to %IPM.Storage.ModuleReference
 - HSIEO-10274: Separate DependencyAnalyzer out from IPM
+- #261: We no longer default to using only the deployment registry for zpm "install" if there are multiple registries configured and a registry is not specified as a package prefix.
 
 ### Fixed
 - HSIEO-9269, HSIEO-9402: % percent perforce directories are no longer necessary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HSIEO-9484: Add additional argument to buildDepsGraph to allow putting in an additional list element of dependency's DisplayName
 - HSIEO-9484: Add additional property DisplayName to %IPM.Storage.ModuleReference
 - HSIEO-10274: Separate DependencyAnalyzer out from IPM
-- #261: We no longer default to using only the deployment registry for zpm "install" if there are multiple registries configured and a registry is not specified as a package prefix.
+- #261: IPM now truly supports using multiple registries for installation / discovery of packages (without needing to prefix the package with the registry name on "install", although it is still possible and now effective to use the prefix).
 
 ### Fixed
 - HSIEO-9269, HSIEO-9402: % percent perforce directories are no longer necessary

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1881,12 +1881,6 @@ ClassMethod Install(ByRef pCommandInfo) [ Internal ]
   If (tModuleName = "") {
     Quit $$$OK
   }
-	If tRegistry = "" {
-		Set tServer = ##class(%IPM.Repo.Remote.Definition).DeploymentServerOpen(1,,.tSC)
-		If $IsObject(tServer) {
-			Set tRegistry = tServer.Name
-		}
-	}
 
 	Set tVersion = $Get(pCommandInfo("parameters","version"))
 	Set tKeywords = $$$GetModifier(pCommandInfo,"keywords")

--- a/src/cls/IPM/Repo/Manager.cls
+++ b/src/cls/IPM/Repo/Manager.cls
@@ -52,7 +52,11 @@ Method SearchRepositoriesForModule(pSearchCriteria As %IPM.Repo.SearchCriteria, 
 	Try {
     Set registry = pSearchCriteria.Registry
 	Set pSearchCriteria.Name = $$$lcase(pSearchCriteria.Name)
-    Set tRes = ##class(%SQL.Statement).%ExecDirect(,"select ID from %IPM_Repo.Definition where Enabled = 1 and (:registry is null or Name = :registry) order by %IPM_Repo.Definition_SortOrder(ID)")
+    Set tRes = ##class(%SQL.Statement).%ExecDirect(,
+		"select ID from %IPM_Repo.Definition "_
+		"where Enabled = 1 "_
+		"and (? is null or Name = ?) order by %IPM_Repo.Definition_SortOrder(ID)",
+		registry,registry)
 		If (tRes.%SQLCODE < 0) {
 			Set tSC = $$$ERROR($$$SQLCode,tRes.%SQLCODE,tRes.%Message)
 			Quit


### PR DESCRIPTION
Fixes #261 

This boils down to truly supporting multiple registries - that is, even if there is a deployment server enabled, we won't automatically force installation from there (as was previously intended but didn't actually work).

This is a "change" from a semver perspective because it's possible that users were relying on the old / incorrect behavior of "install"