### PR TITLE
feat: support dynamic python runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,8 @@ jobs:
             for tag in $tags
             do
               # Skip irishealth-community due to bad interaction with ZPM document type
-              if test "$n" = "irishealth-community" && test "$tag" = "2023.3"
+              # Also skip 2023.2 because the license has expired
+              if [ "$n" = "irishealth-community" -a "$tag" = "2023.3" -o "$tag" = "2023.2" ];
                 then
                   continue
               fi

--- a/Installer.cls
+++ b/Installer.cls
@@ -62,6 +62,8 @@ ClassMethod ZPMInit(pRegistry As %String = "", pAnalyticsTrackingID As %String =
     $$$QuitOnError(##class(%ZPM.PackageManager.Client.Settings).SetAnalyticsAvailable(1))
     $$$QuitOnError(##class(%ZPM.PackageManager.Client.Settings).SetAnalyticsTrackingId(pAnalyticsTrackingID))
     $$$QuitOnError(##class(%ZPM.PackageManager.Client.Settings).SetValue("ColorScheme",""))
+    $$$QuitOnError(##class(%ZPM.PackageManager.Client.Settings).SetValue("PipCaller",""))
+    $$$QuitOnError(##class(%ZPM.PackageManager.Client.Settings).SetValue("UseStandalonePip",""))
     Quit $$$OK
 }
 

--- a/src/%ZPM/PackageManager/Client/Settings.cls
+++ b/src/%ZPM/PackageManager/Client/Settings.cls
@@ -22,16 +22,16 @@ Parameter TerminalPrompt = "TerminalPrompt";
 
 Parameter PublishTimeout = "publish_timeout";
 
-/// A path pointing either to a python executable or a pip executable, controlled by #UseStandalonePip
+/// A path pointing either to a python executable or a pip executable, controlled by <parameter>UseStandalonePip</parameter>
 /// In the special case where the path is empty, the script tries to resolve the path in the following order:
 /// 1. Where available (typically 2024.2+) - Use PythonRuntimeLibrary in iris.cpf to find the directory containing the python executable
 /// 2. On Windows, try to find <iris-root>/bin/irispip.exe
-/// 3. Unless UseStandalonePip is explicitly set to 1, try to find whichever python3/python is first available in $PATH
-/// 4. Unless UseStandalonePip is explicitly set to 0, try to find whichever pip3/pip is first available in $PATH
+/// 3. Unless <parameter>UseStandalonePip</parameter> is explicitly set to 1, try to find whichever python3/python is first available in $PATH
+/// 4. Unless <parameter>UseStandalonePip</parameter> is explicitly set to 0, try to find whichever pip3/pip is first available in $PATH
 Parameter PipCaller = "PipCaller";
 
 /// Possible values: "", 0, 1
-/// Indicates whether PipCaller is a pip executable instead of python
+/// Indicates whether <parameter>PipCaller</parameter> is a pip executable instead of python
 Parameter UseStandalonePip = "UseStandalonePip";
 
 Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PipCaller,UseStandalonePip";

--- a/src/%ZPM/PackageManager/Client/Settings.cls
+++ b/src/%ZPM/PackageManager/Client/Settings.cls
@@ -22,7 +22,19 @@ Parameter TerminalPrompt = "TerminalPrompt";
 
 Parameter PublishTimeout = "publish_timeout";
 
-Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout";
+/// A path pointing either to a python executable or a pip executable, controlled by #UseStandalonePip
+/// In the special case where the path is empty, the script tries to resolve the path in the following order:
+/// 1. Where available (typically 2024.2+) - Use PythonRuntimeLibrary in iris.cpf to find the directory containing the python executable
+/// 2. On Windows, try to find <iris-root>/bin/irispip.exe
+/// 3. Unless UseStandalonePip is explicitly set to 1, try to find whichever python3/python is first available in $PATH
+/// 4. Unless UseStandalonePip is explicitly set to 0, try to find whichever pip3/pip is first available in $PATH
+Parameter PipCaller = "PipCaller";
+
+/// Possible values: "", 0, 1
+/// Indicates whether PipCaller is a pip executable instead of python
+Parameter UseStandalonePip = "UseStandalonePip";
+
+Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PipCaller,UseStandalonePip";
 
 /// Returns configArray, that includes all configurable settings
 ClassMethod GetAll(Output configArray) As %Status

--- a/src/%ZPM/PackageManager/Developer/Lifecycle/Base.cls
+++ b/src/%ZPM/PackageManager/Developer/Lifecycle/Base.cls
@@ -612,7 +612,7 @@ Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) 
 			If pVerbose {
 				Write "Success!"
 			}
-			Return $lb(tInterpreter, "-m", "pip")
+			Return $lb(irispip)
 		}
 		If pVerbose {
 			Write "Not Found"

--- a/src/%ZPM/PackageManager/Developer/Lifecycle/Base.cls
+++ b/src/%ZPM/PackageManager/Developer/Lifecycle/Base.cls
@@ -522,14 +522,14 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
     Write:tVerbose !
 
     Set target = ##class(%File).NormalizeDirectory("python", $System.Util.ManagerDirectory())
-	If '$System.CLS.IsMthd("%SYS.Python", "Import") {
-		Throw ##class(%Exception.General).%New("Embedded Python is not available in this instance.")
-	}
-	Set tSysModule = ##class(%SYS.Python).Import("sys")
-	Set tPyMajor = tSysModule."version_info".major
-	Set tPyMinor = tSysModule."version_info".minor
-	Set tPyMicro = tSysModule."version_info".micro
-	Set tPyVersion = tPyMajor_"."_tPyMinor_"."_tPyMicro
+    If '$System.CLS.IsMthd("%SYS.Python", "Import") {
+        Throw ##class(%Exception.General).%New("Embedded Python is not available in this instance.")
+    }
+    Set tSysModule = ##class(%SYS.Python).Import("sys")
+    Set tPyMajor = tSysModule."version_info".major
+    Set tPyMinor = tSysModule."version_info".minor
+    Set tPyMicro = tSysModule."version_info".micro
+    Set tPyVersion = tPyMajor_"."_tPyMinor_"."_tPyMicro
     Set command = ..ResolvePipCaller(.pParams) _ $ListBuild("install", "-r", "requirements.txt", "-t", target, "--python-version", tPyVersion, "--only-binary=:all:")
     If 'tVerbose {
       Set stdout = ""

--- a/src/%ZPM/PackageManager/Developer/Lifecycle/Base.cls
+++ b/src/%ZPM/PackageManager/Developer/Lifecycle/Base.cls
@@ -560,14 +560,18 @@ Method ResolvePipCaller(ByRef pParams) As %List
 
 Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) As %List
 {
-	Write:pVerbose !,"Detecting pip caller"
+	If pVerbose {
+		Write !,"Detecting pip caller"
+	}
 
 	// First try to detect flexible python (in 2024.2 and later)
 	// This is a hack that doesn't always work because the python interpreter may not be in the same directory as the so/dylib/dll.
 	// In fact, the python interpreter executable, in theory, may not even exist at all!
 	// What IRIS does it #include <Python.h> and then link against the dynamic library. This is independent of the python interpreter.
 	If $System.CLS.IsMthd("%SYS.Python","GetPythonInfo") {
-		Write:pVerbose !, "Attempting to find flexible python... "
+		If pVerbose {
+			Write !, "Attempting to find flexible python... "
+		}
 		Do ##class(%SYS.Python).GetPythonInfo(.info)
 		If $Data(info("CPF_PythonRuntimeLibrary"), tPyDylib) && tPyDylib {
 			// TODO: try `../bin/python3` or `../bin/python` in case the .so is in subfolder `lib`
@@ -578,54 +582,78 @@ Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) 
 					Set tInterpreter = tInterpreter_".exe"
 				}
 				If ##class(%File).Exists(tInterpreter) {
-					Write:pVerbose "Success!"
+					If pVerbose {
+						Write "Success!"
+					}
 					Return $lb(tInterpreter, "-m", "pip")
 				}
-				Write:pVerbose "Not Found"
+				If pVerbose {
+					Write "Not Found"
+				}
 			}
 		}
-    }
+	}
 
 	// For windows, try to find irispip.exe (in 2024.1 and earlier)
 	If $$$isWINDOWS {
-		Write:pVerbose !, "Attempting to find irispip.exe..."
+		If pVerbose {
+			Write !, "Attempting to find irispip.exe..."
+		}
 		Set irispip = ##class(%File).NormalizeFilename("irispip.exe", $System.Util.BinaryDirectory())
 		If ##class(%File).Exists(irispip) {
-			Write:pVerbose "Success!"
+			If pVerbose {
+				Write "Success!"
+			}
 			Return $lb(tInterpreter, "-m", "pip")
 		}
-		Write:pVerbose "Not Found"
+		If pVerbose {
+			Write "Not Found"
+		}
 	}
 
 	Set flags = "/SHELL/LOGCMD/STDOUT=""DetectPipCaller.log""/STDERR=""DetectPipCaller.err"""
 	// Unless UseStandalonePip is set to 1, try to find python3 or python
 	If pUseStandalonePip '= 1 {
-		Write:pVerbose !, "Attempting to find python3 or python..."
+		If pVerbose {
+			Write !, "Attempting to find python3 or python..."
+		}
 		For cmd = "python3", "python" {
-			If $$$isWINDOWS { Set cmd = cmd _ ".exe" }
+			If $$$isWINDOWS {
+				Set cmd = cmd _ ".exe"
+			}
 			Kill args
 			Set args($I(args)) = "-m"
 			Set args($I(args)) = "pip"
 			Set retCode = $ZF(-100, flags, cmd, .args)
 			If retCode = 0 {
-				Write:pVerbose !, "Success!"
+				If pVerbose {
+					Write "Success!"
+				}
 				Return $lb(cmd, "-m", "pip")
 			}
-			Write:pVerbose "Not Found"
+			If pVerbose {
+				Write "Not Found"
+			}
 		}
 	}
 
 	// Unless UseStandalonePip is set to 0, try to find pip3 or pip
 	If pUseStandalonePip '= 0 {
-		Write:pVerbose !, "Attempting to find pip3 or pip..."
+		If pVerbose {
+			Write !, "Attempting to find pip3 or pip..."
+		}
 		For cmd = "pip3", "pip" {
-			If $$$isWINDOWS { Set cmd = cmd _ ".exe" }
+			If $$$isWINDOWS { 
+				Set cmd = cmd _ ".exe" 
+			}
 			Set retCode = $ZF(-100, flags, cmd)
 			If retCode = 0 {
-				Write !, "Success!"
+				Write "Success!"
 				Return $lb(cmd)
 			}
-			Write:pVerbose "Not Found"
+			If pVerbose {
+				Write "Not Found"
+			}
 		}
 	}
 

--- a/src/%ZPM/PackageManager/Developer/Lifecycle/Base.cls
+++ b/src/%ZPM/PackageManager/Developer/Lifecycle/Base.cls
@@ -522,9 +522,7 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
     Write:tVerbose !
 
     Set target = ##class(%File).NormalizeDirectory("python", $System.Util.ManagerDirectory())
-    Set command = $ListBuild("pip", "install", "-r", "requirements.txt", "-t", target)
-    Set pip = $Select($$$isWINDOWS: ##class(%File).NormalizeFilename("irispip.exe", $System.Util.BinaryDirectory()), 1: "pip")
-    Set command = $ListBuild(pip, "install", "-r", "requirements.txt", "-t", target)
+    Set command = ..ResolvePipCaller(.pParams) _ $ListBuild("install", "-r", "requirements.txt", "-t", target)
     If 'tVerbose {
       Set stdout = ""
     }
@@ -538,6 +536,100 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
     Do ..Log("requirements.txt FAILURE")
   }
   Quit tSC
+}
+
+Method ResolvePipCaller(ByRef pParams) As %List
+{
+	Set tUseStandalonePip = ##class(%ZPM.PackageManager.Client.Settings).GetValue("UseStandalonePip")
+	Set tPipCaller = ##class(%ZPM.PackageManager.Client.Settings).GetValue("PipCaller")
+
+	If tPipCaller '= "" {
+		If tUseStandalonePip = 1 {
+			Return $lb(tPipCaller)
+		} ElseIf tUseStandalonePip = 0 {
+			Return $lb(tPipCaller, "-m", "pip")
+		} Else {
+			Set msg = "Detected PipCaller=""" _ tPipCaller _ """ but UseStandalonePip is not properly set." _ $Char(13, 10)
+			Set msg = msg _ "Please set UseStandalonePip to 1 (if using a pip executable) or 0 (if using a python executable)." _ $Char(13, 10)
+			Set msg = msg _ "Example: zpm ""config set UseStandalonePip 1"""
+			Throw ##class(%Exception.General).%New(msg)
+		}
+	}
+	Return ..DetectPipCaller(tUseStandalonePip, $Get(pParams("Verbose"), 0))
+}
+
+Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) As %List
+{
+	Write:pVerbose !,"Detecting pip caller"
+
+	// First try to detect flexible python (in 2024.2 and later)
+	// This is a hack that doesn't always work because the python interpreter may not be in the same directory as the so/dylib/dll.
+	// In fact, the python interpreter executable, in theory, may not even exist at all!
+	// What IRIS does it #include <Python.h> and then link against the dynamic library. This is independent of the python interpreter.
+	If $System.CLS.IsMthd("%SYS.Python","GetPythonInfo") {
+		Write:pVerbose !, "Attempting to find flexible python... "
+		Do ##class(%SYS.Python).GetPythonInfo(.info)
+		If $Data(info("CPF_PythonRuntimeLibrary"), tPyDylib) && tPyDylib {
+			// TODO: try `../bin/python3` or `../bin/python` in case the .so is in subfolder `lib`
+			// TODO: try to find `pip3` or `pip` if pUseStandalonePip is 1
+			For filename = "python3", "python" {
+				Set tInterpreter = ##class(%File).GetDirectory(tPyDylib, 1) _ filename
+				If $$$isWINDOWS {
+					Set tInterpreter = tInterpreter_".exe"
+				}
+				If ##class(%File).Exists(tInterpreter) {
+					Write:pVerbose "Success!"
+					Return $lb(tInterpreter, "-m", "pip")
+				}
+				Write:pVerbose "Not Found"
+			}
+		}
+    }
+
+	// For windows, try to find irispip.exe (in 2024.1 and earlier)
+	If $$$isWINDOWS {
+		Write:pVerbose !, "Attempting to find irispip.exe..."
+		Set irispip = ##class(%File).NormalizeFilename("irispip.exe", $System.Util.BinaryDirectory())
+		If ##class(%File).Exists(irispip) {
+			Write:pVerbose "Success!"
+			Return $lb(tInterpreter, "-m", "pip")
+		}
+		Write:pVerbose "Not Found"
+	}
+
+	Set flags = "/SHELL/LOGCMD/STDOUT=""DetectPipCaller.log""/STDERR=""DetectPipCaller.err"""
+	// Unless UseStandalonePip is set to 1, try to find python3 or python
+	If pUseStandalonePip '= 1 {
+		Write:pVerbose !, "Attempting to find python3 or python..."
+		For cmd = "python3", "python" {
+			If $$$isWINDOWS { Set cmd = cmd _ ".exe" }
+			Kill args
+			Set args($I(args)) = "-m"
+			Set args($I(args)) = "pip"
+			Set retCode = $ZF(-100, flags, cmd, .args)
+			If retCode = 0 {
+				Write:pVerbose !, "Success!"
+				Return $lb(cmd, "-m", "pip")
+			}
+			Write:pVerbose "Not Found"
+		}
+	}
+
+	// Unless UseStandalonePip is set to 0, try to find pip3 or pip
+	If pUseStandalonePip '= 0 {
+		Write:pVerbose !, "Attempting to find pip3 or pip..."
+		For cmd = "pip3", "pip" {
+			If $$$isWINDOWS { Set cmd = cmd _ ".exe" }
+			Set retCode = $ZF(-100, flags, cmd)
+			If retCode = 0 {
+				Write !, "Success!"
+				Return $lb(cmd)
+			}
+			Write:pVerbose "Not Found"
+		}
+	}
+
+	Throw ##class(%Exception.General).%New("Could not find a suitable pip caller. Consider setting UseStandalonePip and PipCaller")
 }
 
 Method %Validate(ByRef pParams) As %Status

--- a/src/%ZPM/PackageManager/Developer/Lifecycle/Base.cls
+++ b/src/%ZPM/PackageManager/Developer/Lifecycle/Base.cls
@@ -531,7 +531,11 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
     Set tPyMicro = tSysModule."version_info".micro
     Set tPyVersion = tPyMajor_"."_tPyMinor_"."_tPyMicro
     Set command = ..ResolvePipCaller(.pParams) _ $ListBuild("install", "-r", "requirements.txt", "-t", target, "--python-version", tPyVersion, "--only-binary=:all:")
-    If 'tVerbose {
+    If tVerbose {
+        Write !, "Running "
+        Zwrite command
+    }
+    Else{
       Set stdout = ""
     }
     Set tSC = ##class(%ZPM.PackageManager.Developer.Utils).RunCommand(pRoot, command,.stdout)
@@ -619,7 +623,6 @@ Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) 
 		}
 	}
 
-	Set flags = "/SHELL/LOGCMD/STDOUT=""DetectPipCaller.log""/STDERR=""DetectPipCaller.err"""
 	// Unless UseStandalonePip is set to 1, try to find python3 or python
 	If pUseStandalonePip '= 1 {
 		If pVerbose {
@@ -629,15 +632,14 @@ Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) 
 			If $$$isWINDOWS {
 				Set cmd = cmd _ ".exe"
 			}
-			Kill args
-			Set args($I(args)) = "-m"
-			Set args($I(args)) = "pip"
-			Set retCode = $ZF(-100, flags, cmd, .args)
-			If retCode = 0 {
+			set cmd = $lb(cmd, "-m", "pip")
+			Set cwd = ##class(%SYSTEM.Util).InstallDirectory()
+			Set tSC = ##class(%ZPM.PackageManager.Developer.Utils).RunCommand(cwd, cmd, "")
+			If $$$ISOK(tSC) {
 				If pVerbose {
 					Write "Success!"
 				}
-				Return $lb(cmd, "-m", "pip")
+				Return cmd
 			}
 			If pVerbose {
 				Write "Not Found"
@@ -654,10 +656,14 @@ Method DetectPipCaller(pUseStandalonePip As %Boolean, pVerbose As %Boolean = 0) 
 			If $$$isWINDOWS { 
 				Set cmd = cmd _ ".exe" 
 			}
-			Set retCode = $ZF(-100, flags, cmd)
-			If retCode = 0 {
-				Write "Success!"
-				Return $lb(cmd)
+			set cmd = $lb(cmd)
+			Set cwd = ##class(%SYSTEM.Util).InstallDirectory()
+			Set tSC = ##class(%ZPM.PackageManager.Developer.Utils).RunCommand(cwd, cmd, "")
+			If $$$ISOK(tSC) {
+				If pVerbose {
+					Write "Success!"
+				}
+				Return cmd
 			}
 			If pVerbose {
 				Write "Not Found"

--- a/src/%ZPM/PackageManager/Developer/Lifecycle/Base.cls
+++ b/src/%ZPM/PackageManager/Developer/Lifecycle/Base.cls
@@ -522,7 +522,15 @@ Method InstallPythonRequirements(pRoot As %String = "", ByRef pParams)
     Write:tVerbose !
 
     Set target = ##class(%File).NormalizeDirectory("python", $System.Util.ManagerDirectory())
-    Set command = ..ResolvePipCaller(.pParams) _ $ListBuild("install", "-r", "requirements.txt", "-t", target)
+	If '$System.CLS.IsMthd("%SYS.Python", "Import") {
+		Throw ##class(%Exception.General).%New("Embedded Python is not available in this instance.")
+	}
+	Set tSysModule = ##class(%SYS.Python).Import("sys")
+	Set tPyMajor = tSysModule."version_info".major
+	Set tPyMinor = tSysModule."version_info".minor
+	Set tPyMicro = tSysModule."version_info".micro
+	Set tPyVersion = tPyMajor_"."_tPyMinor_"."_tPyMicro
+    Set command = ..ResolvePipCaller(.pParams) _ $ListBuild("install", "-r", "requirements.txt", "-t", target, "--python-version", tPyVersion, "--only-binary=:all:")
     If 'tVerbose {
       Set stdout = ""
     }


### PR DESCRIPTION
This PR is aimed to support dynamic python runtime in IRIS 2024.2+. 

It adds 2 more configurable properties, PipCaller and UseStandalonePip. 
* PipCaller is the path to a `pip` or `python` executable. If set, UseStandalonPip must also be set
* UseStandalonePip is 1 if PipCaller is a pip executable (packages will be installed using `<pip> install` and 0 if PipCaller is a python executable (packages will be installed using `<python> -m pip install`.
* By default, neither is set, and we attempt to resolve the call to pip when installing requirements.txt
* In special cases, they do need to be set!

v1 equivalent: #538 