### PR TITLE
Search legacy src/mac in addition to src/rtn when locating resources

### DIFF
--- a/src/cls/IPM/ResourceProcessor/Default/Document.cls
+++ b/src/cls/IPM/ResourceProcessor/Default/Document.cls
@@ -71,6 +71,9 @@ Method OnPhase(pPhase As %String, ByRef pParams, Output pResourceHandled As %Boo
 		If ((pPhase = "Reload") && tInScope) || tInCurrentPhase {
 	    Set tCatDirectory = ""	
       Set tCatDirectory = tCatDirectory _ $ListBuild(..Directory)	
+      If (..Directory="rtn") {	// Ensure backward compatibility. In v0.7.0 and earlier, the default directory was "mac" for routines
+        Set tCatDirectory = tCatDirectory _ $ListBuild("mac")
+      }
       If ('..DirectoryDefined) {	
         If (..Directory="mac") {	
           Set tCatDirectory = tCatDirectory _ $ListBuild("rtn")	
@@ -160,7 +163,6 @@ Method OnPhase(pPhase As %String, ByRef pParams, Output pResourceHandled As %Boo
 							Set tSC = $$$ERROR($$$GeneralError, "Resource path '" _ tResourcePath _ "' not found")
 							Continue
 						}
-
 						$$$ThrowOnError(..OnLoad(tResourcePath,tVerbose,tInCurrentPhase,.tLoadedList,.pParams))
 						
 						Set tSC = ##class(%IPM.Storage.LoadedResource).TrackResourceNames(..ResourceReference.Module.Name,..ResourceReference.UniqueName,tLoadedList)


### PR DESCRIPTION
A previous commit (see [here](https://github.com/intersystems/ipm/blame/v1/src/cls/IPM/ResourceProcessor/Default/Routine.cls#L12)) changed the default subfolder containing routine files from `mac` to `rtn`. 

This PR ensures backward compatibility with legacy packages by checking for both `mac/` and `rtn/`. This fixes the error when installing certain packages (such as `run-container-command-execution` in #475 )