### PR TITLE
feat: warn that dbrole is deprecated when evaluating it

### DIFF
--- a/src/cls/IPM/ResourceProcessor/CSPApplication.cls
+++ b/src/cls/IPM/ResourceProcessor/CSPApplication.cls
@@ -69,8 +69,8 @@ Property PermittedClasses As %String(MAXLEN = 32767);
 Method %OnNew(pResourceReference As %IPM.Storage.ResourceReference) As %Status [ Private, ServerOnly = 1 ]
 {
 	Set packageName = pResourceReference.Module.Name
-	If ($Get(packageName) '= "") && '$Data($$$DeprecationWarned(packageName)) {
-		Set $$$DeprecationWarned(packageName) = 1
+	If ($Get(packageName) '= "") && '$Data($$$DeprecationWarned(packageName, "CSPApplication")) {
+		Set $$$DeprecationWarned(packageName, "CSPApplication") = 1
 		Write !, $$$FormattedLine($$$Red, "WARNING: The <CSPApplication></CSPApplication> resource tag is deprecated and may be removed in a future release of IPM.")
 		Write !, $$$FormattedLine($$$Red, $$$FormatText("         Please contact the package developer of %1 to use <WebApplication></WebApplication> instead", packageName))
 	}

--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -1,4 +1,4 @@
-Include (%occInclude, %occErrors, %syConfig, %syPrompt, %IPM.Common)
+Include (%occInclude, %occErrors, %syConfig, %syPrompt, %IPM.Common, %IPM.Formatting)
 
 Class %IPM.Utils.Module [ System = 3 ]
 {
@@ -2288,6 +2288,10 @@ ClassMethod %EvaluateSystemExpression(pString As %String) As %String [ Internal 
 	Do ##class(%Studio.General).GetWebServerPort(,,,.urlRoot)
 	Set result = ..%RegExReplace(result, "webroot", urlRoot)
 
+	If '$Get($$$DeprecationWarned("<expression>", "dbrole")) && ((result [ "${dbrole}") || (result [ "{$dbrole}")) {
+		Set $$$DeprecationWarned("<expression>", "dbrole") = 1
+		Write !, $$$FormattedLine($$$Red, "WARNING: The {$dbrole}/${dbrole} expression is deprecated. Please contact package developer to use {$globalsDbRole} instead.")
+	}
 	Set dbRole = ..GetDatabaseRole()
 	Set result = ..%RegExReplace(result, "dbrole", dbRole)
 	Set result = ..%RegExReplace(result, "globalsDbRole", dbRole)


### PR DESCRIPTION
Show a deprecation warning when ${dbrole} or {$dbrole} is used. The dbrole expression will be removed in v1-next.