### PR TITLE
feat: support a summary view of `help`

### DIFF
--- a/src/cls/IPM/CLI.cls
+++ b/src/cls/IPM/CLI.cls
@@ -17,6 +17,10 @@ ClassMethod %Help(ByRef pCommandInfo) [ Final ]
 	Set tCommand = $Get(pCommandInfo("parameters","command"))
 	Set tVerbose = ''$Data(pCommandInfo("modifiers","verbose"))
 	Set tMarkdown = ''$Data(pCommandInfo("modifiers","markdown"))
+	If (tMarkdown) {
+		// Force verbose for markdown because summary mode not supported
+		Set tVerbose = 1
+	}
 	Do ..%GetCommandStructure(.tCommandStruct)
 	
 	If (tCommand '= "") && '$Data(tCommandStruct(tCommand)) {
@@ -50,7 +54,6 @@ ClassMethod %Help(ByRef pCommandInfo) [ Final ]
 		// List commands
 		If 'tMarkdown {
 			Write !, $$$FormattedLine($$$Underlined, "Available commands:")
-			Write !, "NOTE: [] around a parameter indicates it is optional"
 			Write !
 		}
 		Set tCommand = ""
@@ -66,7 +69,7 @@ ClassMethod %Help(ByRef pCommandInfo) [ Final ]
 			
 			Kill tOneCommandStruct
 			Merge tOneCommandStruct = tCommandStruct(tCommand)
-			Do ..%HelpForCommand(tCommand,.tOneCommandStruct,tVerbose,tMarkdown)
+			Do ..%HelpForCommand(tCommand,.tOneCommandStruct,tVerbose,tMarkdown,$Get(tCommandStruct(-1, "maxLength"),0))
 			
 			Write !
 		}
@@ -78,25 +81,28 @@ ClassMethod %Help(ByRef pCommandInfo) [ Final ]
 	Write !
 }
 
-ClassMethod %HelpForCommand(pCommandName As %String, ByRef pCommandStruct, pDetailed As %Boolean = 0, pMarkdownFormat As %Boolean = 0)
+ClassMethod %HelpForCommand(pCommandName As %String, ByRef pCommandStruct, pDetailed As %Boolean = 0, pMarkdownFormat As %Boolean = 0, pMaxLength As %Integer = 0)
 {
+	/// Section separator in Markdown
+	#define SectionSeparator $Case(pMarkdownFormat, 1: "-----", : "")
 	// Macro to escape if in markdown
 	#define Escape(%string) $Select(pMarkdownFormat:$Replace(%string,"[","\["),1:%string)
 	// Macro to format strings if printing to terminal and to escape if in markdown
 	#define EscapeOrFormat(%string, %format) $Case(pMarkdownFormat, 1:$Replace(%string, "[", "\["), :$$$FormattedLine(%format, %string))
 	// Bullet point if in Terminal
-	#define BulletPoint $Case(pMarkdownFormat, 1: "", :$Char(8729)_" ")
+	#define BulletPoint $Case(pMarkdownFormat, 1: "", :$Char(9675)_" ")
 	// Black square if in Terminal
 	#define BlackSquare $Case(pMarkdownFormat, 1: "", :$Char(9632)_" ")
 
   	#define DefaultGroup "-"
 	
-  	#define Indent 2
+  	#define Indent 4
 	
 	Set tIsAlias = $Data(pCommandStruct)<10
 	If pMarkdownFormat && tIsAlias {
 		Write !, "----", !, "h2. ", pCommandName
 		Write !, "_Alias for [", pCommandStruct, "|#", pCommandStruct, "]_"
+		Write !, $$$SectionSeparator
 	}
 	
 	// Don't show full documentation for aliases 
@@ -104,6 +110,26 @@ ClassMethod %HelpForCommand(pCommandName As %String, ByRef pCommandStruct, pDeta
 		Return
 	}
 	
+	If ('pDetailed) {
+		Set tIndent = 10
+		If (pMaxLength > tIndent) {
+			// Do twice max length to account for aliases (which are usually shorter so this should be sufficient)
+			Set tIndent = 2 * pMaxLength + 2
+		}
+		// Command name and aliases
+		Write pCommandName
+		If $Data(pCommandStruct("aliases"), tAliases) {
+			Write ", "_$Replace(tAliases, ",", ", ")
+		}
+		// Summary
+		If $Data(pCommandStruct("summary"), tSummary) {
+			Write ?tIndent, $ZStrip(tSummary, "<>CW")
+		} ElseIf $Data(pCommandStruct("description"), tDescription) {
+			Write ?tIndent, $ZStrip(tDescription, "<>CW")
+		}
+		Quit
+	}
+
 	Write !, $Select(pMarkdownFormat:"----",1:""), !
 	If pMarkdownFormat {
 		Write "h2. "
@@ -157,10 +183,7 @@ ClassMethod %HelpForCommand(pCommandName As %String, ByRef pCommandStruct, pDeta
 	If $Data(pCommandStruct("description"), tDescription) {
 		Write !, ?$$$Indent, $$$BlackSquare_"Description: "_tDescription
 	}
-	
-	If (pDetailed) {
     Do ..%HelpForCommandDetails(.pCommandStruct, pMarkdownFormat)
-	}
 }
 
 ClassMethod %HelpForCommandDetails(ByRef pCommandStruct, pMarkdownFormat As %Boolean = 0) [ Internal ]


### PR DESCRIPTION
Output of `zpm "help"` is now:

```
USER>zpm "help"

Available commands:
arrange                                 Rearranges the resources in a module manifest to follow the standard format.
compile                                 This command is an alias for `module-action module-name compile`
config                                  Update ZPM settings. Setting is a key-value pair.
default-modifiers                       Manages default modifiers to use for all package manager commands in the current namespace.
dependency-analyzer, deps               Computes references to other items/modules for a given module/item.
enable                                  Enable IPM in other namespaces.
exec, cos                               Executes the provided ObjectScript expression.
generate, gen                           Generates module.xml
help, ?                                 Displays help information for the shell or a particular command.
import                                  Imports classes from a file or file(s), reexporting to source control if needed.
init, initialize                        Configures the current namespace for package manager use.
install                                 Installs a module available in a configured repository.
list-dependents, dependents             Lists modules dependent on the specified module.
list-installed, list                    Lists modules installed in the current namespace.
load                                    Loads a module from the specified directory into the current namespace.
module-action                           Performs operations on modules - compiling, running tests, packaging/registering, etc.
namespace, zn                           See list modules in namespace and go to the namespace
orphans                                 Lists resources in the current namespace's default code database that are not part of any module.
package                                 This command is an alias for `module-action module-name package`
publish                                 This command is an alias for `module-action module-name publish`
quit, q, exit                           Exits the package manager shell.
reinstall                               Reinstalls the already installed version of the provided module.
reload                                  This command is an alias for `module-action module-name reload`
repo, repository                        Configures the current namespace to search for modules in a repository.
run-from-file, run                      Runs Package Manager Shell commands provided in a file.
search, find                            Shows all modules in current registry or namespaces
test                                    This command is an alias for `module-action module-name test`
uninstall                               Uninstalls a module currently installed in this namespace.
unpublish                               Delete package from registry
verify                                  This command is an alias for `module-action module-name verify`
version, ver                            Prints the currently-installed package manager and registry version (excluding +snapshot or other build information)

For more detail, run:
  help <command-name>
or
  help -v```