### PR TITLE
fix(docker): OS file permission isn't always preserved in container

### DIFF
--- a/scripts/setup-registry.sh
+++ b/scripts/setup-registry.sh
@@ -1,3 +1,4 @@
-#!/bin/env iriscli
-
+/bin/env iriscli << EOF
 zpm "install zpm-registry"
+halt
+EOF


### PR DESCRIPTION
It seems OS file permission isn't always preserved in docker, which causes setup-registry.sh to be non-executable when copied to container (at least on my Mac). 

This change is necessary to make registry container work on my machine. It should be compatible on other platforms. Also, `.sh` extension is canonically used for shell scripts.