### PR TITLE
Treat top-level <Mapping> elements consistently

### DIFF
--- a/src/cls/IPM/StudioDocument/Module.cls
+++ b/src/cls/IPM/StudioDocument/Module.cls
@@ -496,6 +496,11 @@ XData InternalXSL
       <xsl:copy-of select="." />
     </xsl:element>
   </xsl:template>
+  <xsl:template match="Module/Mapping">
+    <xsl:element name="Mappings">
+      <xsl:copy-of select="." />
+    </xsl:element>
+  </xsl:template>
   <xsl:template match="Module/Default|Module/Parameter">
     <xsl:element name="Defaults">
       <xsl:element name="Default">
@@ -507,8 +512,8 @@ XData InternalXSL
     <xsl:call-template name="resource">
       <xsl:with-param name="name" select="'Name'" />
     </xsl:call-template>
-	</xsl:template>
-	<xsl:template match="Module" mode="pass2">
+  </xsl:template>
+  <xsl:template match="Module" mode="pass2">
     <xsl:copy>
       <xsl:apply-templates select="./@*" mode="pass2" />
       <xsl:apply-templates mode="pass2" />

--- a/tests/integration_tests/Test/PM/Integration/Mappings.cls
+++ b/tests/integration_tests/Test/PM/Integration/Mappings.cls
@@ -1,0 +1,41 @@
+Class Test.PM.Integration.Mappings Extends %UnitTest.TestCase
+{
+
+Method TestWrapped()
+{
+    Do ..RunTestCase("_data/mapping-test-wrapped","MappingTestWrapped")
+}
+
+Method TestUnwrappedWrapped()
+{
+    Do ..RunTestCase("_data/mapping-test-unwrapped","MappingTestUnwrapped")
+}
+
+Method RunTestCase(subdirectory As %String, packageName As %String)
+{
+    Try {
+        Set tTestRoot = $Get(^UnitTestRoot)
+        Set tParams("Verbose") = 1
+        Set tModuleDirectory = ##class(%File).NormalizeDirectory(subdirectory, tTestRoot)
+        $$$ThrowOnError(##class(%IPM.Utils.Module).LoadModuleFromDirectory(tModuleDirectory,.tParams))
+        Set module = ##class(%IPM.Storage.Module).NameOpen(packageName,,.sc)
+        $$$ThrowOnError(sc)
+        Do $$$AssertEquals(module.Mappings.Count(),1)
+        
+        Do ..AssertPackageMappingExists(packageName_".Foo")
+    } Catch e {
+        Do $$$AssertFailure("An exception occurred: "_$System.Status.GetErrorText(e.AsStatus()))
+    }
+}
+
+Method AssertPackageMappingExists(mappingName As %String)
+{
+    Set namespace = $namespace
+    New $namespace
+    Set $namespace = "%SYS"
+    Set mappingCreated = ##class(Config.MapPackages).Exists("USER-VERIFY","MappingTestUnwrapped.Foo")
+    Set $namespace = namespace
+    Do $$$AssertTrue(mappingCreated)
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/mapping-test-unwrapped/cls/MappingTestUnwrapped/Sample.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/mapping-test-unwrapped/cls/MappingTestUnwrapped/Sample.cls
@@ -1,0 +1,4 @@
+Class MappingTestUnwrapped.Sample Extends %RegisteredObject
+{
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/mapping-test-unwrapped/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/mapping-test-unwrapped/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+<Document name="MappingTestUnwrapped.ZPM"><Module>
+  <Name>MappingTestUnwrapped</Name>
+  <Version>0.0.1+snapshot</Version>
+  <Packaging>module</Packaging>
+  <Mapping Name="MappingTestUnwrapped.Foo.PKG" Source="USER" />
+  <Resource Name="MappingTestUnwrapped.PKG" />
+  <LifecycleClass>Module</LifecycleClass>
+</Module>
+</Document></Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/mapping-test-wrapped/cls/MappingTestWrapped/Sample.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/mapping-test-wrapped/cls/MappingTestWrapped/Sample.cls
@@ -1,0 +1,4 @@
+Class MappingTestWrapped.Sample Extends %RegisteredObject
+{
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/mapping-test-wrapped/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/mapping-test-wrapped/module.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+<Document name="MappingTestWrapped.ZPM"><Module>
+  <Name>MappingTestWrapped</Name>
+  <Version>0.0.1+snapshot</Version>
+  <Packaging>module</Packaging>
+  <Resources>
+    <Resource Name="MappingTestWrapped.PKG" />
+  </Resources>
+  <Mappings>
+    <Mapping Name="MappingTestWrapped.Foo.PKG" Source="USER" />
+  </Mappings>
+  <LifecycleClass>Module</LifecycleClass>
+</Module>
+</Document></Export>


### PR DESCRIPTION
Fixes #499

I couldn't actually reproduce the issue where they didn't import at all, but we now have integration tests covering both the wrapped and unwrapped cases.