### PR TITLE
feat(ci): add a check for changelog updates on PR to v1/v1-next

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,25 @@
+name: Changelog Check
+
+on:
+  pull_request:
+    branches:
+      - v1
+      - v1-next
+
+jobs:
+  check_changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Check for updated CHANGELOG.md
+      run: |
+        git fetch origin ${{ github.event.pull_request.base.ref }}
+        if git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD | grep -q 'CHANGELOG.md'; then
+          echo "CHANGELOG.md has been updated."
+        else
+          echo "CHANGELOG.md has not been updated."
+          exit 1
+        fi


### PR DESCRIPTION
Ensure CHANGELOG.md is updated every time a PR is created targeting `v1`/`v1-next`. 

Currently, `master` branch doesn't have a CHAGNELOG. So it's not included.