### PR TITLE
fix: move namespace filtering from SQL to ObjectScript for IRIS compat.

### DIFF
--- a/src/cls/IPM/DataType/RegExString.cls
+++ b/src/cls/IPM/DataType/RegExString.cls
@@ -50,4 +50,19 @@ ClassMethod IsValid(%val As %CacheString) As %Status [ ServerOnly = 0 ]
     return $$$OK
 }
 
+ClassMethod FromWildCard(wildcard As %String) As %String
+{
+    Set regex = ""
+    For i=1:1:$Length(wildcard) {
+        Set char = $Extract(wildcard, i)
+        If char = "*" {
+            Set regex = regex_".*"
+        } Else {
+            Set regex = regex_char
+        }
+    }
+    // Is there a way to return an instance of this class instead of %String?
+    Quit "^(?i)"_regex_"$"
+}
+
 }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -902,7 +902,7 @@ ClassMethod GetListNamespace(Output list, pSearch As %String = "")
   Set transformedPieces = ""
   Set ptr = 0
   While $ListNext(pieces, ptr, val) {
-    If val '? .(1AN,1"%") { // namespace
+    If val '? .(1AN,1"%") { // namespace contain only numbers, letters and %, otherwise there's guaranteed no match
       Return
     }
     Set transformedPieces = transformedPieces _ $ListBuild(1_$$$QUOTE(val))
@@ -913,9 +913,8 @@ ClassMethod GetListNamespace(Output list, pSearch As %String = "")
   }
 
   Set width = 0
-  Set tArgs = 0
   Set tQuery = "SELECT Nsp FROM %SYS.Namespace_List()"
-  Set tRes = ##class(%SQL.Statement).%ExecDirect(,tQuery, tArgs...)
+  Set tRes = ##class(%SQL.Statement).%ExecDirect(,tQuery) 
   $$$ThrowSQLIfError(tRes.%SQLCODE, tRes.%Message)
   While tRes.%Next(.tSC) {
     $$$ThrowOnError(tSC)

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -892,25 +892,13 @@ ClassMethod GetListNamespace(Output list, pSearch As %String = "")
   Kill list
   Set list = 0
 
-  // Build pattern for matching outside of SQL. 
+  // Build regex for matching outside of SQL. 
   // Directly using `where Nsp LIKE ?` causes a bug described in https://github.com/intersystems/ipm/issues/579 
   Set pSearch = $Zstrip(pSearch, "<>WC")
   If pSearch = "" {
     Set pSearch = "*"
   }
-  Set pieces = $ListFromString(pSearch, "*")
-  Set transformedPieces = ""
-  Set ptr = 0
-  While $ListNext(pieces, ptr, val) {
-    If val '? .(1AN,1"%") { // namespace contain only numbers, letters and %, otherwise there's guaranteed no match
-      Return
-    }
-    Set transformedPieces = transformedPieces _ $ListBuild(1_$$$QUOTE(val))
-  }
-  Set pattern = $ListToString(transformedPieces, ".(1AN,1""%"")")
-  If pattern = "" { // should never happen
-    Set pattern = "0""""" 
-  }
+  Set regex = ##class(%IPM.DataType.RegExString).FromWildCard(pSearch)
 
   Set width = 0
   Set tQuery = "SELECT Nsp FROM %SYS.Namespace_List()"
@@ -919,7 +907,7 @@ ClassMethod GetListNamespace(Output list, pSearch As %String = "")
   While tRes.%Next(.tSC) {
     $$$ThrowOnError(tSC)
     Set nsp = tRes.Nsp
-    If nsp ? @pattern {
+    If $Match(nsp, regex) {
       Set list(nsp) = ""
     }
   }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -889,20 +889,40 @@ ClassMethod Namespace(ByRef pCommandInfo) [ Internal ]
 /// Get list Namespace, example do ##class(%IPM.Main).GetListNamespace(.ns)
 ClassMethod GetListNamespace(Output list, pSearch As %String = "")
 {
+  Kill list
   Set list = 0
+
+  // Build pattern for matching outside of SQL. 
+  // Directly using `where Nsp LIKE ?` causes a bug described in https://github.com/intersystems/ipm/issues/579 
+  Set pSearch = $Zstrip(pSearch, "<>WC")
+  If pSearch = "" {
+    Set pSearch = "*"
+  }
+  Set pieces = $ListFromString(pSearch, "*")
+  Set transformedPieces = ""
+  Set ptr = 0
+  While $ListNext(pieces, ptr, val) {
+    If val '? .(1AN,1"%") { // namespace
+      Return
+    }
+    Set transformedPieces = transformedPieces _ $ListBuild(1_$$$QUOTE(val))
+  }
+  Set pattern = $ListToString(transformedPieces, ".(1AN,1""%"")")
+  If pattern = "" { // should never happen
+    Set pattern = "0""""" 
+  }
+
   Set width = 0
   Set tArgs = 0
   Set tQuery = "SELECT Nsp FROM %SYS.Namespace_List()"
-  If pSearch'="" {
-    Set tQuery = tQuery _ " WHERE Nsp " _ $Select(pSearch["*": "LIKE", 1: "=") _ " ?"
-    Set tArgs($Increment(tArgs)) = $Translate($$$UPPER(pSearch), "*", "%")
-  }
   Set tRes = ##class(%SQL.Statement).%ExecDirect(,tQuery, tArgs...)
   $$$ThrowSQLIfError(tRes.%SQLCODE, tRes.%Message)
   While tRes.%Next(.tSC) {
     $$$ThrowOnError(tSC)
     Set nsp = tRes.Nsp
-    Set list(nsp) = ""
+    If nsp ? @pattern {
+      Set list(nsp) = ""
+    }
   }
 }
 
@@ -2221,9 +2241,49 @@ ClassMethod RunDependencyAnalyzer(ByRef pCommandInfo)
 	Write !
 }
 
-Query ActiveNamespaces() As %SQLQuery(ROWSPEC = "ID:%String,Name:%String") [ SqlProc ]
+/// Implemented as custom query instead of `select Nsp, Nsp from %SYS.Namespace_List(0,0) WHERE status = 1` because of a DP issue, see https://github.com/intersystems/ipm/issues/579
+Query ActiveNamespaces() As %Query(ROWSPEC = "ID:%String,Name:%String") [ SqlProc ]
 {
-	select Nsp,Nsp from %SYS.Namespace_List(0,0) where Status = 1
+}
+
+ClassMethod ActiveNamespacesExecute(qHandle As %Binary) As %Status
+{
+  Try {
+    Set tQuery = "SELECT NSP, Status FROM %SYS.Namespace_List(0,0)"
+    Set rs = ##class(%SQL.Statement).%ExecDirect(, tQuery)
+    Kill qHandle
+    While rs.%Next() {
+      If rs.%Get("Status") {
+        Set qHandle($INCREMENT(qHandle)) = rs.%Get("NSP")
+      }
+    }
+    Set qHandle = 0
+  } catch ex {
+    Return ex.AsStatus()
+  }
+  Return $$$OK
+}
+
+ClassMethod ActiveNamespacesFetch(qHandle As %Binary, ByRef Row As %List, ByRef AtEnd As %Integer = 0) As %Status [ PlaceAfter = ActiveNamespacesExecute ]
+{
+  Try {
+    If $Data(qHandle($Increment(qHandle)), nsp) # 2 {
+      Set Row = $ListBuild(nsp, nsp)
+      Set AtEnd = 0
+    } Else {
+      Set Row = ""
+      Set AtEnd = 1
+    }
+  } catch ex {
+    Return ex.AsStatus()
+  }
+  Return $$$OK
+}
+
+ClassMethod ActiveNamespacesClose(qHandle As %Binary) As %Status [ PlaceAfter = ActiveNamespacesFetch ]
+{
+  Kill qHandle
+  Return $$$OK
 }
 
 ClassMethod ListInstalled(ByRef pCommandInfo) [ Private ]


### PR DESCRIPTION
Fix #579 

Move `WHERE` clause in `SELECT nsp FROM %SYS.Namespace_List()` outside of SQL into ObjectScript code, to avoid the weird Data Platform bug related to Lite terminal in latest vscode extension, as described in #579.