### PR TITLE
fix: exact prerelease match (HSIEO-10520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HSIEO-9430: Module definition should not expose DisplayName + deprecate DisplayNameInternal as it will not be used anymore
 - HSIEO-9924: RunDev needs to do complete installation of component and dependencies via ignoreInstalled, so adding ignoreInstalledModules checker in syncLoadDependencies
 - HSIEO-10267: Bug Fix - Resource name should be the fifth argument of CreateDatabase
+- HSIEO-10520: Pre-Release module versions does not get exact version match
 - #440: IPM works with delimited identifiers disabled
 - #451: CI runs on fewer versions to minimize overhead and Community Edition expiration issues
 - #451, #428: Fixes "Verify" phase to work properly after %IPM rename

--- a/src/cls/IPM/General/SemanticVersionExpression/Comparator.cls
+++ b/src/cls/IPM/General/SemanticVersionExpression/Comparator.cls
@@ -93,6 +93,10 @@ Method Evaluate(pVersion As %IPM.General.SemanticVersion) As %Boolean
       Set tEquals = tEquals && (val1 = val2)
     }
   }
+	If ($Extract(..Operator,1) = "=") {
+		// Means direct equality and not <= or >= so compare pre-release as well
+		Set tEquals = tEquals && (pVersion.Prerelease = ..Prerelease)
+	}
 	If tEquals || (..Operator = "=") {
 		Quit tEquals
 	}

--- a/tests/unit_tests/Test/PM/Unit/SemVer/Expressions.cls
+++ b/tests/unit_tests/Test/PM/Unit/SemVer/Expressions.cls
@@ -27,6 +27,22 @@ Method TestEvaluate()
 	Do ..AssertNotSatisfied(tExpression,"2.0.0")
 }
 
+Method TestPrerelease()
+{
+	Do ..AssertSatisfied("1.0.0-beta.1","1.0.0-beta.1")
+	Do ..AssertSatisfied("=1.0.0-beta.1","1.0.0-beta.1")
+	Do ..AssertSatisfied(">=1.0.0-beta.1","1.0.0-beta.1")
+	Do ..AssertSatisfied(">=1.0.0-beta.1","1.0.0-beta.2")
+	Do ..AssertSatisfied(">=1.0.0-alpha.1","1.0.0-beta.1")
+	Do ..AssertSatisfied("^1.0.0","1.0.0-1.m1")
+	Do ..AssertNotSatisfied(">=1.0.0-beta.2","1.0.0-beta.1")
+	Do ..AssertNotSatisfied(">=1.0.0-beta.1","1.0.0-alpha.1")
+	
+	// This is the problematic case without HSIEO-10520
+	Do ..AssertNotSatisfied("1.0.0-1.m1","1.0.0") 
+	Do ..AssertNotSatisfied("=1.0.0-1.m1","1.0.0")
+}
+
 Method TestEquivalenceHyphenRanges()
 {
 	Do ..AssertEquivalent("1.2.3 - 2.3.4", ">=1.2.3 <=2.3.4")


### PR DESCRIPTION
Merged from internal repo.

Note: this gets GitHub up-to-date with internal work, though I believe @isc-eneil also has work in progress that will need to merge. Other than that in-progress work, this was the last straggler.