### PR TITLE
feat: auto update legacy abstract resource processor before compiling

### DIFF
--- a/src/cls/IPM/Utils/LegacyCompat.cls
+++ b/src/cls/IPM/Utils/LegacyCompat.cls
@@ -16,13 +16,19 @@ ClassMethod UpdateSuperclassAndCompile(ByRef pItems, ByRef qSpec = "") As %Statu
             Continue
         }
         Set tClass = $EXTRACT(tName, 1, *-4)
-        // Assuming this is the only one we care about. Eventually it may become a list.
-        Set tOldLifecycle = "%ZPM.PackageManager.Developer.Lifecycle.Module"
-        Set tNewLifecycle = "%IPM.Lifecycle.Module"
-        If $$$defClassKeyGet(tClass, $$$cCLASSsuper) = tOldLifecycle {
-            $$$defClassKeySet(tClass, $$$cCLASSsuper, tNewLifecycle)
-            Write !, $$$FormattedLine($$$Magenta, "WARNING: ")
-            Write tName _ " extends the deprecated class " _ tOldLifecycle _ ". It has been updated to " _ tNewLifecycle _ " before compiled.", !
+
+        Set tPairs = $ListBuild(
+            $LISTBUILD("%ZPM.PackageManager.Developer.Lifecycle.Module", "%IPM.Lifecycle.Module"),
+            $LISTBUILD("%ZPM.PackageManager.Developer.Processor.Abstract", "%IPM.ResourceProcessor.Abstract")
+        )
+        Set ptr = 0
+        While $ListNext(tPairs, ptr, pair) {
+            Set $ListBuild(tOldLifecycle, tNewLifecycle) = pair
+            If $$$defClassKeyGet(tClass, $$$cCLASSsuper) = tOldLifecycle {
+                $$$defClassKeySet(tClass, $$$cCLASSsuper, tNewLifecycle)
+                Write !, $$$FormattedLine($$$Magenta, "WARNING: ")
+                Write tName _ " extends the deprecated class " _ tOldLifecycle _ ". It has been updated to " _ tNewLifecycle _ " before compiled.", !
+            }
         }
     }
     Quit $System.OBJ.CompileList(.pItems, .qSpec)

--- a/src/cls/IPM/Utils/LegacyCompat.cls
+++ b/src/cls/IPM/Utils/LegacyCompat.cls
@@ -27,7 +27,7 @@ ClassMethod UpdateSuperclassAndCompile(ByRef pItems, ByRef qSpec = "") As %Statu
             If $$$defClassKeyGet(tClass, $$$cCLASSsuper) = tOldLifecycle {
                 $$$defClassKeySet(tClass, $$$cCLASSsuper, tNewLifecycle)
                 Write !, $$$FormattedLine($$$Magenta, "WARNING: ")
-                Write tName _ " extends the deprecated class " _ tOldLifecycle _ ". It has been updated to " _ tNewLifecycle _ " before compiled.", !
+                Write tName _ " extends the deprecated class " _ tOldLifecycle _ ". It has been updated to " _ tNewLifecycle _ " before compilation.", !
             }
         }
     }


### PR DESCRIPTION
In addition to renaming `%ZPM.PackageManager.Developer.Lifecycle.Module` to `%IPM.Lifecycle.Module`, also update `%ZPM.PackageManager.Developer.Processor.Abstract` to `%IPM.ResourceProcessor.Abstract` when installing packages. 

This change is needed for isc-ipm-js to work.