### PR TITLE
feat(ci): allow parameterization of package test timeout

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -12,6 +12,11 @@ on:
         required: true
         type: number
         default: 1
+      timeoutSeconds:
+        description: "Timeout in seconds for each test"
+        required: true
+        type: number
+        default: 120
 
 jobs:
   matrix-setup:
@@ -114,7 +119,7 @@ jobs:
           
             echo "::group::Test package $package"
             set +e
-            timeout 60s docker exec -i $CONTAINER iris session IRIS <<- EOF
+            timeout ${{ inputs.timeoutSeconds }}s docker exec -i $CONTAINER iris session IRIS <<- EOF
               zpm "install $package":1
               zpm "$package test -only ${{ env.test-flags }}":1:1
               halt


### PR DESCRIPTION
Allow developers to parameterize the timeout for each package test. Should be mergeable once [this CI run](https://github.com/intersystems/ipm/actions/runs/12163252835/job/33922496093) passes.