### PR TITLE
Support enabling IPM instance-wide

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -19,6 +19,7 @@
   <UnitTest Name="/tests/integration_tests/" Package="Test.PM.Integration" Phase="verify"/>
   <Resource Name="/doc/README.txt"/>
   <Invoke Class="IPM.Installer" Method="Map" Phase="Reload" When="Before" />
+  <Invoke Class="IPM.Installer" Method="MapIfLegacy" Phase="Compile" When="After" />
   <Invoke Class="%IPM.Main" Method="UpdateLanguageExtensions" />
   <Invoke Class="%IPM.Utils.Migration" Method="RunAll">
     <Arg>${verbose}</Arg>

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -44,10 +44,10 @@ XData PM [ XMLNamespace = INSTALLER ]
 XData MapOnly [ XMLNamespace = INSTALLER ]
 {
 <Manifest>
-  <Namespace Name="${CURNS}" Code="${CURNSRoutineDB}" Data="${CURNSGlobalDB}" Create="overwrite" Ensemble="0">
+  <Namespace Name="${CURNS}" Code="${CURNSRoutineDB}" Data="${CURNSGlobalDB}" Create="no" Ensemble="0">
     <Configuration>
         <ClassMapping Package="%IPM" From="${CURNSRoutineDB}" />
-        <RoutineMapping Routines="%IPM.*" Type="ALL" From="${CURNSRoutineDB}"/> 
+        <RoutineMapping Routines="%IPM.*" Type="ALL" From="${CURNSRoutineDB}" /> 
     </Configuration>
   </Namespace>
 </Manifest>
@@ -80,6 +80,7 @@ ClassMethod Map(ByRef pVars, pLogLevel As %Integer, pInstaller As %Installer.Ins
   Do %code.WriteLine(" Set sc = ##class(Config.Namespaces).Get(prevNS, .properties)")
   Do %code.WriteLine(" Set pVars(""CURNSRoutineDB"")=$Get(properties(""Routines""))")
   Do %code.WriteLine(" Set pVars(""CURNSGlobalDB"")=$Get(properties(""Globals""))")
+  Do %code.WriteLine(" If ##class(Config.MapPackages).Exists(prevNS,""%IPM"") { Quit $$$OK }")
   Quit ##class(%Installer.Manifest).%Generate(%compiledclass, %code, "MapOnly")
 }
 

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -35,7 +35,6 @@ XData PM [ XMLNamespace = INSTALLER ]
     <Arg Value="${MODDIR}"/>
   </Invoke>
   <Invoke Class="IPM.Installer" Method="ZPMCompile" CheckStatus="true" />
-  <Invoke Class="IPM.Installer" Method="MapIfLegacy" CheckStatus="true" />
 </Namespace>
 
 </Manifest>

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -35,6 +35,7 @@ XData PM [ XMLNamespace = INSTALLER ]
     <Arg Value="${MODDIR}"/>
   </Invoke>
   <Invoke Class="IPM.Installer" Method="ZPMCompile" CheckStatus="true" />
+  <Invoke Class="IPM.Installer" Method="MapIfLegacy" CheckStatus="true" />
 </Namespace>
 
 </Manifest>
@@ -43,10 +44,10 @@ XData PM [ XMLNamespace = INSTALLER ]
 XData MapOnly [ XMLNamespace = INSTALLER ]
 {
 <Manifest>
-  <Namespace Name="${CURNS}" Code="${CURNSRoutineDB}" Data="${CURNSGlobalDB}" Create="no" Ensemble="0">
+  <Namespace Name="${CURNS}" Code="${CURNSRoutineDB}" Data="${CURNSGlobalDB}" Create="overwrite" Ensemble="0">
     <Configuration>
         <ClassMapping Package="%IPM" From="${CURNSRoutineDB}" />
-        <RoutineMapping Routines="%IPM.*" Type="ALL" From="${CURNSRoutineDB}" /> 
+        <RoutineMapping Routines="%IPM.*" Type="ALL" From="${CURNSRoutineDB}"/> 
     </Configuration>
   </Namespace>
 </Manifest>
@@ -79,7 +80,6 @@ ClassMethod Map(ByRef pVars, pLogLevel As %Integer, pInstaller As %Installer.Ins
   Do %code.WriteLine(" Set sc = ##class(Config.Namespaces).Get(prevNS, .properties)")
   Do %code.WriteLine(" Set pVars(""CURNSRoutineDB"")=$Get(properties(""Routines""))")
   Do %code.WriteLine(" Set pVars(""CURNSGlobalDB"")=$Get(properties(""Globals""))")
-  Do %code.WriteLine(" If ##class(Config.MapPackages).Exists(prevNS,""%IPM"") { Quit $$$OK }")
   Quit ##class(%Installer.Manifest).%Generate(%compiledclass, %code, "MapOnly")
 }
 
@@ -113,6 +113,14 @@ ClassMethod ZPMLoad(pDirectoryName)
 ClassMethod ZPMCompile()
 {
   Quit ##class(%IPM.Main).Shell("ZPM compile")
+}
+
+ClassMethod MapIfLegacy()
+{
+  If ##class(%IPM.Utils.Migration).HasLegacyZPMPackage() {
+    Quit ##class(%IPM.Main).Shell("enable -globally -map")
+  }
+  Quit $$$OK
 }
 
 ClassMethod EndCompile(qstruct) As %Status

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2697,6 +2697,8 @@ ZPM(pArgs...)
  	Do ##class(%IPM.Main).Shell(pArgs...) Quit
  } Else {
 	// TODO: Needs to support enabling IPM from here, also need to decide what level of customization to provide
+	Set tQuitOnError = $Get(pArgs(2))
+	Set tHaltOnComplete = $Get(pArgs(3))
 	Write !, "IPM is not enabled in this namespace."
 	&sql(SELECT %DLIST(Nsp) INTO :namespaces FROM %SYS.Namespace_List())
 	If SQLCODE '= 0 {
@@ -2704,18 +2706,32 @@ ZPM(pArgs...)
 	} Else {
 		New $Namespace
 		Set ptr = 0
+		Set found = 0	
 		While $ListNext(namespaces, ptr, ns) {
 			Set $Namespace = $Zstrip(ns, "<>WC")
 			If $System.CLS.IsMthd("%IPM.Main", "Shell") {
 				Write !, "Change namepace to one of the following to run the ""zpm"" command"
 				Do ##class(%IPM.Main).Shell("version")
-				Return ""
+				Set found = 1
+				Quit
 			}
 		}
 		// Shouldn't happen since %ZLANGC00.mac and %ZLANGF00.mac are present
-		Write "No namespace found with IPM enabled."
+		If 'found {
+			Write !, "No namespace found with IPM enabled."
+		}
 	}
-	Quit ""
+
+	If tQuitOnError {
+		Write ! // Add a newline before quitting, otherwise the shell prompt will be on the same line as the error message
+		Do $System.Process.Terminate($Job, 1)
+	}
+	If tHaltOnComplete {
+		Write ! // Add a newline before halting
+		Halt
+	}
+	// The $$$ERROR macro is not available for use in language extension
+	Return $$Error^%apiOBJ(5001,"IPM is not enabled in this namespace.")
  }
 }
 

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -611,7 +611,7 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
 		<!-- Modifiers -->
 		<modifier name="version" aliases="v" value="true" description="A special version of IPM can be provided. If not specified, the latest version from the registry will be installed (hence is not required if quiet flag is set)."/>
 		<modifier name="namespaces" aliases="ns" value="true" description="Comma-separated namespaces in which IPM needs to be enabled."/>
-		<modifier name="globally" aliases="g" description="Will install IPM in all non-%SYS explicit namespaces that currently do not have IPM installed. By default, this modifier is not set and will not install globally."/>
+		<modifier name="globally" aliases="g" description="Will install IPM in all explicit namespaces that currently do not have IPM installed. Unless using it together with the -map option, will not include %SYS. By default, this modifier is not set and will not install globally."/>
 		<modifier name="local-only" description="If specified, only local artifacts will be used for installation. By default, this modifier is not set and will not limit to local artifacts." />
 		<modifier name="allow-upgrade" description="If specified, will also check for IPM version in specified namespaces and upgrade if version is lower than the target version. By deafult, this modifier is not ste and will not allow upgrade." />
 		<modifier name="map" aliases="m" description="If specified, will map IPM code from the current namespace-default code database rather than installing a separate copy." />

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2648,8 +2648,25 @@ ZPM(pArgs...)
  If $System.CLS.IsMthd("%IPM.Main", "Shell") { 
  	Do ##class(%IPM.Main).Shell(pArgs...) Quit
  } Else {
-	// TODO: Decide what to do here; definitely needs to support enabling IPM from here as well,
-	// but need to decide what level of customization to provide
+	// TODO: Needs to support enabling IPM from here, also need to decide what level of customization to provide
+	Write !, "IPM is not enabled in this namespace."
+	&sql(SELECT %DLIST(Nsp) INTO :namespaces FROM %SYS.Namespace_List())
+	If SQLCODE '= 0 {
+		Write !, "Error getting namespace name. SQLCODE =", SQLCODE
+	} Else {
+		New $Namespace
+		Set ptr = 0
+		While $ListNext(namespaces, ptr, ns) {
+			Set $Namespace = $Zstrip(ns, "<>WC")
+			If $System.CLS.IsMthd("%IPM.Main", "Shell") {
+				Write !, "Change namepace to one of the following to run the ""zpm"" command"
+				Do ##class(%IPM.Main).Shell("version")
+				Return ""
+			}
+		}
+		// Shouldn't happen since %ZLANGC00.mac and %ZLANGF00.mac are present
+		Write "No namespace found with IPM enabled."
+	}
 	Quit ""
  }
 }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -613,7 +613,7 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
 		<modifier name="namespaces" aliases="ns" value="true" description="Comma-separated namespaces in which IPM needs to be enabled."/>
 		<modifier name="globally" aliases="g" description="Will install IPM in all explicit namespaces that currently do not have IPM installed. Unless using it together with the -map option, will not include %SYS. By default, this modifier is not set and will not install globally."/>
 		<modifier name="local-only" description="If specified, only local artifacts will be used for installation. By default, this modifier is not set and will not limit to local artifacts." />
-		<modifier name="allow-upgrade" description="If specified, will also check for IPM version in specified namespaces and upgrade if version is lower than the target version. By deafult, this modifier is not ste and will not allow upgrade." />
+		<modifier name="allow-upgrade" description="If specified, will also check for IPM version in specified namespaces and upgrade if version is lower than the target version. By default, this modifier is not ste and will not allow upgrade." />
 		<modifier name="map" aliases="m" description="If specified, will map IPM code from the current namespace-default code database rather than installing a separate copy." />
 		<modifier name="quiet" aliases="q" description="Quiet mode. By default, this modifier is not set and will display the contents onto the terminal/caller command line." />
 		<modifier name="preview" aliases="p" description="Preview only - for -map option, shows the namespaces that would be enabled." />
@@ -637,7 +637,7 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
 
 <command name="unmap">
 	<summary>
-		Unmap %IPM package and rountines in specified namespaces. Will Skip non-mapped namespaces.
+		Unmap %IPM package and routines in specified namespaces. Will Skip non-mapped namespaces.
 	</summary>
 	<modifier name="namespaces" aliases="ns" value="true" description="Comma-separated namespaces in which IPM mapping needs to be deleted."/>
 	<modifier name="globally" aliases="g" description="Will unmap IPM in all explicit namespaces that currently do not have IPM installed."/>
@@ -2697,8 +2697,8 @@ ZPM(pArgs...)
  	Do ##class(%IPM.Main).Shell(pArgs...) Quit
  } Else {
 	// TODO: Needs to support enabling IPM from here, also need to decide what level of customization to provide
-	Set tQuitOnError = $Get(pArgs(2))
-	Set tHaltOnComplete = $Get(pArgs(3))
+	Set quitOnError = $Get(pArgs(2))
+	Set haltOnComplete = $Get(pArgs(3))
 	Write !, "IPM is not enabled in this namespace."
 	&sql(SELECT %DLIST(Nsp) INTO :namespaces FROM %SYS.Namespace_List())
 	If SQLCODE '= 0 {
@@ -2722,16 +2722,16 @@ ZPM(pArgs...)
 		}
 	}
 
-	If tQuitOnError {
+	If quitOnError {
 		Write ! // Add a newline before quitting, otherwise the shell prompt will be on the same line as the error message
 		Do $System.Process.Terminate($Job, 1)
 	}
-	If tHaltOnComplete {
+	If haltOnComplete {
 		Write ! // Add a newline before halting
 		Halt
 	}
 	// The $$$ERROR macro is not available for use in language extension
-	Return $$Error^%apiOBJ(5001,"IPM is not enabled in this namespace.")
+	Return $System.Status.Error(5001, "IPM is not enabled in this namespace.")
  }
 }
 

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -614,11 +614,11 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
 		<modifier name="globally" aliases="g" description="Will install IPM in all non-%SYS explicit namespaces that currently do not have IPM installed. By default, this modifier is not set and will not install globally."/>
 		<modifier name="local-only" description="If specified, only local artifacts will be used for installation. By default, this modifier is not set and will not limit to local artifacts." />
 		<modifier name="allow-upgrade" description="If specified, will also check for IPM version in specified namespaces and upgrade if version is lower than the target version. By deafult, this modifier is not ste and will not allow upgrade." />
-		<modifier name="map" aliases="m" description="If specified, will map IPM code from the current namespace-default code database rather than installing a separate copy. Can be used with -globally to add a %ALL namespace mapping." />
+		<modifier name="map" aliases="m" description="If specified, will map IPM code from the current namespace-default code database rather than installing a separate copy." />
 		<modifier name="quiet" aliases="q" description="Quiet mode. By default, this modifier is not set and will display the contents onto the terminal/caller command line." />
 		<modifier name="preview" aliases="p" description="Preview only - for -map option, shows the namespaces that would be enabled." />
 		<!-- Examples -->
-		<example description="Make IPM available in all namespaces (including %SYS) by mapping the version in the current namespace default routine database to the %ALL psuedo-namespace. Namespace-specific installation will override this.">
+		<example description="Make IPM available in all namespaces (including %SYS) by mapping the version in the current namespace default routine database. Namespace-specific installation will override this.">
 			enable -map -globally
 		</example>
 		<example description="Install IPM version 0.3.4 in quiet mode in namespaces: NS1, NS2, NS3.">

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2739,7 +2739,7 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
 {
 	New $Namespace
 	Set initNamespace = $Namespace
-	If ##class(%IPM.Storage.Module).NameExists($$$IPMModuleName,.ipmModuleId) {
+	If ..IPMInstalled(.ipmModuleId){
 		Set modDef = ##class(%IPM.Storage.Module).%OpenId(ipmModuleId,,.sc)
 		$$$ThrowOnError(sc)
 		Write !, "Version of IPM in current namespace: "
@@ -3093,9 +3093,9 @@ ClassMethod GetMapInfo(Output pIsMappedFrom, Output pIsMappedTo)
 	}
 }
 
-ClassMethod IPMInstalled() As %Boolean [ CodeMode = expression ]
+ClassMethod IPMInstalled(ByRef ipmModuleId) As %Boolean [ CodeMode = expression ]
 {
-$$$comClassDefined("%IPM.Storage.Module") && ##class(%IPM.Storage.Module).NameExists($$$IPMModuleName)
+$$$comClassDefined("%IPM.Storage.Module") && ##class(%IPM.Storage.Module).NameExists($$$IPMModuleName, .ipmModuleId)
 }
 
 /// Runs package manager commands in a way that is friendly to the OS-level shell.

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -636,9 +636,9 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
 	</command>
 
 <command name="unmap">
-	<summary>
+	<description>
 		Unmap %IPM package and routines in specified namespaces. Will Skip non-mapped namespaces.
-	</summary>
+	</description>
 	<modifier name="namespaces" aliases="ns" value="true" description="Comma-separated namespaces in which IPM mapping needs to be deleted."/>
 	<modifier name="globally" aliases="g" description="Will unmap IPM in all explicit namespaces that currently do not have IPM installed."/>
 	<modifier name="quiet" aliases="q" description="Quiet mode. By default, this modifier is not set and will display the contents onto the terminal/caller command line." />
@@ -2792,7 +2792,8 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
 		}
 		Set pointer = 0
 		While $ListNext(namespaces,pointer,namespace) {
-			Set $Namespace = $Zstrip(namespace, "<>WC")
+			Set namespace = $Zstrip(namespace, "<>WC")
+			Set $Namespace = namespace
 			If ..IPMInstalled() {
 				If 'quiet || preview {
 					Write !,"Skipping "_namespace_" - IPM already installed."

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -640,7 +640,7 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
 		Unmap %IPM package and rountines in specified namespaces. Will Skip non-mapped namespaces.
 	</summary>
 	<modifier name="namespaces" aliases="ns" value="true" description="Comma-separated namespaces in which IPM mapping needs to be deleted."/>
-	<modifier name="globally" aliases="g" description="Will unmap IPM in all explicit namespaces that currently do not have IPM installed. By default, this modifier is not set and will not install globally."/>
+	<modifier name="globally" aliases="g" description="Will unmap IPM in all explicit namespaces that currently do not have IPM installed."/>
 	<modifier name="quiet" aliases="q" description="Quiet mode. By default, this modifier is not set and will display the contents onto the terminal/caller command line." />
 	<example description="Unmap IPM from namespaces NS1, NS2, NS3.">
 		unmap -ns NS1,NS2,NS3

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -611,11 +611,16 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
 		<!-- Modifiers -->
 		<modifier name="version" aliases="v" value="true" description="A special version of IPM can be provided. If not specified, the latest version from the registry will be installed (hence is not required if quiet flag is set)."/>
 		<modifier name="namespaces" aliases="ns" value="true" description="Comma-separated namespaces in which IPM needs to be enabled."/>
-		<modifier name="globally" description="Will install IPM in all non-%SYS explicit namespaces that currently do not have IPM installed. By default, this modifier is not set and will not install globally."/>
+		<modifier name="globally" aliases="g" description="Will install IPM in all non-%SYS explicit namespaces that currently do not have IPM installed. By default, this modifier is not set and will not install globally."/>
 		<modifier name="local-only" description="If specified, only local artifacts will be used for installation. By default, this modifier is not set and will not limit to local artifacts." />
 		<modifier name="allow-upgrade" description="If specified, will also check for IPM version in specified namespaces and upgrade if version is lower than the target version. By deafult, this modifier is not ste and will not allow upgrade." />
+		<modifier name="map" aliases="m" description="If specified, will map IPM code from the current namespace-default code database rather than installing a separate copy. Can be used with -globally to add a %ALL namespace mapping." />
 		<modifier name="quiet" aliases="q" description="Quiet mode. By default, this modifier is not set and will display the contents onto the terminal/caller command line." />
+		<modifier name="preview" aliases="p" description="Preview only - for -map option, shows the namespaces that would be enabled." />
 		<!-- Examples -->
+		<example description="Make IPM available in all namespaces (including %SYS) by mapping the version in the current namespace default routine database to the %ALL psuedo-namespace. Namespace-specific installation will override this.">
+			enable -map -globally
+		</example>
 		<example description="Install IPM version 0.3.4 in quiet mode in namespaces: NS1, NS2, NS3.">
 			enable -v 0.3.4 -q -ns NS1,NS2,NS3
 		</example>
@@ -1132,8 +1137,9 @@ ClassMethod GetVersionModule(name, namespace = {$namespace})
 /// Version client and registry
 ClassMethod Version(ByRef pCommandInfo) [ Internal ]
 {
-  Do ..GetListModules("*", $$$IPMModuleName_","_$$$IPMServerRegistryModuleName, .list)
-  Do ..DisplayModules(.list)
+	Do ..GetListModules("*", $$$IPMModuleName_","_$$$IPMServerRegistryModuleName, .list)
+	Do ..AddIPMMappedNamespaces(.list)
+	Do ..DisplayModules(.list)
 
 	// Get URL current registry
 	Set tRes = ##class(%IPM.Repo.Remote.Definition).ExtentFunc()
@@ -1148,6 +1154,38 @@ ClassMethod Version(ByRef pCommandInfo) [ Internal ]
 		Write !,$$$FormattedLine($$$Blue,tRepository.URL)," - ",tInfo.ToString()
 	}
 	Quit $$$OK
+}
+
+ClassMethod AddIPMMappedNamespaces(ByRef list) [ Private ]
+{
+	Do ..GetListNamespace(.allNS,"*")
+	For i=1:1:+$Get(list) {
+		Set namespace = $ListGet(list(i))
+		If (namespace '= "") {
+			Kill allNS(namespace)
+		}
+		Set sourceDB = ##class(%SYS.Namespace).GetPackageDest(namespace,"%IPM")
+		Set mappedFrom(sourceDB) = namespace
+		Merge mappedFrom(sourceDB,"info") = list(i)
+	}
+
+	Set namespace = ""
+	For {
+		Set namespace = $Order(allNS(namespace))
+		Quit:namespace=""
+
+		Set sourceDB = ##class(%SYS.Namespace).GetPackageDest(namespace,"%IPM")
+		If $Data(mappedFrom(sourceDB),sourceNamespace) {
+			Kill info
+			Merge info = mappedFrom(sourceDB,"info")
+			Set info = $lb(namespace)
+			Set info("modules",1,"Installed In") = sourceNamespace
+			Merge list($i(list)) = info
+			If $Length(namespace) > +$Get(list("width")) {
+				Set list("width") = $Length(namespace)
+			}
+		}
+	}
 }
 
 /// @API.Method
@@ -2602,14 +2640,18 @@ ZPM(pArgs...)
 
 ClassMethod EnableIPM(ByRef pCommandInfo)
 {
-	Write !, "Version of IPM in current namespace: "
-	Do ..GetListModules($Namespace,$$$IPMModuleName,.list)
-	If $Data(list($$$IPMModuleName)) {
-			Write !,($namespace)_"> "_$$$FormattedLine($$$Green,$$$IPMModuleName_" ")_$ListGet(list($$$IPMModuleName),1)
+	New $Namespace
+	Set initNamespace = $Namespace
+	If ##class(%IPM.Storage.Module).NameExists($$$IPMModuleName,.ipmModuleId) {
+		Set modDef = ##class(%IPM.Storage.Module).%OpenId(ipmModuleId,,.sc)
+		$$$ThrowOnError(sc)
+		Write !, "Version of IPM in current namespace: "
+		Write !,($namespace)_"> "_$$$FormattedLine($$$Green,$$$IPMModuleName_" ")_modDef.VersionString
 	}
-	Kill list
 
 	Set quiet = $$$HasModifier(pCommandInfo,"quiet")
+	Set preview = $$$HasModifier(pCommandInfo,"preview")
+	Set map = $$$HasModifier(pCommandInfo,"map")
 	Set globally = $$$HasModifier(pCommandInfo, "globally")
 	Set localOnly = $$$HasModifier(pCommandInfo, "local-only")
 	Set version = $$$GetModifier(pCommandInfo, "version")
@@ -2626,6 +2668,59 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
 	}
 	If ((namespaces '= "") && globally) {
 		$$$ThrowOnError($$$ERROR($$$GeneralError,"Cannot specify namespaces and global installation flag at the same time."))
+	}
+	If (version '= "") && (globally && map) {
+		$$$ThrowOnError($$$ERROR($$$GeneralError,"Cannot specify version when mapping the currently-installed version globally."))
+	}
+	If map && 'globally && (namespaces = "") {
+		$$$ThrowOnError($$$ERROR($$$GeneralError,"If mapping from the current namespace's routine database with -map, must specify either -globally or a list of namespaces with -ns"))
+	}
+
+	If map {
+		If globally {
+			Set namespaces = ""
+			Do ..GetListNamespace(.list)
+			Kill list("%ALL")
+			Set key = ""
+			For {
+				Set key = $Order(list(key))
+				Quit:key=""
+				Set namespaces = namespaces _ $ListBuild(key)
+			}
+		} Else {
+			Set namespaces = $ListFromString(namespaces)
+		}
+		Set pointer = 0
+		While $ListNext(namespaces,pointer,namespace) {
+			Set $Namespace = namespace
+			If $$$comClassDefined("%IPM.Storage.Module") && ##class(%IPM.Storage.Module).NameExists($$$IPMModuleName) {
+				If 'quiet || preview {
+					Write !,"Skipping "_namespace_" - IPM already installed."
+				}
+				Continue
+			}
+			Set $Namespace = initNamespace
+			If preview {
+				Write !,"Would add IPM mappings to "_namespace
+				Continue
+			}
+			If 'quiet {
+				Write !,"Mapping %IPM package in "_namespace_" equivalently to "_initNamespace
+			}
+			$$$ThrowOnError(##class(%IPM.Utils.Build).MapPackageEquivalently("%IPM",initNamespace,namespace))
+			If 'quiet {
+				Write !,"Mapping %IPM.* routines in "_namespace_" equivalently to "_initNamespace
+			}
+			$$$ThrowOnError(##class(%IPM.Utils.Build).MapRoutineEquivalently("%IPM.*",initNamespace,,namespace))
+		}
+		Set $Namespace = initNamespace
+		If preview {
+			Write !,"Preview mode; no configuration changes were made."
+		} ElseIf 'quiet {
+			Write !,"Done.",!
+			Do ..Version()
+		}
+		Return
 	}
 
 	New $Namespace
@@ -2914,7 +3009,8 @@ ClassMethod DisplayModules(ByRef pList, pNumbered As %Boolean = 0, pWithNamespac
     $ListBuild("Author.Person", $$$Yellow, "Author"),
     $ListBuild("Origin", $$$Blue),
     $ListBuild("AllVersions", $$$Blue, "Versions"),
-    $ListBuild("Repository", $$$Blue)
+    $ListBuild("Repository", $$$Blue),
+    $ListBuild("Installed In", $$$Blue)
   )
 
   Set width = $Get(pList("width")) + 1

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -635,6 +635,21 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
 		</example>
 	</command>
 
+<command name="unmap">
+	<summary>
+		Unmap %IPM package and rountines in specified namespaces. Will Skip non-mapped namespaces.
+	</summary>
+	<modifier name="namespaces" aliases="ns" value="true" description="Comma-separated namespaces in which IPM mapping needs to be deleted."/>
+	<modifier name="globally" aliases="g" description="Will unmap IPM in all explicit namespaces that currently do not have IPM installed. By default, this modifier is not set and will not install globally."/>
+	<modifier name="quiet" aliases="q" description="Quiet mode. By default, this modifier is not set and will display the contents onto the terminal/caller command line." />
+	<example description="Unmap IPM from namespaces NS1, NS2, NS3.">
+		unmap -ns NS1,NS2,NS3
+	</example>
+	<example description="Unmap IPM from all namespaces">
+		unmap -g
+	</example>
+</command>
+
 </commands>
 }
 
@@ -804,6 +819,8 @@ ClassMethod ShellInternal(pCommand As %String, Output pException As %Exception.A
 				Do ..Namespace(.tCommandInfo)			
 			} ElseIf (tCommandInfo = "enable") {
 				Do ..EnableIPM(.tCommandInfo)
+			} ElseIf (tCommandInfo = "unmap") {
+				Do ..UnmapIPM(.tCommandInfo)
 			}
 		} Catch pException {
 			If (pException.Code = $$$ERCTRLC) {
@@ -1925,31 +1942,22 @@ ClassMethod Load(ByRef pCommandInfo) [ Internal ]
 	}
 }
 
-ClassMethod CheckModuleNamespace(pModuleName As %String) As %Status
+ClassMethod CheckModuleNamespace() As %Status
 {
-	// ZPM can be mapped from another namespace. If so, we need to perform upgrade in the source namespace.
-	Do ..GetListModules("*", pModuleName, .list)
-	Do ..AddIPMMappedNamespaces(.list)
-	Set found = 0
-	Set affectedNamespace = ""
-	For i = 1:1:list {
-		If list(i) = $ListBuild($Namespace) {
-			Set found = 1
-			If $Data(list(i, "modules", 1, "Installed In"), mappedFrom) # 2 {
-				Write "Module "_pModuleName_" is mapped from namespace "_mappedFrom_" and must be managed from there.",!
-				Return $$$ERROR($$$GeneralError, $$$FormatText("Cannot manage '%1' in this namespace", pModuleName))
+	Do ..GetMapInfo(.tIsMappedFrom, .tIsMappedTo)
+	If $Data(tIsMappedFrom($Namespace), sourceNS) # 2 {
+		Quit $$$ERROR($$$GeneralError, $$$FormatText("Cannot install '%1' in namespace '%2' because it is mapped from namespace '%3'.", $$$IPMModuleName, $Namespace, sourceNS))
+	}
+	If $Data(tIsMappedTo($Namespace)) / 2 {
+		Write !, "Will affect the following namespaces:", $NAMESPACE
+		Set ns = ""
+		For {
+			Set ns = $Order(tIsMappedTo($Namespace, ns))
+			If ns = "" {
+				Quit
 			}
-		} ElseIf $Get(list(i, "modules", 1, "Installed In")) = $Namespace {
-			Set affectedNamespace = affectedNamespace _ list(i)
+			Write ", ", ns
 		}
-	}
-	If 'found {
-		// This shouldn't happen, but worth checking for.
-		$$$ThrowStatus($$$ERROR($$$GeneralError,$$$FormatText("Could not find namespace for '%1'", pModuleName)))
-	}
-	If affectedNamespace '= "" {
-		Set affectedNamespace = $ListBuild($Namespace) _ affectedNamespace
-		Write !, "The following namespaces fill be affected: ", $LISTTOSTRING(affectedNamespace, ", ")
 	}
 	Quit $$$OK
 }
@@ -1966,7 +1974,7 @@ ClassMethod Install(ByRef pCommandInfo) [ Internal ]
 	}
 
 	If tModuleName = $$$IPMModuleName {
-		$$$ThrowOnError(..CheckModuleNamespace(tModuleName))
+		$$$ThrowOnError(..CheckModuleNamespace())
 	}
 
 	Set tVersion = $Get(pCommandInfo("parameters","version"))
@@ -2053,7 +2061,7 @@ ClassMethod Reinstall(ByRef pCommandInfo) [ Internal ]
 	$$$ThrowOnError(tSC)
 
 	If tModuleName = $$$IPMModuleName {
-		$$$ThrowOnError(..CheckModuleNamespace(tModuleName))
+		$$$ThrowOnError(..CheckModuleNamespace())
 	}
 	
 	Set tVersionString = tModule.Version.ToString()
@@ -2072,7 +2080,7 @@ ClassMethod Uninstall(ByRef pCommandInfo) [ Internal ]
 	} Else {
 		Set tModuleName = pCommandInfo("parameters","module")
 		If tModuleName = $$$IPMModuleName {
-			$$$ThrowOnError(..CheckModuleNamespace(tModuleName))
+			$$$ThrowOnError(..CheckModuleNamespace())
 		}	
 		Set tRecurse = $$$HasModifier(pCommandInfo,"recurse") // Recursively uninstall unneeded dependencies
 		$$$ThrowOnError(##class(%IPM.Storage.Module).Uninstall(tModuleName,tForce,tRecurse,.tParams))
@@ -2998,6 +3006,73 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
 		If $$$ISERR(tOverallSC) {
 			Write !, "IPM failed to enable for namespace "_$ListToString(problematicList)
 			$$$ThrowOnError(tOverallSC)
+		}
+	}
+}
+
+ClassMethod UnmapIPM(ByRef pCommandInfo)
+{
+	Set globally = $$$HasModifier(pCommandInfo,"globally")
+	Set namespaces = $ListFromString($$$GetModifier(pCommandInfo,"namespaces"), ",")
+	Set verbose = '$$$HasModifier(pCommandInfo,"quiet")
+	// Sanity check
+	If (globally && (namespaces '= "")) {
+		$$$ThrowOnError($$$ERROR($$$GeneralError,"Cannot specify namespaces and global unmap flag at the same time."))
+	}
+	If ('globally && (namespaces = "")) {
+		$$$ThrowOnError($$$ERROR($$$GeneralError,"Must specify either -globally or a list of namespaces with -ns"))
+	}
+	// populate namespaces if globally is set
+	If globally {
+		Do ..GetListNamespace(.nsTree)
+		Set ns = ""
+		For {
+			Set ns = $Order(nsTree(ns))
+			If ns = "" {
+				Quit
+			}
+			Set namespaces = namespaces_$ListBuild(ns)
+		}
+	}
+	If verbose {
+		Write !,"Will attempt to unmap %IPM package and routines from: "_ $ListToString(namespaces, ", ")
+	}
+
+	// Gather namespaces where %IPM is mapped into
+	Do ..GetMapInfo(.tIsMappedFrom)
+	
+	Set ptr = 0
+	While $ListNext(namespaces, ptr, ns) {
+		Set src = $Get(tIsMappedFrom(ns))
+		If (src = "") {
+			If verbose {
+				Write !,"No mapping found for "_ns_". Skipping."
+			}
+			Continue
+		} 
+		If verbose {
+			Write !,"Unmapping %IPM package and routines from "_ns_" (mapped from "_src_")"
+		}
+		$$$ThrowOnError(##class(%IPM.Utils.Module).RemovePackageMapping(ns, "%IPM"))
+		$$$ThrowOnError(##class(%IPM.Utils.Module).RemoveRoutineMapping(ns, "%IPM.*"))
+	}
+}
+
+/// Get the mapping relationship for %IPM package. Format: 
+/// <ul>
+/// <li>pIsMappedFrom(destinationNamespace) = sourceNamespace</li>
+/// <li>pIsMappedTo(sourceNamespace, destinationNamespace) = ""</li>
+/// </ul>
+ClassMethod GetMapInfo(Output pIsMappedFrom, Output pIsMappedTo)
+{
+	Kill pIsMappedFrom, pIsMappedTo 
+	Do ..GetListModules("*", $$$IPMModuleName, .list)	
+	Do ..AddIPMMappedNamespaces(.list)
+	For i = 1:1:list {
+		Set destNS = $ListGet(list(i))
+		If $Data(list(i,  "modules", 1, "Installed In"), srcNS) # 2 {
+			Set pIsMappedFrom(destNS) = srcNS
+			Set pIsMappedTo(srcNS, destNS) = ""
 		}
 	}
 }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1925,6 +1925,35 @@ ClassMethod Load(ByRef pCommandInfo) [ Internal ]
 	}
 }
 
+ClassMethod CheckModuleNamespace(pModuleName As %String) As %Status
+{
+	// ZPM can be mapped from another namespace. If so, we need to perform upgrade in the source namespace.
+	Do ..GetListModules("*", pModuleName, .list)
+	Do ..AddIPMMappedNamespaces(.list)
+	Set found = 0
+	Set affectedNamespace = ""
+	For i = 1:1:list {
+		If list(i) = $ListBuild($Namespace) {
+			Set found = 1
+			If $Data(list(i, "modules", 1, "Installed In"), mappedFrom) # 2 {
+				Write "Module "_pModuleName_" is mapped from namespace "_mappedFrom_" and must be managed from there.",!
+				Return $$$ERROR($$$GeneralError, $$$FormatText("Cannot manage '%1' in this namespace", pModuleName))
+			}
+		} ElseIf $Get(list(i, "modules", 1, "Installed In")) = $Namespace {
+			Set affectedNamespace = affectedNamespace _ list(i)
+		}
+	}
+	If 'found {
+		// This shouldn't happen, but worth checking for.
+		$$$ThrowStatus($$$ERROR($$$GeneralError,$$$FormatText("Could not find namespace for '%1'", pModuleName)))
+	}
+	If affectedNamespace '= "" {
+		Set affectedNamespace = $ListBuild($Namespace) _ affectedNamespace
+		Write !, "The following namespaces fill be affected: ", $LISTTOSTRING(affectedNamespace, ", ")
+	}
+	Quit $$$OK
+}
+
 ClassMethod Install(ByRef pCommandInfo) [ Internal ]
 {
 	Set tRegistry = ""
@@ -1932,9 +1961,13 @@ ClassMethod Install(ByRef pCommandInfo) [ Internal ]
 	If (tModuleName["/") {
 		Set $ListBuild(tRegistry, tModuleName) = $ListFromString(tModuleName, "/")
 	}
-  If (tModuleName = "") {
-    Quit $$$OK
-  }
+	If (tModuleName = "") {
+		Quit $$$OK
+	}
+
+	If tModuleName = $$$IPMModuleName {
+		$$$ThrowOnError(..CheckModuleNamespace(tModuleName))
+	}
 
 	Set tVersion = $Get(pCommandInfo("parameters","version"))
 	Set tKeywords = $$$GetModifier(pCommandInfo,"keywords")
@@ -2018,6 +2051,10 @@ ClassMethod Reinstall(ByRef pCommandInfo) [ Internal ]
 		$$$ThrowStatus($$$ERROR($$$GeneralError,$$$FormatText("Module '%1' is not currently installed.",tModuleName)))
 	}
 	$$$ThrowOnError(tSC)
+
+	If tModuleName = $$$IPMModuleName {
+		$$$ThrowOnError(..CheckModuleNamespace(tModuleName))
+	}
 	
 	Set tVersionString = tModule.Version.ToString()
 	Write !,"Reinstalling ",tModuleName," ",tVersionString
@@ -2034,6 +2071,9 @@ ClassMethod Uninstall(ByRef pCommandInfo) [ Internal ]
     Return
 	} Else {
 		Set tModuleName = pCommandInfo("parameters","module")
+		If tModuleName = $$$IPMModuleName {
+			$$$ThrowOnError(..CheckModuleNamespace(tModuleName))
+		}	
 		Set tRecurse = $$$HasModifier(pCommandInfo,"recurse") // Recursively uninstall unneeded dependencies
 		$$$ThrowOnError(##class(%IPM.Storage.Module).Uninstall(tModuleName,tForce,tRecurse,.tParams))
 	}

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -616,7 +616,7 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
 		<modifier name="allow-upgrade" description="If specified, will also check for IPM version in specified namespaces and upgrade if version is lower than the target version. By default, this modifier is not ste and will not allow upgrade." />
 		<modifier name="map" aliases="m" description="If specified, will map IPM code from the current namespace-default code database rather than installing a separate copy." />
 		<modifier name="quiet" aliases="q" description="Quiet mode. By default, this modifier is not set and will display the contents onto the terminal/caller command line." />
-		<modifier name="preview" aliases="p" description="Preview only - for -map option, shows the namespaces that would be enabled." />
+		<modifier name="preview" aliases="p" description="Preview what will be changed without actually making the changes." />
 		<!-- Examples -->
 		<example description="Make IPM available in all namespaces (including %SYS) by mapping the version in the current namespace default routine database. Namespace-specific installation will override this.">
 			enable -map -globally
@@ -2995,6 +2995,10 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
 					Quit
 				}
 				Set $Namespace = currentNS
+				If preview {
+					Write !, $$$FormatText("Would install IPM version %1 from registry in namespace %2", targetVersion, currentNS)
+					Continue
+				}
 				Do $SYSTEM.OBJ.LoadStream(manifest, loadFlag)
 				Write !, "IPM enabled for namespace "_currentNS
 			}
@@ -3009,6 +3013,11 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
 		Set tOverallSC = $$$OK
 		While (currentNS '="") {
 			Set $Namespace = currentNS
+			If preview {
+				Set filePath = ##class(%File).NormalizeFilename(targetIPMFileName, XMLDir)
+				Write !, $$$FormatText("Would install IPM using file at %1 in namespace %2", filePath, currentNS)
+				Continue
+			}
 			Set tSC = $SYSTEM.OBJ.Load(##class(%File).NormalizeFilename(targetIPMFileName, XMLDir), loadFlag)
 			If $$$ISOK(tSC) {
 				Set enabledNSList = enabledNSList_$ListBuild(currentNS)
@@ -3018,11 +3027,17 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
 			Set currentNS = $ORDER(targetNamespaces(currentNS))
 			Set tOverallSC = $$$ADDSC(tOverallSC,tSC)
 		}
-		Write !, "IPM enabled for namespace(s) "_$ListToString(enabledNSList)
-		If $$$ISERR(tOverallSC) {
-			Write !, "IPM failed to enable for namespace "_$ListToString(problematicList)
-			$$$ThrowOnError(tOverallSC)
+		If 'preview {
+			Write !, "IPM enabled for namespace(s) "_$ListToString(enabledNSList)
+			If $$$ISERR(tOverallSC) {
+				Write !, "IPM failed to enable for namespace "_$ListToString(problematicList)
+				$$$ThrowOnError(tOverallSC)
+			}
 		}
+	}
+
+	If preview {
+		Write !,"Preview mode; no configuration changes were made."
 	}
 }
 

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1156,6 +1156,20 @@ ClassMethod Version(ByRef pCommandInfo) [ Internal ]
 	Quit $$$OK
 }
 
+/// Argument `list` is a multidimensional array where `list` contains the a numeric value `n`, indicating the length of the list
+/// Each subnode `list(i)` where 1 <= i <= n contains a $ListBuild of a single namespace
+/// Each subnote `list(i,"modules")` contains the number of modules in the namespace
+/// For 1 <= j <= `list(i,"modules")`, each subnode `list(i,"modules",j)` contains a $ListBuild of the module name, version, external name, and whether the module is installed in developer mode
+/// Additional nodes are also accepted, although they are not used in this method
+/// For example:
+/// list=1
+/// list(1)=$lb("USER")
+/// list(1,"modules")=2
+/// list(1,"modules",1)=$lb("zpm","0.9.0-SNAPSHOT","Package Management System",1)
+/// list(1,"modules",2)=$lb("zpm-registry","1.3.2","ZPM Registry",0)
+/// list(1,"modules","width")=12
+/// list("ns")="*"
+/// list("width")=4
 ClassMethod AddIPMMappedNamespaces(ByRef list) [ Private ]
 {
 	Do ..GetListNamespace(.allNS,"*")
@@ -1172,7 +1186,9 @@ ClassMethod AddIPMMappedNamespaces(ByRef list) [ Private ]
 	Set namespace = ""
 	For {
 		Set namespace = $Order(allNS(namespace))
-		Quit:namespace=""
+		If namespace = "" {
+			Quit
+		}
 
 		Set sourceDB = ##class(%SYS.Namespace).GetPackageDest(namespace,"%IPM")
 		If $Data(mappedFrom(sourceDB),sourceNamespace) {
@@ -2680,11 +2696,14 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
 		If globally {
 			Set namespaces = ""
 			Do ..GetListNamespace(.list)
+			// Namespace-specific mappings aren't allowed to override %ALL mappings. See https://github.com/intersystems/ipm/pull/485
 			Kill list("%ALL")
 			Set key = ""
 			For {
 				Set key = $Order(list(key))
-				Quit:key=""
+				If key = "" {
+					Quit
+				}
 				Set namespaces = namespaces _ $ListBuild(key)
 			}
 		} Else {
@@ -2692,8 +2711,8 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
 		}
 		Set pointer = 0
 		While $ListNext(namespaces,pointer,namespace) {
-			Set $Namespace = namespace
-			If $$$comClassDefined("%IPM.Storage.Module") && ##class(%IPM.Storage.Module).NameExists($$$IPMModuleName) {
+			Set $Namespace = $Zstrip(namespace, "<>WC")
+			If ..IPMInstalled() {
 				If 'quiet || preview {
 					Write !,"Skipping "_namespace_" - IPM already installed."
 				}
@@ -2924,6 +2943,11 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
 			$$$ThrowOnError(tOverallSC)
 		}
 	}
+}
+
+ClassMethod IPMInstalled() As %Boolean [ CodeMode = expression ]
+{
+$$$comClassDefined("%IPM.Storage.Module") && ##class(%IPM.Storage.Module).NameExists($$$IPMModuleName)
 }
 
 /// Runs package manager commands in a way that is friendly to the OS-level shell.

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2700,15 +2700,14 @@ ZPM(pArgs...)
 	Set quitOnError = $Get(pArgs(2))
 	Set haltOnComplete = $Get(pArgs(3))
 	Write !, "IPM is not enabled in this namespace."
-	&sql(SELECT %DLIST(Nsp) INTO :namespaces FROM %SYS.Namespace_List())
-	If SQLCODE '= 0 {
-		Write !, "Error getting namespace name. SQLCODE =", SQLCODE
+	Set rs = ##class(%SQL.Statement).%ExecDirect(, "SELECT Nsp FROM %SYS.Namespace_List()")
+	If rs.%SQLCODE '= 0 {
+		Write !, "Error getting namespace name. SQLCODE =", rs.%SQLCODE
 	} Else {
 		New $Namespace
-		Set ptr = 0
 		Set found = 0	
-		While $ListNext(namespaces, ptr, ns) {
-			Set $Namespace = $Zstrip(ns, "<>WC")
+		While rs.%Next() {
+			Set $Namespace = $Zstrip(rs.%Get("Nsp"), "<>WC")
 			If $System.CLS.IsMthd("%IPM.Main", "Shell") {
 				Write !, "Change namepace to one of the following to run the ""zpm"" command"
 				Do ##class(%IPM.Main).Shell("version")

--- a/src/cls/IPM/Utils/Migration.cls
+++ b/src/cls/IPM/Utils/Migration.cls
@@ -223,7 +223,7 @@ ClassMethod MigrateOneRepo(oldId As %String, name As %String, verbose As %Boolea
     Merge ^IPM.Repo.DefinitionD(newId) = data
 
     // Make sure loading/saving the object works
-    Set newObj = ##class(%IPM.Storage.Module).%OpenId(newId,,.sc)
+    Set newObj = ##class(%IPM.Repo.Definition).%OpenId(newId,,.sc)
     $$$ThrowOnError(sc)
 
     // Save object to validate

--- a/src/cls/IPM/Utils/Migration.cls
+++ b/src/cls/IPM/Utils/Migration.cls
@@ -6,11 +6,11 @@ Class %IPM.Utils.Migration
 ClassMethod RunAll(verbose As %Boolean = 1) As %Status
 {
     Set tOriginalNS = $Namespace
+    Do ##class(%IPM.Main).GetListNamespace(.list)
     New $Namespace
     Set $Namespace = "%SYS"
     Set sourceDB = ##class(%SYS.Namespace).GetPackageDest(tOriginalNS, "%IPM")
 
-    Do ##class(%IPM.Main).GetListNamespace(.list)
     Set ns = ""
     Set sc = $$$OK
     For {

--- a/src/cls/IPM/Utils/Migration.cls
+++ b/src/cls/IPM/Utils/Migration.cls
@@ -7,7 +7,17 @@ ClassMethod RunAll(verbose As %Boolean = 1) As %Status
 {
     Set sc = $$$OK
     Try {
-        Do ..MigrateZPMToIPM(verbose)
+        New $Namespace
+        Do ##class(%IPM.Main).GetListNamespace(.list)
+        set ns = ""
+        For {
+            Set ns = $Order(list(ns))
+            If ns = "" {
+                Quit
+            }
+            Set $Namespace = $Zstrip(ns,"<>WC")
+            Do ..MigrateZPMToIPM(verbose)
+        }
     } Catch e {
         Set sc = e.AsStatus()
     }
@@ -22,6 +32,9 @@ ClassMethod HasLegacyZPMPackage()
 
 ClassMethod MigrateZPMToIPM(verbose As %Boolean = 1)
 {
+    If verbose {
+        Write !, "Migrating ZPM data to IPM... in namespace ", $Namespace
+    }
     If '..HasLegacyZPMPackage() {
         Write:verbose !,"Older IPM version not found; nothing to migrate.",!
         Quit

--- a/src/cls/IPM/Utils/Migration.cls
+++ b/src/cls/IPM/Utils/Migration.cls
@@ -14,10 +14,15 @@ ClassMethod RunAll(verbose As %Boolean = 1) As %Status
     Quit sc
 }
 
-ClassMethod MigrateZPMToIPM(verbose As %Boolean = 1)
+ClassMethod HasLegacyZPMPackage()
 {
     Set oldTopPackage = "%ZPM.PackageManager."
-    If $Order(^oddCOM(oldTopPackage)) '[ oldTopPackage {
+    Quit $Order(^oddCOM(oldTopPackage)) [ oldTopPackage
+}
+
+ClassMethod MigrateZPMToIPM(verbose As %Boolean = 1)
+{
+    If '..HasLegacyZPMPackage() {
         Write:verbose !,"Older IPM version not found; nothing to migrate.",!
         Quit
     }

--- a/src/cls/IPM/Utils/Migration.cls
+++ b/src/cls/IPM/Utils/Migration.cls
@@ -5,12 +5,20 @@ Class %IPM.Utils.Migration
 
 ClassMethod RunAll(verbose As %Boolean = 1) As %Status
 {
+    Set tOriginalNS = $Namespace
     New $Namespace
-    Set sc = $$$OK
+    Set $Namespace = "%SYS"
+    Set sourceDB = ##class(%SYS.Namespace).GetPackageDest(tOriginalNS, "%IPM")
+
     Do ##class(%IPM.Main).GetListNamespace(.list)
     Set ns = ""
+    Set sc = $$$OK
     For {
         Set ns = $Order(list(ns))
+        // Perform migration for namespaces to which %IPM is mapped from the current namespace's default routine database
+        If ##class(%SYS.Namespace).GetPackageDest(ns, "%IPM") '= sourceDB {
+            Continue
+        }
         If ns = "" {
             Quit
         }

--- a/src/cls/IPM/Utils/Migration.cls
+++ b/src/cls/IPM/Utils/Migration.cls
@@ -5,21 +5,21 @@ Class %IPM.Utils.Migration
 
 ClassMethod RunAll(verbose As %Boolean = 1) As %Status
 {
+    New $Namespace
     Set sc = $$$OK
-    Try {
-        New $Namespace
-        Do ##class(%IPM.Main).GetListNamespace(.list)
-        set ns = ""
-        For {
-            Set ns = $Order(list(ns))
-            If ns = "" {
-                Quit
-            }
+    Do ##class(%IPM.Main).GetListNamespace(.list)
+    Set ns = ""
+    For {
+        Set ns = $Order(list(ns))
+        If ns = "" {
+            Quit
+        }
+        Try {
             Set $Namespace = $Zstrip(ns,"<>WC")
             Do ..MigrateZPMToIPM(verbose)
+        } Catch e {
+            Set sc = $$$ADDSC(sc, e.AsStatus())
         }
-    } Catch e {
-        Set sc = e.AsStatus()
     }
     Quit sc
 }

--- a/tests/migration/v0.7-to-v0.9/tests/unit_tests/Test/PM/Migration/GloballyEnabled.cls
+++ b/tests/migration/v0.7-to-v0.9/tests/unit_tests/Test/PM/Migration/GloballyEnabled.cls
@@ -1,0 +1,10 @@
+Class Test.PM.Migration.GloballyEnabled Extends %UnitTest.TestCase
+{
+
+Method TestEnabledInSYS()
+{
+    Do $$$AssertTrue($Data(^|"%SYS"|oddCOM("%IPM.Main")))
+    Do $$$AssertEquals(##class(%SYS.Namespace).GetPackageDest($Namespace,"%IPM"),##class(%SYS.Namespace).GetPackageDest("%SYS","%IPM"))
+}
+
+}


### PR DESCRIPTION
This is done via new options in the existing zpm "enable" command that add package mappings.

We looked into using %ALL but ultimately that doesn't work, because namespace-specific mappings aren't allowed to override %ALL mappings (!?).

Fixes #470 