### PR TITLE
Detect whether preload class extends legacy classes; update if necessary

### DIFF
--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -546,10 +546,10 @@ Method %Reload(ByRef pParams) As %Status
 		
 		Set tPreloadRoot = tRoot_"preload"
 		If ##class(%File).DirectoryExists(tPreloadRoot) {
-						Set tSC = $System.OBJ.ImportDir(tPreloadRoot, "*", $Select(tVerbose:"d",1:"-d")_"/compile" _ $Select($Tlevel:"/multicompile=0", 1: ""), , 1)
-			If $$$ISERR(tSC) {
-				Quit
-			}
+			Set tSC = $System.OBJ.ImportDir(tPreloadRoot, "*", $Select(tVerbose:"d",1:"-d")_$Select($Tlevel:"/multicompile=0", 1: ""), , 1, .tImported)
+			If $$$ISERR(tSC) { Quit }
+			Set tSC = ##class(%IPM.Utils.LegacyCompat).UpdateSuperclassAndCompile(.tImported)
+			If $$$ISERR(tSC) { Quit }
 		} ElseIf tVerbose {
 			Write !,"Skipping preload - directory does not exist."
 		}

--- a/src/cls/IPM/Utils/LegacyCompat.cls
+++ b/src/cls/IPM/Utils/LegacyCompat.cls
@@ -1,0 +1,35 @@
+Include %IPM.Formatting
+
+Class %IPM.Utils.LegacyCompat
+{
+
+/// This method updates the superclasses of a list of classes that have been loaded but not compiled.
+ClassMethod UpdateSuperclassAndCompile(ByRef tClasses) As %Status
+{
+    Set tName = "" 
+    Set tToCompile = ""
+    For {
+        Set tName = $ORDER(tClasses(tName))
+        If (tName = "") { Quit } 
+        If ($$$lcase($EXTRACT(tName, *-3, *)) '= ".cls") { Continue }
+
+        Set tClassName = $EXTRACT(tName, 1, *-4)
+        Set tToCompile(tClassName) = ""
+        Set tClass = ##class(%Dictionary.ClassDefinition).%OpenId(tClassName)
+
+        // Assuming this is the only one we care about. Eventually it may become a list.
+        Set tOldLifecycle = "%ZPM.PackageManager.Developer.Lifecycle.Module"
+        Set tNewLifecycle = "%IPM.Lifecycle.Module"
+        
+        If tClass.Super = tOldLifecycle {
+            Set tClass.Super = tNewLifecycle
+            $$$ThrowOnError(tClass.%Save())
+            Write !, $$$FormattedLine($$$Magenta, "WARNING: ")
+            Write tName _ " extends the deprecated class " _ tOldLifecycle _ ". It has been updated to " _ tNewLifecycle _ " before compiled.", !
+        }
+    }
+    Set sc = $System.OBJ.Compile(.tToCompile)
+    Quit sc
+}
+
+}

--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -1214,7 +1214,10 @@ ClassMethod LoadNewModule(pDirectory As %String, ByRef pParams, pRepository As %
 		
 		Set tPath = pDirectory_"preload"
 		If ##class(%File).DirectoryExists(tPath) {
-      Set tSC = $system.OBJ.ImportDir(tPath,,$Select(tVerbose:"d",1:"-d")_"/compile"_$Select($TLevel:"/multicompile=0",1:""),,1)
+			// Load first, update legacy superclasses, then compile
+			Set tSC = $system.OBJ.ImportDir(tPath,,$Select(tVerbose:"d",1:"-d")_$Select($TLevel:"/multicompile=0",1:""),,1,.tImported)
+			$$$ThrowOnError(tSC)
+			Set tSC = ##class(%IPM.Utils.LegacyCompat).UpdateSuperclassAndCompile(.tImported)
 			$$$ThrowOnError(tSC)
 		} Else {
 			Write:tVerbose !,"Skipping preload - directory does not exist."


### PR DESCRIPTION
Automatically detect whether a preload class extends legacy class `%ZPM.PackageManager.Developer.Lifecycle.Module` and update the parent class to `%IPM.Lifecycle.Module` before compiling