### PR TITLE
enhance: allow specifying pip/pip3 path

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -31,7 +31,7 @@ jobs:
             do
               # Skip irishealth-community due to bad interaction with ZPM document type
               # Also skip 2023.2 because the license has expired
-              if [ "$n" = "irishealth-community" -a test "$tag" = "2023.3" -o "$tag" = "2023.2" ];
+              if [ "$n" = "irishealth-community" -a "$tag" = "2023.3" -o "$tag" = "2023.2" ];
                 then
                   continue
               fi

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -30,7 +30,8 @@ jobs:
             for tag in $tags
             do
               # Skip irishealth-community due to bad interaction with ZPM document type
-              if test "$n" = "irishealth-community" && test "$tag" = "2023.3"
+              # Also skip 2023.2 because the license has expired
+              if [ "$n" = "irishealth-community" -a test "$tag" = "2023.3" -o "$tag" = "2023.2" ];
                 then
                   continue
               fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #364 Added ability to restrict the installation to IRIS or IRIS for Health platform to the SystemRequirements attribute
 - #518 Added ability to show source file location when running `list-installed`. E.g., `zpm "list-installed -showsource"`.
-- #538 Added ability to customize path to `pip3`/`pip` through `config set PipPath` command.
+- #538 Added ability to customize path to `python`/`python3` through `config set PyPath` command.
 
 ### Changed
 - IPM is now namespace-specific rather than being installed in %SYS and being available instance-wide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #364 Added ability to restrict the installation to IRIS or IRIS for Health platform to the SystemRequirements attribute
 - #518 Added ability to show source file location when running `list-installed`. E.g., `zpm "list-installed -showsource"`.
 - #538 Added ability to customize caller to `pip`. By default will be `<IRIS-ROOT>/bin/irispip.exe`, `python3 -m pip`, or `python -m pip`, whichever is found first.
+- Added support for `%List` to `config list` and `config get <key>`.
 
 ### Changed
 - IPM is now namespace-specific rather than being installed in %SYS and being available instance-wide.
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HSIEO-10274: Separate DependencyAnalyzer out from IPM
 - #261: IPM now truly supports using multiple registries for installation / discovery of packages (without needing to prefix the package with the registry name on "install", although it is still possible and now effective to use the prefix).
 - #454: IPM 0.9.x+ uses different globals for storage vs. 0.7.0 and previous. Installation will automatically migrate data from the old globals to the new ones. The old globals are left around in case the user decides to revert to an earlier version.
+- Enclose output of `config list` and `config get <key>` with quotes.
 
 ### Fixed
 - HSIEO-9269, HSIEO-9402: % percent perforce directories are no longer necessary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #364 Added ability to restrict the installation to IRIS or IRIS for Health platform to the SystemRequirements attribute
 - #518 Added ability to show source file location when running `list-installed`. E.g., `zpm "list-installed -showsource"`.
+- #538 Added ability to customize path to `pip3`/`pip` through `config set PipPath` command.
 
 ### Changed
 - IPM is now namespace-specific rather than being installed in %SYS and being available instance-wide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #364 Added ability to restrict the installation to IRIS or IRIS for Health platform to the SystemRequirements attribute
 - #518 Added ability to show source file location when running `list-installed`. E.g., `zpm "list-installed -showsource"`.
-- #538 Added ability to customize path to `python`/`python3` through `config set PyPath` command.
+- #538 Added ability to customize caller to `pip`. By default will be `<IRIS-ROOT>/bin/irispip.exe`, `python3 -m pip`, or `python -m pip`, whichever is found first.
 
 ### Changed
 - IPM is now namespace-specific rather than being installed in %SYS and being available instance-wide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #364 Added ability to restrict the installation to IRIS or IRIS for Health platform to the SystemRequirements attribute
 - #518 Added ability to show source file location when running `list-installed`. E.g., `zpm "list-installed -showsource"`.
 - #538 Added ability to customize caller to PipCaller and UseStandalonePip through `config set`, which are empty by default and can be used to override the auto-detection of pip.
-- Added support for `%List` to `config list` and `config get <key>`.
 
 ### Changed
 - IPM is now namespace-specific rather than being installed in %SYS and being available instance-wide.
@@ -20,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HSIEO-10274: Separate DependencyAnalyzer out from IPM
 - #261: IPM now truly supports using multiple registries for installation / discovery of packages (without needing to prefix the package with the registry name on "install", although it is still possible and now effective to use the prefix).
 - #454: IPM 0.9.x+ uses different globals for storage vs. 0.7.0 and previous. Installation will automatically migrate data from the old globals to the new ones. The old globals are left around in case the user decides to revert to an earlier version.
-- Enclose output of `config list` and `config get <key>` with quotes.
 
 ### Fixed
 - HSIEO-9269, HSIEO-9402: % percent perforce directories are no longer necessary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #364 Added ability to restrict the installation to IRIS or IRIS for Health platform to the SystemRequirements attribute
 - #518 Added ability to show source file location when running `list-installed`. E.g., `zpm "list-installed -showsource"`.
-- #538 Added ability to customize caller to `pip`. By default will be `<IRIS-ROOT>/bin/irispip.exe`, `python3 -m pip`, or `python -m pip`, whichever is found first.
+- #538 Added ability to customize caller to PipCaller and UseStandalonePip through `config set`, which are empty by default and can be used to override the auto-detection of pip.
 - Added support for `%List` to `config list` and `config get <key>`.
 
 ### Changed

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -102,49 +102,9 @@ ClassMethod ZPMInit(pRegistry As %String = "", pAnalyticsTrackingID As %String =
     $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetAnalyticsAvailable(1, 0))
     $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetAnalyticsTrackingId(pAnalyticsTrackingID, 0))
     $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetValue("ColorScheme","", 0))
-    Set tPipCallerKey = ##class(%IPM.Repo.UniversalSettings).#PipCaller
-    Set tPipCallerValue = ..DetectPipCaller()
-    If tPipCallerValue = "" {
-      Write !, "WARNING: Failed to detect proper way of calling pip."
-      Write "You can set it manually using `config set PipCaller $lb(""<python-path>"", ""-m"", ""pip"")`" 
-    }
-    $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetValue(tPipCallerKey, tPipCallerValue, 0))
+    $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetValue("PipCaller", "", 0))
+    $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetValue("UseStandalonePip", "", 0))
     Quit $$$OK
-}
-
-/// Detect the proper call to `pip`. Possible options are `python3 -m pip`, `python -m pip`, `irispip.exe` (for Windows IRIS <= 2024.1).
-/// We prefer `python3 -m pip` over `python -m pip` because on certain legacy systems, `python` might be Python 2.
-ClassMethod DetectPipCaller() As %String
-{
-  Write !, "Detecting pip caller"
-  If $$$isWINDOWS {
-    If $System.CLS.IsMthd("%SYS.Python","GetPythonInfo") {
-      do ##class(%SYS.Python).GetPythonInfo(.info)
-      If $Data(info("CPF_PythonRuntimeLibrary"), tPyDylib) && tPyDylib {
-        set tInterpreter = ##class(%File).GetDirectory(tPyDylib, 1)_"python.exe"
-        set tFlexiblePython = $lb($lb(tInterpreter, "-m", "pip"))
-      }
-    }
-    set irispip = ##class(%File).NormalizeFilename("irispip.exe", $System.Util.BinaryDirectory())
-    Set tPipCallers = $lb($lb(irispip))_$Get(tFlexiblePython)_$lb($lb("python3.exe", "-m", "pip"), $lb("python.exe","-m", "pip"))
-  } Else {
-    Set tPipCallers = $lb($lb("python3", "-m", "pip"), $lb("python", "-m", "pip"))
-  }
-
-  Set ptr = 0
-  Set flags = "/SHELL/LOGCMD/STDOUT=""DetectPipCaller.log""/STDERR=""DetectPipCaller.err"""
-  While $ListNext(tPipCallers, ptr, cmd) {
-    Write !, "Checking """, $LISTTOSTRING(cmd, " "), """"
-    Set program = $List(cmd)
-    Do ..ListToMultiDimensional($List(cmd, 2, *), .args)
-    Set retCode = $ZF(-100, flags, program, .args)
-    If retCode = 0 {
-      Write !, "Success!"
-      Return cmd
-    }
-  }
-
-  Return ""
 }
 
 ClassMethod ListToMultiDimensional(pList As %List, Output pOutput)

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -102,6 +102,10 @@ ClassMethod ZPMInit(pRegistry As %String = "", pAnalyticsTrackingID As %String =
     $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetAnalyticsAvailable(1, 0))
     $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetAnalyticsTrackingId(pAnalyticsTrackingID, 0))
     $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetValue("ColorScheme","", 0))
+    Set tPipPathKey = ##class(%IPM.Repo.UniversalSettings).#PipPath
+    // Consider detecting whether pip or pip3 is available, and where it is located
+    Set tPipPathValue = $Select($$$isWINDOWS: ##class(%File).NormalizeFilename("irispip.exe", $System.Util.BinaryDirectory()), 1: "pip3")
+    $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetValue(tPipPathKey, tPipPathValue, 0))
     Quit $$$OK
 }
 

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -102,37 +102,52 @@ ClassMethod ZPMInit(pRegistry As %String = "", pAnalyticsTrackingID As %String =
     $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetAnalyticsAvailable(1, 0))
     $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetAnalyticsTrackingId(pAnalyticsTrackingID, 0))
     $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetValue("ColorScheme","", 0))
-    Set tPyPathKey = ##class(%IPM.Repo.UniversalSettings).#PyPath
-    Set tPyPathValue = ..DetectPython()
-    If tPyPathValue = "" {
-      Write !, "WARNING: Failed to detect path to Python interpreter. You can set it manually using `config set PyPath <path>`"
+    Set tPipCallerKey = ##class(%IPM.Repo.UniversalSettings).#PipCaller
+    Set tPipCallerValue = ..DetectPipCaller()
+    If tPipCallerValue = "" {
+      Write !, "WARNING: Failed to detect proper way of calling pip."
+      Write "You can set it manually using `config set PipCaller $lb(""<python-path>"", ""-m"", ""pip"")`" 
     }
-    $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetValue(tPyPathKey, tPyPathValue, 0))
+    $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetValue(tPipCallerKey, tPipCallerValue, 0))
     Quit $$$OK
 }
 
-/// Detect whether python or python3 is available on $PATH
-/// When both are available, use python3
-/// Most of the time, it's equivalent to $Select($$$isWINDOWS:"python", 1:"python3")
-ClassMethod DetectPython() As %String
+/// Detect the proper call to `pip`. Possible options are `python3 -m pip`, `python -m pip`, `irispip.exe` (for Windows IRIS <= 2024.1).
+/// We prefer `python3 -m pip` over `python -m pip` because on certain legacy systems, `python` might be Python 2.
+ClassMethod DetectPipCaller() As %String
 {
+  Write !, "Detecting pip caller"
   If $$$isWINDOWS {
-    Set tPythons = $lb("python3.exe", "python3", "python.exe", "python")
+    set irispip = ##class(%File).NormalizeFilename("irispip.exe", $System.Util.BinaryDirectory())
+    // irispip.exe is the first one we try
+    Set tPipCallers = $lb($lb(irispip), $lb("python3.exe", "-m", "pip"), $lb("python.exe","-m", "pip"))
   } Else {
-    Set tPythons = $lb("python3", "python")
+    Set tPipCallers = $lb($lb("python3", "-m", "pip"), $lb("python", "-m", "pip"))
   }
 
   Set ptr = 0
-  While $ListNext(tPythons, ptr, tPy) {
-    Set flags = "/SHELL/LOGCMD/STDOUT=""DetectPython.log""/STDERR=""DetectPython.err"""
-    Set retCode = $ZF(-100, flags, tPy, "--version")  
-    If retCode=0 {
-      // TODO resolve absolute path with `python -c "import sys; print(sys.executable)"`
-      Return tPy
+  Set flags = "/SHELL/LOGCMD/STDOUT=""DetectPipCaller.log""/STDERR=""DetectPipCaller.err"""
+  While $ListNext(tPipCallers, ptr, cmd) {
+    Write !, "Checking """, $LISTTOSTRING(cmd, " "), """"
+    Set program = $List(cmd)
+    Do ..ListToMultiDimensional($List(cmd, 2, *), .args)
+    Set retCode = $ZF(-100, flags, program, .args)
+    If retCode = 0 {
+      Write !, "Success!"
+      Return cmd
     }
   }
 
   Return ""
+}
+
+ClassMethod ListToMultiDimensional(pList As %List, Output pOutput)
+{
+  Set ptr = 0
+  Kill pOutput
+  While $ListNext(pList, ptr, tItem) {
+    Set pOutput($Increment(pOutput)) = tItem
+  }
 }
 
 ClassMethod ZPMLoad(pDirectoryName)

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -118,9 +118,15 @@ ClassMethod DetectPipCaller() As %String
 {
   Write !, "Detecting pip caller"
   If $$$isWINDOWS {
+    If $System.CLS.IsMthd("%SYS.Python","GetPythonInfo") {
+      do ##class(%SYS.Python).GetPythonInfo(.info)
+      If $Data(info("CPF_PythonRuntimeLibrary"), tPyDylib) {
+        set tInterpreter = ##class(%File).GetDirectory(tPyDylib, 1)_"python.exe"
+        set tFlexiblePython = $lb($lb(tInterpreter, "-m", "pip"))
+      }
+    }
     set irispip = ##class(%File).NormalizeFilename("irispip.exe", $System.Util.BinaryDirectory())
-    // irispip.exe is the first one we try
-    Set tPipCallers = $lb($lb(irispip), $lb("python3.exe", "-m", "pip"), $lb("python.exe","-m", "pip"))
+    Set tPipCallers = $lb($lb(irispip))_$Get(tFlexiblePython)_$lb($lb("python3.exe", "-m", "pip"), $lb("python.exe","-m", "pip"))
   } Else {
     Set tPipCallers = $lb($lb("python3", "-m", "pip"), $lb("python", "-m", "pip"))
   }

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -107,15 +107,6 @@ ClassMethod ZPMInit(pRegistry As %String = "", pAnalyticsTrackingID As %String =
     Quit $$$OK
 }
 
-ClassMethod ListToMultiDimensional(pList As %List, Output pOutput)
-{
-  Set ptr = 0
-  Kill pOutput
-  While $ListNext(pList, ptr, tItem) {
-    Set pOutput($Increment(pOutput)) = tItem
-  }
-}
-
 ClassMethod ZPMLoad(pDirectoryName)
 {
   Quit ##class(%IPM.Main).Shell("load "_pDirectoryName)

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -102,11 +102,37 @@ ClassMethod ZPMInit(pRegistry As %String = "", pAnalyticsTrackingID As %String =
     $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetAnalyticsAvailable(1, 0))
     $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetAnalyticsTrackingId(pAnalyticsTrackingID, 0))
     $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetValue("ColorScheme","", 0))
-    Set tPipPathKey = ##class(%IPM.Repo.UniversalSettings).#PipPath
-    // Consider detecting whether pip or pip3 is available, and where it is located
-    Set tPipPathValue = $Select($$$isWINDOWS: ##class(%File).NormalizeFilename("irispip.exe", $System.Util.BinaryDirectory()), 1: "pip3")
-    $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetValue(tPipPathKey, tPipPathValue, 0))
+    Set tPyPathKey = ##class(%IPM.Repo.UniversalSettings).#PyPath
+    Set tPyPathValue = ..DetectPython()
+    If tPyPathValue = "" {
+      Write !, "WARNING: Failed to detect path to Python interpreter. You can set it manually using `config set PyPath <path>`"
+    }
+    $$$QuitOnError(##class(%IPM.Repo.UniversalSettings).SetValue(tPyPathKey, tPyPathValue, 0))
     Quit $$$OK
+}
+
+/// Detect whether python or python3 is available on $PATH
+/// When both are available, use python3
+/// Most of the time, it's equivalent to $Select($$$isWINDOWS:"python", 1:"python3")
+ClassMethod DetectPython() As %String
+{
+  If $$$isWINDOWS {
+    Set tPythons = $lb("python3.exe", "python3", "python.exe", "python")
+  } Else {
+    Set tPythons = $lb("python3", "python")
+  }
+
+  Set ptr = 0
+  While $ListNext(tPythons, ptr, tPy) {
+    Set flags = "/SHELL/LOGCMD/STDOUT=""DetectPython.log""/STDERR=""DetectPython.err"""
+    Set retCode = $ZF(-100, flags, tPy, "--version")  
+    If retCode=0 {
+      // TODO resolve absolute path with `python -c "import sys; print(sys.executable)"`
+      Return tPy
+    }
+  }
+
+  Return ""
 }
 
 ClassMethod ZPMLoad(pDirectoryName)

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -120,7 +120,7 @@ ClassMethod DetectPipCaller() As %String
   If $$$isWINDOWS {
     If $System.CLS.IsMthd("%SYS.Python","GetPythonInfo") {
       do ##class(%SYS.Python).GetPythonInfo(.info)
-      If $Data(info("CPF_PythonRuntimeLibrary"), tPyDylib) {
+      If $Data(info("CPF_PythonRuntimeLibrary"), tPyDylib) && tPyDylib {
         set tInterpreter = ##class(%File).GetDirectory(tPyDylib, 1)_"python.exe"
         set tFlexiblePython = $lb($lb(tInterpreter, "-m", "pip"))
       }

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -621,7 +621,15 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
     Write:tVerbose !
 
     Set target = ##class(%File).NormalizeDirectory("python", $System.Util.ManagerDirectory())
-    Set command = ..ResolvePipCaller(.pParams) _ $ListBuild("install", "-r", "requirements.txt", "-t", target)
+	If '$System.CLS.IsMthd("%SYS.Python", "Import") {
+		Throw ##class(%Exception.General).%New("Embedded Python is not available in this instance.")
+	}
+	Set tSysModule = ##class(%SYS.Python).Import("sys")
+	Set tPyMajor = tSysModule."version_info".major
+	Set tPyMinor = tSysModule."version_info".minor
+	Set tPyMicro = tSysModule."version_info".micro
+	Set tPyVersion = tPyMajor_"."_tPyMinor_"."_tPyMicro
+    Set command = ..ResolvePipCaller(.pParams) _ $ListBuild("install", "-r", "requirements.txt", "-t", target, "--python-version", tPyVersion, "--only-binary=:all:")
     If 'tVerbose {
       Set stdout = ""
     }

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -654,7 +654,7 @@ Method ResolvePipCaller(ByRef pParams) As %List
 			Throw ##class(%Exception.General).%New(msg)
 		}
 	}
-	Return DetectPipCaller(tUseStandalonePip, $Get(pParams("Verbose"), 0))
+	Return ..DetectPipCaller(tUseStandalonePip, $Get(pParams("Verbose"), 0))
 }
 
 Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) As %List

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -630,7 +630,11 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
 	Set tPyMicro = tSysModule."version_info".micro
 	Set tPyVersion = tPyMajor_"."_tPyMinor_"."_tPyMicro
     Set command = ..ResolvePipCaller(.pParams) _ $ListBuild("install", "-r", "requirements.txt", "-t", target, "--python-version", tPyVersion, "--only-binary=:all:")
-    If 'tVerbose {
+    If tVerbose {
+        Write !, "Running "
+        Zwrite command
+    }
+    Else{
       Set stdout = ""
     }
     Set tSC = ##class(%IPM.Utils.Module).RunCommand(pRoot, command,.stdout)
@@ -716,7 +720,6 @@ Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) 
 		}
 	}
 
-  	Set flags = "/SHELL/LOGCMD/STDOUT=""DetectPipCaller.log""/STDERR=""DetectPipCaller.err"""
 	// Unless UseStandalonePip is set to 1, try to find python3 or python
 	If pUseStandalonePip '= 1 {
 		If pVerbose {
@@ -726,15 +729,14 @@ Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) 
 			If $$$isWINDOWS {
 				Set cmd = cmd _ ".exe"
 			}
-			Kill args
-			Set args($I(args)) = "-m"
-			Set args($I(args)) = "pip"
-			Set retCode = $ZF(-100, flags, cmd, .args)
-			If retCode = 0 {
+			set cmd = $lb(cmd, "-m", "pip")
+			Set cwd = ##class(%SYSTEM.Util).InstallDirectory()
+			Set tSC = ##class(%IPM.Utils.Module).RunCommand(cwd, cmd, "")
+			If $$$ISOK(tSC) {
 				If pVerbose {
 					Write "Success!"
 				}
-				Return $lb(cmd, "-m", "pip")
+				Return cmd
 			}
 			If pVerbose {
 				Write "Not Found"
@@ -751,10 +753,14 @@ Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) 
 			If $$$isWINDOWS {
 				Set cmd = cmd _ ".exe"
 			}
-			Set retCode = $ZF(-100, flags, cmd)
-			If retCode = 0 {
-				Write "Success!"
-				Return $lb(cmd)
+			Set cmd = $lb(cmd)
+			Set cwd = ##class(%SYSTEM.Util).InstallDirectory()
+			Set tSC = ##class(%IPM.Utils.Module).RunCommand(cwd, cmd, "")
+			If $$$ISOK(tSC) {
+				If pVerbose {
+					Write "Success!"
+				}
+				Return cmd
 			}
 			If pVerbose {
 				Write "Not Found"

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -621,9 +621,9 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
     Write:tVerbose !
 
     Set target = ##class(%File).NormalizeDirectory("python", $System.Util.ManagerDirectory())
-	Set tPipPathKey = ##class(%IPM.Repo.UniversalSettings).#PipPath
-    Set pip = ##class(%IPM.Repo.UniversalSettings).GetValue(tPipPathKey)
-    Set command = $ListBuild(pip, "install", "-r", "requirements.txt", "-t", target)
+	Set tPyPathKey = ##class(%IPM.Repo.UniversalSettings).#PyPath
+    Set python = ##class(%IPM.Repo.UniversalSettings).GetValue(tPyPathKey)
+    Set command = $ListBuild(python, "-m", "pip", "install", "-r", "requirements.txt", "-t", target)
     If 'tVerbose {
       Set stdout = ""
     }

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -621,9 +621,9 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
     Write:tVerbose !
 
     Set target = ##class(%File).NormalizeDirectory("python", $System.Util.ManagerDirectory())
-	Set tPyPathKey = ##class(%IPM.Repo.UniversalSettings).#PyPath
-    Set python = ##class(%IPM.Repo.UniversalSettings).GetValue(tPyPathKey)
-    Set command = $ListBuild(python, "-m", "pip", "install", "-r", "requirements.txt", "-t", target)
+	Set tPipCallerKey = ##class(%IPM.Repo.UniversalSettings).#PipCaller
+    Set tPipCallerValue = ##class(%IPM.Repo.UniversalSettings).GetValue(tPipCallerKey)
+    Set command = tPipCallerValue _ $ListBuild("install", "-r", "requirements.txt", "-t", target)
     If 'tVerbose {
       Set stdout = ""
     }

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -709,7 +709,7 @@ Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) 
 			If pVerbose {
 				Write "Success!"
 			}
-			Return $lb(tInterpreter, "-m", "pip")
+			Return $lb(irispip)
 		}
 		If pVerbose {
 			Write "Not Found"

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -621,9 +621,7 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
     Write:tVerbose !
 
     Set target = ##class(%File).NormalizeDirectory("python", $System.Util.ManagerDirectory())
-	Set tPipCallerKey = ##class(%IPM.Repo.UniversalSettings).#PipCaller
-    Set tPipCallerValue = ##class(%IPM.Repo.UniversalSettings).GetValue(tPipCallerKey)
-    Set command = tPipCallerValue _ $ListBuild("install", "-r", "requirements.txt", "-t", target)
+    Set command = ..ResolvePipCaller() _ $ListBuild("install", "-r", "requirements.txt", "-t", target)
     If 'tVerbose {
       Set stdout = ""
     }
@@ -637,6 +635,98 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
     Do ..Log("requirements.txt FAILURE")
   }
   Quit tSC
+}
+
+Method ResolvePipCaller(ByRef pParams) As %List
+{
+	Set tUseStandalonePip = ##class(%IPM.Repo.UniversalSettings).GetValue("UseStandalonePip")
+	Set tPipCaller = ##class(%IPM.Repo.UniversalSettings).GetValue("PipCaller")
+
+	If tPipCaller '= "" {	
+		If tUseStandalonePip = 1 {
+			Return $lb(tPipCaller)
+		} ElseIf tUseStandalonePip = 0 {
+			Return $lb(tPipCaller, "-m", "pip")
+		} Else {
+			Set msg = "Detected PipCaller=""" _ tPipCaller _ """ but UseStandalonePip is not properly set." _ $Char(13, 10)
+			Set msg = msg _ "Please set UseStandalonePip to 1 (if using a pip executable) or 0 (if using a python executable)." _ $Char(13, 10)
+			Set msg = msg _ "Example: zpm ""config set UseStandalonePip 1"""
+			Throw ##class(%Exception.General).%New(msg)
+		}
+	}
+	Return DetectPipCaller(tUseStandalonePip, $Get(pParams("Verbose"), 0))
+}
+
+Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) As %List
+{
+	Write:pVerbose !,"Detecting pip caller"
+
+	// First try to detect flexible python (in 2024.2 and later)
+	// This is a hack that doesn't always work because the python interpreter may not be in the same directory as the so/dylib/dll.
+	If $System.CLS.IsMthd("%SYS.Python","GetPythonInfo") {
+		Write:pVerbose !, "Attempting to find flexible python... "
+		Do ##class(%SYS.Python).GetPythonInfo(.info)
+		If $Data(info("CPF_PythonRuntimeLibrary"), tPyDylib) && tPyDylib {
+			// TODO: try `../bin/python3` or `../bin/python` in case the .so is in subfolder `lib`
+			// TODO: try to find `pip3` or `pip` if pUseStandalonePip is 1
+			For filename = "python3", "python" {
+				Set tInterpreter = ##class(%File).GetDirectory(tPyDylib, 1) _ filename
+				If $$$isWINDOWS {
+					Set tInterpreter = tInterpreter_".exe"
+				}
+				If ##class(%File).Exists(tInterpreter) {
+					Write:pVerbose "Success!"
+					Return $lb(tInterpreter, "-m", "pip")
+				}
+				Write:pVerbose "Not Found"
+			}
+		}
+    }
+
+	// For windows, try to find irispip.exe (in 2024.1 and earlier)
+	If $$$isWINDOWS {
+		Write:pVerbose !, "Attempting to find irispip.exe..."
+		Set irispip = ##class(%File).NormalizeFilename("irispip.exe", $System.Util.BinaryDirectory())
+		If ##class(%File).Exists(irispip) {
+			Write:pVerbose "Success!"
+			Return $lb(tInterpreter, "-m", "pip")
+		}
+		Write:pVerbose "Not Found"
+	}
+
+  	Set flags = "/SHELL/LOGCMD/STDOUT=""DetectPipCaller.log""/STDERR=""DetectPipCaller.err"""
+	// Unless UseStandalonePip is set to 1, try to find python3 or python
+	If pUseStandalonePip '= 1 {
+		Write:pVerbose !, "Attempting to find python3 or python..."
+		For cmd = "python3", "python" {
+			If $$$isWINDOWS { Set cmd = cmd _ ".exe" }
+			Kill args
+			Set args($I(args)) = "-m"
+			Set args($I(args)) = "pip"
+			Set retCode = $ZF(-100, flags, cmd, .args)
+			If retCode = 0 {
+				Write:pVerbose !, "Success!"
+				Return $lb(cmd, "-m", "pip")
+			}
+			Write:pVerbose "Not Found"
+		}
+	}
+
+	// Unless UseStandalonePip is set to 0, try to find pip3 or pip
+	If pUseStandalonePip '= 0 {
+		Write:pVerbose !, "Attempting to find pip3 or pip..."
+		For cmd = "pip3", "pip" {
+			If $$$isWINDOWS { Set cmd = cmd _ ".exe" }
+			Set retCode = $ZF(-100, flags, cmd)
+			If retCode = 0 {
+				Write !, "Success!"
+				Return $lb(cmd)
+			}
+			Write:pVerbose "Not Found"
+		}
+	}
+
+	Throw ##class(%Exception.General).%New("Could not find a suitable pip caller. Consider setting UseStandalonePip and PipCaller")
 }
 
 Method %Validate(ByRef pParams) As %Status

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -621,8 +621,8 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
     Write:tVerbose !
 
     Set target = ##class(%File).NormalizeDirectory("python", $System.Util.ManagerDirectory())
-    Set command = $ListBuild("pip", "install", "-r", "requirements.txt", "-t", target)
-    Set pip = $Select($$$isWINDOWS: ##class(%File).NormalizeFilename("irispip.exe", $System.Util.BinaryDirectory()), 1: "pip")
+	Set tPipPathKey = ##class(%IPM.Repo.UniversalSettings).#PipPath
+    Set pip = ##class(%IPM.Repo.UniversalSettings).GetValue(tPipPathKey)
     Set command = $ListBuild(pip, "install", "-r", "requirements.txt", "-t", target)
     If 'tVerbose {
       Set stdout = ""

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -621,7 +621,7 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
     Write:tVerbose !
 
     Set target = ##class(%File).NormalizeDirectory("python", $System.Util.ManagerDirectory())
-    Set command = ..ResolvePipCaller() _ $ListBuild("install", "-r", "requirements.txt", "-t", target)
+    Set command = ..ResolvePipCaller(.pParams) _ $ListBuild("install", "-r", "requirements.txt", "-t", target)
     If 'tVerbose {
       Set stdout = ""
     }

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -659,12 +659,16 @@ Method ResolvePipCaller(ByRef pParams) As %List
 
 Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) As %List
 {
-	Write:pVerbose !,"Detecting pip caller"
+	If pVerbose {
+		Write !,"Detecting pip caller"
+	}
 
 	// First try to detect flexible python (in 2024.2 and later)
 	// This is a hack that doesn't always work because the python interpreter may not be in the same directory as the so/dylib/dll.
 	If $System.CLS.IsMthd("%SYS.Python","GetPythonInfo") {
-		Write:pVerbose !, "Attempting to find flexible python... "
+		If pVerbose {
+			Write !, "Attempting to find flexible python... "
+		}
 		Do ##class(%SYS.Python).GetPythonInfo(.info)
 		If $Data(info("CPF_PythonRuntimeLibrary"), tPyDylib) && tPyDylib {
 			// TODO: try `../bin/python3` or `../bin/python` in case the .so is in subfolder `lib`
@@ -675,54 +679,78 @@ Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) 
 					Set tInterpreter = tInterpreter_".exe"
 				}
 				If ##class(%File).Exists(tInterpreter) {
-					Write:pVerbose "Success!"
+					If pVerbose{
+						Write "Success!"
+					}
 					Return $lb(tInterpreter, "-m", "pip")
 				}
-				Write:pVerbose "Not Found"
+				If pVerbose {
+					Write "Not Found"
+				}
 			}
 		}
-    }
+	}
 
 	// For windows, try to find irispip.exe (in 2024.1 and earlier)
 	If $$$isWINDOWS {
-		Write:pVerbose !, "Attempting to find irispip.exe..."
+		If pVerbose {
+			Write !, "Attempting to find irispip.exe..."
+		}
 		Set irispip = ##class(%File).NormalizeFilename("irispip.exe", $System.Util.BinaryDirectory())
 		If ##class(%File).Exists(irispip) {
-			Write:pVerbose "Success!"
+			If pVerbose {
+				Write "Success!"
+			}
 			Return $lb(tInterpreter, "-m", "pip")
 		}
-		Write:pVerbose "Not Found"
+		If pVerbose {
+			Write "Not Found"
+		}
 	}
 
   	Set flags = "/SHELL/LOGCMD/STDOUT=""DetectPipCaller.log""/STDERR=""DetectPipCaller.err"""
 	// Unless UseStandalonePip is set to 1, try to find python3 or python
 	If pUseStandalonePip '= 1 {
-		Write:pVerbose !, "Attempting to find python3 or python..."
+		If pVerbose {
+			Write !, "Attempting to find python3 or python..."
+		}
 		For cmd = "python3", "python" {
-			If $$$isWINDOWS { Set cmd = cmd _ ".exe" }
+			If $$$isWINDOWS {
+				Set cmd = cmd _ ".exe"
+			}
 			Kill args
 			Set args($I(args)) = "-m"
 			Set args($I(args)) = "pip"
 			Set retCode = $ZF(-100, flags, cmd, .args)
 			If retCode = 0 {
-				Write:pVerbose !, "Success!"
+				If pVerbose {
+					Write "Success!"
+				}
 				Return $lb(cmd, "-m", "pip")
 			}
-			Write:pVerbose "Not Found"
+			If pVerbose {
+				Write "Not Found"
+			}
 		}
 	}
 
 	// Unless UseStandalonePip is set to 0, try to find pip3 or pip
 	If pUseStandalonePip '= 0 {
-		Write:pVerbose !, "Attempting to find pip3 or pip..."
+		If pVerbose {
+			Write !, "Attempting to find pip3 or pip..."
+		}
 		For cmd = "pip3", "pip" {
-			If $$$isWINDOWS { Set cmd = cmd _ ".exe" }
+			If $$$isWINDOWS {
+				Set cmd = cmd _ ".exe"
+			}
 			Set retCode = $ZF(-100, flags, cmd)
 			If retCode = 0 {
-				Write !, "Success!"
+				Write "Success!"
 				Return $lb(cmd)
 			}
-			Write:pVerbose "Not Found"
+			If pVerbose {
+				Write "Not Found"
+			}
 		}
 	}
 

--- a/src/cls/IPM/Repo/UniversalSettings.cls
+++ b/src/cls/IPM/Repo/UniversalSettings.cls
@@ -22,9 +22,9 @@ Parameter TerminalPrompt = "TerminalPrompt";
 
 Parameter PublishTimeout = "publish_timeout";
 
-Parameter PipPath = "PipPath";
+Parameter PyPath = "PyPath";
 
-Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PipPath";
+Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PyPath";
 
 /// Returns configArray, that includes all configurable settings
 ClassMethod GetAll(Output configArray) As %Status

--- a/src/cls/IPM/Repo/UniversalSettings.cls
+++ b/src/cls/IPM/Repo/UniversalSettings.cls
@@ -22,9 +22,19 @@ Parameter TerminalPrompt = "TerminalPrompt";
 
 Parameter PublishTimeout = "publish_timeout";
 
+/// A path pointing either to a python executable or a pip executable, controlled by #UseStandalonePip
+/// In the special case where the path is empty, the script tries to resolve the path in the following order:
+/// 1. Where available (typically 2024.2+) - Use PythonRuntimeLibrary in iris.cpf to find the directory containing the python executable
+/// 2. On Windows, try to find <iris-root>/bin/irispip.exe
+/// 3. Unless UseStandalonePip is explicitly set to 1, try to find whichever python3/python is first available in $PATH
+/// 4. Unless UseStandalonePip is explicitly set to 0, try to find whichever pip3/pip is first available in $PATH
 Parameter PipCaller = "PipCaller";
 
-Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PipCaller";
+/// Possible values: "", 0, 1
+/// Indicates whether PipCaller is a pip executable instead of python
+Parameter UseStandalonePip = "UseStandalonePip";
+
+Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PipCaller,UseStandalonePip";
 
 /// Returns configArray, that includes all configurable settings
 ClassMethod GetAll(Output configArray) As %Status

--- a/src/cls/IPM/Repo/UniversalSettings.cls
+++ b/src/cls/IPM/Repo/UniversalSettings.cls
@@ -44,7 +44,7 @@ ClassMethod PrintList()
     For {
         Set k = $Order(confArr(k))
         Quit:(k="")
-        Write k_": "_confArr(k),! 
+        Write k_": "_..PrettyFormat(confArr(k)),! 
     }
 }
 
@@ -55,7 +55,35 @@ ClassMethod PrintOne(key As %String)
         Write "Config key = """_key_""" not found",!
         Quit
     }
-    Write key_":"_..GetValue($Parameter(..%ClassName(1),key)),!
+    Write key_":"_..PrettyFormat(..GetValue($Parameter(..%ClassName(1),key))),!
+}
+
+/// A helper method to format string/number/$lb() recursively
+ClassMethod PrettyFormat(input As %String) As %String
+{
+    If $Data(input) # 2 = 0 { Return "" }
+    If input = $lb() { Return "$lb()" }
+    If input = "" { Return """""" }
+    Try {
+        Set ptr = 0
+        Set output = ""
+        While $ListNext(input, ptr, value) {
+            If output = "" {
+                Set output = "$lb(" _ ..PrettyFormat(value)
+            } Else {
+                Set output = output _ ", " _ ..PrettyFormat(value)
+            }
+        }
+        Set output = output _ ")"
+        Return output
+    } Catch ex {
+        If input = +input {
+            Return input
+        }
+        Return """" _ input _ """"
+    }
+
+    Return "Failed to Format input: " _ input
 }
 
 ClassMethod ResetToDefault(key As %String) As %Status

--- a/src/cls/IPM/Repo/UniversalSettings.cls
+++ b/src/cls/IPM/Repo/UniversalSettings.cls
@@ -22,7 +22,9 @@ Parameter TerminalPrompt = "TerminalPrompt";
 
 Parameter PublishTimeout = "publish_timeout";
 
-Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout";
+Parameter PipPath = "PipPath";
+
+Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PipPath";
 
 /// Returns configArray, that includes all configurable settings
 ClassMethod GetAll(Output configArray) As %Status

--- a/src/cls/IPM/Repo/UniversalSettings.cls
+++ b/src/cls/IPM/Repo/UniversalSettings.cls
@@ -54,7 +54,7 @@ ClassMethod PrintList()
     For {
         Set k = $Order(confArr(k))
         Quit:(k="")
-        Write k_": "_..PrettyFormat(confArr(k)),! 
+        Write k_": "_confArr(k),! 
     }
 }
 
@@ -65,35 +65,7 @@ ClassMethod PrintOne(key As %String)
         Write "Config key = """_key_""" not found",!
         Quit
     }
-    Write key_":"_..PrettyFormat(..GetValue($Parameter(..%ClassName(1),key))),!
-}
-
-/// A helper method to format string/number/$lb() recursively
-ClassMethod PrettyFormat(input As %String) As %String
-{
-    If $Data(input) # 2 = 0 { Return "" }
-    If input = $lb() { Return "$lb()" }
-    If input = "" { Return """""" }
-    Try {
-        Set ptr = 0
-        Set output = ""
-        While $ListNext(input, ptr, value) {
-            If output = "" {
-                Set output = "$lb(" _ ..PrettyFormat(value)
-            } Else {
-                Set output = output _ ", " _ ..PrettyFormat(value)
-            }
-        }
-        Set output = output _ ")"
-        Return output
-    } Catch ex {
-        If input = +input {
-            Return input
-        }
-        Return """" _ input _ """"
-    }
-
-    Return "Failed to Format input: " _ input
+    Write key_":"_..GetValue($Parameter(..%ClassName(1),key)),!
 }
 
 ClassMethod ResetToDefault(key As %String) As %Status

--- a/src/cls/IPM/Repo/UniversalSettings.cls
+++ b/src/cls/IPM/Repo/UniversalSettings.cls
@@ -22,9 +22,9 @@ Parameter TerminalPrompt = "TerminalPrompt";
 
 Parameter PublishTimeout = "publish_timeout";
 
-Parameter PyPath = "PyPath";
+Parameter PipCaller = "PipCaller";
 
-Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PyPath";
+Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PipCaller";
 
 /// Returns configArray, that includes all configurable settings
 ClassMethod GetAll(Output configArray) As %Status

--- a/src/cls/IPM/Repo/UniversalSettings.cls
+++ b/src/cls/IPM/Repo/UniversalSettings.cls
@@ -22,16 +22,16 @@ Parameter TerminalPrompt = "TerminalPrompt";
 
 Parameter PublishTimeout = "publish_timeout";
 
-/// A path pointing either to a python executable or a pip executable, controlled by #UseStandalonePip
+/// A path pointing either to a python executable or a pip executable, controlled by <parameter>UseStandalonePip</parameter>
 /// In the special case where the path is empty, the script tries to resolve the path in the following order:
 /// 1. Where available (typically 2024.2+) - Use PythonRuntimeLibrary in iris.cpf to find the directory containing the python executable
 /// 2. On Windows, try to find <iris-root>/bin/irispip.exe
-/// 3. Unless UseStandalonePip is explicitly set to 1, try to find whichever python3/python is first available in $PATH
-/// 4. Unless UseStandalonePip is explicitly set to 0, try to find whichever pip3/pip is first available in $PATH
+/// 3. Unless <parameter>UseStandalonePip</parameter> is explicitly set to 1, try to find whichever python3/python is first available in $PATH
+/// 4. Unless <parameter>UseStandalonePip</parameter> is explicitly set to 0, try to find whichever pip3/pip is first available in $PATH
 Parameter PipCaller = "PipCaller";
 
 /// Possible values: "", 0, 1
-/// Indicates whether PipCaller is a pip executable instead of python
+/// Indicates whether <parameter>PipCaller</parameter> is a pip executable instead of python
 Parameter UseStandalonePip = "UseStandalonePip";
 
 Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PipCaller,UseStandalonePip";


### PR DESCRIPTION
Allow specifying path to `pip` or `pip3` for installation of requirements.txt.

On many Unix systems, `pip` command is a symlink to `pip3` located somewhere on $PATH. In some cases, `pip` can be nonexistent and there's only `pip3`.

With this PR, users can specify path to `pip`/`pip3` by running `config set PipPath xxxx` in zpm. Otherwise, the default location is wherever `pip3` first appears on $PATH. This allows for maximum compatibility.

master equivalent: #543 