### PR TITLE
Allow parametrizing timeout for package test

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -12,6 +12,11 @@ on:
         required: true
         type: number
         default: 1
+      timeoutSeconds:
+        description: "Timeout in seconds for each test"
+        required: true
+        type: number
+        default: 120
 
 jobs:
   matrix-setup:
@@ -113,10 +118,10 @@ jobs:
           
             echo "::group::Test package $package"
             set +e
-            timeout 60s docker exec -i $CONTAINER iris session IRIS <<- EOF
-                zpm "install $package":1
-                zpm "$package test -only ${{ env.test-flags }}":1:1
-                halt
+            timeout ${{ inputs.timeoutSeconds }}s docker exec -i $CONTAINER iris session IRIS <<- EOF
+              zpm "install $package":1
+              zpm "$package test -only ${{ env.test-flags }}":1:1
+              halt
           EOF
 
             if [ $? -ne 0 ]; then


### PR DESCRIPTION
V1 version of #643 . Should be safe to merge once [this CI run](https://github.com/intersystems/ipm/actions/runs/12163597037) passes