### PR TITLE
chore(git): run main CI properly on v1-next

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - master
       - v1
+      - v1-next
   pull_request:
     branches:
       - master
       - v1
+      - v1-next
   release:
     types:
       - released


### PR DESCRIPTION
So far v1-next doesn't run main CI on push/PR. This will fix it.