### PR TITLE
bootstrap: make a 0.7 release that honors prerelease & snapshots

### DIFF
--- a/src/%ZPM/PackageManager/Client/REST/PackageManagerClient.cls
+++ b/src/%ZPM/PackageManager/Client/REST/PackageManagerClient.cls
@@ -37,6 +37,8 @@ Method ListModules(pSearchCriteria As %ZPM.PackageManager.Core.SearchCriteria) A
     Set tURL = tRequest.Location_"packages/" _ name
   }
   Do tRequest.SetParam("allVersions", pSearchCriteria.AllVersions)
+  Do tRequest.SetParam("includePrerelease", pSearchCriteria.IncludePrerelease)
+  Do tRequest.SetParam("includeSnapshots", pSearchCriteria.IncludeSnapshots)
 
   Set tSC = tRequest.Get($$$URLENCODE(tURL))
   


### PR DESCRIPTION
CI in #559 is failing because a newer version of zpm-registry has been published. The new zpm-registry needs `IncludePrerelease` and `IncludeSnapshots` in the URL query string to return prereleases and snapshots. Since older version (0.7.x) of zpm doesn't yet properly set them in URL, it won't install prerelease `0.9.0-dev.559.1`, hence causing the migration test from 0.7.x to fail.

This PR addresses this problem by setting `IncludePrerelease` and `IncludeSnapshots`. Another commit to change the CI in v1 branch is also needed (after this PR is merged and released)