### PR TITLE
fix: aggregate all versions of module when searching FS repo

### DIFF
--- a/src/cls/IPM/Repo/Filesystem/Cache.cls
+++ b/src/cls/IPM/Repo/Filesystem/Cache.cls
@@ -37,7 +37,7 @@ ClassMethod %OnBeforeBuildIndices(ByRef indexlist As %String(MAXLEN="") = "") As
 	Quit $$$OK
 }
 
-Query OrderedMatches(pRoot As %String = "", pName As %String = "", pVersionExpression As %String = "*", pParameters As %String = "") As %Query(ROWSPEC = "Name:%String,VersionString:%String") [ SqlProc ]
+Query OrderedMatches(pRoot As %String = "", pName As %String = "", pVersionExpression As %String = "*", pParameters As %String = "") As %Query(ROWSPEC = "Name:%String,VersionString:%String,Version_Major:%String,Version_Minor:%String,Version_Patch:%String,Version_Prerelease:%String,Version_Build:%String") [ SqlProc ]
 {
 }
 
@@ -62,7 +62,7 @@ ClassMethod OrderedMatchesFetch(ByRef qHandle As %Binary, ByRef Row As %List, By
 		}
 		Set tRoot = ..RootGetStored($ListGet(tRow))
 		If (tRoot = qHandle("root")) {
-			Set Row = $ListBuild(..NameGetStored($ListGet(tRow)),..VersionStringGetStored($ListGet(tRow)))
+			Set Row = $ListBuild(..NameGetStored($ListGet(tRow)),..VersionStringGetStored($ListGet(tRow)))_..VersionGetStored($ListGet(tRow))
 			Quit
 		}
 	}

--- a/src/cls/IPM/Repo/Utils.cls
+++ b/src/cls/IPM/Repo/Utils.cls
@@ -105,7 +105,8 @@ ClassMethod moduleSqlToList(pQuery As %String, pSearchCriteria As %IPM.Repo.Sear
 		Set tOrderByParts = tOrderByParts_$ListBuild("case m.VersionString when ? then 0 else 1 end")
 		Set tArgs($i(tArgs)) = pSearchCriteria.VersionExpression
 	}
-	
+	Set tOrderByParts = tOrderByParts_$ListBuild("m.Name")
+	Set tOrderByParts = tOrderByParts_$ListBuild("m.Version_Major desc", "m.Version_Minor desc", "m.Version_Patch desc", "m.Version_Prerelease desc", "m.Version_Build desc")
 	If (tKeywordList '= "") {
 		// TODO: Find some way to order by max similarity (or just similarity of latest version of the module) instead?
 		Set tOrderByParts = tOrderByParts_$ListBuild("%SIMILARITY(Manifest,?) desc")
@@ -122,7 +123,7 @@ ClassMethod moduleSqlToList(pQuery As %String, pSearchCriteria As %IPM.Repo.Sear
 		}
 	}
 	
-	Set tList = ##class(%Library.ListOfObjects).%New()
+	Set tArray = ##class(%Library.ArrayOfObjects).%New()
 	Set tRes = ##class(%SQL.Statement).%ExecDirect(,pQuery,tArgs...)
 	If (tRes.%SQLCODE < 0) {
 		$$$ThrowStatus($$$ERROR($$$SQLCode,tRes.%SQLCODE,tRes.%Message))
@@ -131,14 +132,33 @@ ClassMethod moduleSqlToList(pQuery As %String, pSearchCriteria As %IPM.Repo.Sear
 		If $$$ISERR(tStatus) {
 			Quit
 		}
-		
-		Set tModRef = ##class(%IPM.Storage.ModuleInfo).%New()
-		Set tModRef.Name = tRes.%Get("Name")
-		Set tModRef.VersionString = tRes.%Get("VersionString")
-		Do tList.Insert(tModRef)
+		Set Name = tRes.%Get("Name")
+		Set VersionString = tRes.%Get("VersionString")
+
+		Set tModRef = tArray.GetAt(tRes.%Get("Name")) 
+		If tModRef = "" {
+			Set tModRef = ##class(%IPM.Storage.ModuleInfo).%New()
+			Set tModRef.Name = tRes.%Get("Name")
+			Set tModRef.VersionString = tRes.%Get("VersionString")
+			If pSearchCriteria.AllVersions {
+				Set tModRef.AllVersions = VersionString
+			}
+			Do tArray.SetAt(tModRef, Name)
+		} ElseIf pSearchCriteria.AllVersions {
+			Set tModRef.AllVersions = tModRef.AllVersions_", "_VersionString
+		}
 	}
 	If $$$ISERR(tStatus) {
 		$$$ThrowStatus(tStatus)
+	}
+	Set tList = ##class(%Library.ListOfObjects).%New()
+	Set key = ""
+	For {
+		Set mod = tArray.GetNext(.key)
+		If (key = "") {
+			Quit
+		}
+		Do tList.Insert(mod)
 	}
 	Quit tList
 }


### PR DESCRIPTION
Fix #583

Make sure that 
* `%IPM.Repo.Filesystem.PackageService:ListModules()` returns a list of modules with their **latest** versions; and
* If all versions need to be returned, they appear in the `AllVersions` column, separated by `", "`, instead of creating a new row.