### PR TITLE
fix: behavior of zpm "version" without internet access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #451: Avoid compliation errors due to storage location conflict on IRIS for Health prior to 2024.1
 - #455: Upgrade from %ZPM classes updates language extensions correctly to use %IPM
 - #373: Cleaner cross-version approach used in language extension routine generation
+- #459: zpm "version" behaves better without internet access
 
 ### Security
 -

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1145,7 +1145,7 @@ ClassMethod Version(ByRef pCommandInfo) [ Internal ]
 		$$$ThrowOnError(tSC)
 		Set tService = tRepository.GetPackageService()
 		Set tInfo = tService.GetInfo()
-		Write !,$$$FormattedLine($$$Blue,tRepository.URL)," - ",tInfo.version
+		Write !,$$$FormattedLine($$$Blue,tRepository.URL)," - ",tInfo.ToString()
 	}
 	Quit $$$OK
 }

--- a/src/cls/IPM/Repo/Remote/Info.cls
+++ b/src/cls/IPM/Repo/Remote/Info.cls
@@ -1,0 +1,15 @@
+Class %IPM.Repo.Remote.Info Extends (%RegisteredObject, %JSON.Adaptor)
+{
+
+Parameter %JSONIGNOREINVALIDFIELD As BOOLEAN = 1;
+
+Property version As %String;
+
+Property available As %Boolean [ InitialExpression = 1 ];
+
+Method ToString() As %String
+{
+    Quit $Select(..available:..version,1:"currently unavailable")
+}
+
+}

--- a/src/cls/IPM/Repo/Remote/PackageService.cls
+++ b/src/cls/IPM/Repo/Remote/PackageService.cls
@@ -11,17 +11,20 @@ Property Password As %String;
 
 Property Token As %String;
 
-Method GetInfo(url As %String) As %DynamicObject
+Method GetInfo() As %IPM.Repo.Remote.Info
 {
  	Set tRequest = ..GetHttpRequest()
+  Set tRequest.Timeout = 2 // Short timeout in case it's unavailable
  	Set tSC = tRequest.Get()
+  Set info = ##class(%IPM.Repo.Remote.Info).%New()
 
   If $$$ISOK(tSC), tRequest.HttpResponse.StatusCode=200 {
-    Set tRes = {}.%FromJSON(tRequest.HttpResponse.Data)
-    Return tRes
+    $$$ThrowOnError(info.%JSONImport(tRequest.HttpResponse.Data))
+  } Else {
+    Set info.available = 0
   }
-
-	$$$ThrowStatus($$$ERROR($$$GeneralError,"Registry server not available."))
+  
+  Return info
 }
 
 Method GetLatestModuleVersion(pModuleName As %String) As %String


### PR DESCRIPTION
Fixes #459 

Before:
```
USER>zpm "version"

HSLIB>       zpm 0.9.0+snapshot (DeveloperMode)
USER>        zpm 0.9.0+snapshot (DeveloperMode)
USER-VERIFY> zpm 0.9.0+snapshot
ERROR! Registry server not available.
```

After (when it fails, it fails much faster):
```
USER>zpm "version"

HSLIB>       zpm 0.9.0+snapshot (DeveloperMode)
USER>        zpm 0.9.0+snapshot (DeveloperMode)
USER-VERIFY> zpm 0.9.0+snapshot
https://pm.community.intersystems.com - 1.0.6
USER>zpm "version"

HSLIB>       zpm 0.9.0+snapshot (DeveloperMode)
USER>        zpm 0.9.0+snapshot (DeveloperMode)
USER-VERIFY> zpm 0.9.0+snapshot
https://pm.community.intersystems.com - currently unavailable
```