### PR TITLE
feat(package): allow passing -export-deps to override lifecycle behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #469 Added ability to include an `IPMVersion` in `SystemRequirement` of module.xml
 - #530 Added a `CustomPhase` attribute to `<Invoke>` that doesn't require a corresponding %method in lifecycle class.
 - #582 Added functionality to optionally see time of last update and server version of each package
+- #609 Added support for `-export-deps` when running the "Package" phase of lifecycle
 
 ### Changed
 - IPM is now namespace-specific rather than being installed in %SYS and being available instance-wide.

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -864,7 +864,7 @@ Method %Export(ByRef pParams, ByRef pTargetDirectory As %String, Output pDepende
 	Set tSC = $$$OK
 	Try {
 		Set tVerbose = $Get(pParams("Verbose"))
-    Merge tParams = pParams
+		Merge tParams = pParams
 
 		Kill pDependencyGraph
 		If ($Get(pTargetDirectory) = "") {
@@ -881,15 +881,16 @@ Method %Export(ByRef pParams, ByRef pTargetDirectory As %String, Output pDepende
 				Quit
 			}
 		}
-    Set tParams("ModuleExportPath") = pTargetDirectory
+		Set tParams("ModuleExportPath") = pTargetDirectory
 		
-		Set tSC = ..Module.GetResolvedReferences(.tResourceArray,..#EXPORTDEPENDENCIES,..PhaseList,1,.pDependencyGraph)
+		Set tExportDependencies = $Get(pParams("ExportDependencies"), ..#EXPORTDEPENDENCIES)
+		Set tSC = ..Module.GetResolvedReferences(.tResourceArray, tExportDependencies,..PhaseList,1,.pDependencyGraph)
 		If $$$ISERR(tSC) {
 			Quit
 		}
 		
 		// First pass: if we're exporting dependencies, build an array of modules from which we are deriving things.
-		If ..#EXPORTDEPENDENCIES {
+		If tExportDependencies {
 			Set tFullResourceName = ""
 			For {
 				Set tFullResourceName = $Order(tResourceArray(tFullResourceName))

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -70,7 +70,7 @@ Currently, there may only be one of these per namespace.
 <modifier name="dev" dataAlias="DeveloperMode" dataValue="1" description="Sets the DeveloperMode flag for the module's lifecycle. Key consequences of this are that ^Sources will be configured for resources in the module, and installer methods will be called with the dev mode flag set." />
 <modifier name="quiet" aliases="q" dataAlias="Verbose" dataValue="0" description="Produces minimal output from the command." />
 <modifier name="verbose" aliases="v" dataAlias="Verbose" dataValue="1" description="Produces verbose output from the command." />
-<modifier name="export-deps" dataAlias="ExportDependencies" dataValue="1" description="If specified, will export dependencies of the module to the filesystem. If omitted, defaults to the value of the #EXPORTDEPENDENCIES in lifecycle class. Can be manually set to 0 with -DExportDependencies=0. This modifier is only used in &quot;Package&quot; lifecycle." />
+<modifier name="export-deps" value="true" dataAlias="ExportDependencies" description="If specified, controls whether dependencies are exported. If omitted, defaults to the value of the #EXPORTDEPENDENCIES in lifecycle class. This modifier is only used in &quot;Package&quot; lifecycle." />
 
 </command>
 

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -70,6 +70,7 @@ Currently, there may only be one of these per namespace.
 <modifier name="dev" dataAlias="DeveloperMode" dataValue="1" description="Sets the DeveloperMode flag for the module's lifecycle. Key consequences of this are that ^Sources will be configured for resources in the module, and installer methods will be called with the dev mode flag set." />
 <modifier name="quiet" aliases="q" dataAlias="Verbose" dataValue="0" description="Produces minimal output from the command." />
 <modifier name="verbose" aliases="v" dataAlias="Verbose" dataValue="1" description="Produces verbose output from the command." />
+<modifier name="export-deps" dataAlias="ExportDependencies" dataValue="1" description="If specified, will export dependencies of the module to the filesystem. If omitted, defaults to the value of the #EXPORTDEPENDENCIES in lifecycle class. Can be manually set to 0 with -DExportDependencies=0. This modifier is only used in &quot;Package&quot; lifecycle." />
 
 </command>
 


### PR DESCRIPTION
Fix #608 
Allow users to pass in a `-export-deps` flag to override lifecycle behavior and export dependencies of a module.