### PR TITLE
clear all existing credentials

### DIFF
--- a/src/%ZPM/PackageManager/Client/RemoteServerDefinition.cls
+++ b/src/%ZPM/PackageManager/Client/RemoteServerDefinition.cls
@@ -138,6 +138,13 @@ ClassMethod OnConfigure(pInstance As %ZPM.PackageManager.Client.ServerDefinition
 				$$$ThrowStatus($$$ERROR($$$GeneralError, "Operation cancelled."))
 			}
 		}
+        
+        if ( $$$lcase(tUrl) '= $$$lcase(pInstance.URL) ) {
+            // when repo URL changing - clear all existing credentials
+            Set pInstance.Username = ""
+            Set pInstance.Password = ""
+            Set pInstance.Token = ""
+        }
 		
 		If $Data(pModifiers("username"), tUsername) {
 			Set pInstance.Username = tUsername


### PR DESCRIPTION
fix https://github.com/intersystems/ipm/issues/649

when registry URL changing - clear all existing credentials