### PR TITLE
Fix: add makedeployed lifecycle method (HSIEO-11006)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -30,7 +30,8 @@ jobs:
             for tag in $tags
             do
               # Skip irishealth-community due to bad interaction with ZPM document type
-              if test "$n" = "irishealth-community" && test "$tag" = "2023.3"
+              # Also skip 2023.2 because the license has expired
+              if [ "$n" = "irishealth-community" -a "$tag" = "2023.3" -o "$tag" = "2023.2" ];
                 then
                   continue
               fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - master
       - v1
+      - v1-next
   pull_request:
     branches:
       - master
       - v1
+      - v1-next
   release:
     types:
       - released

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,7 +171,7 @@ jobs:
         run: |
           curl http://localhost:52773/registry/packages/-/all | jq
           curl http://localhost:52773/registry/packages/zpm/ | jq
-          ASSET_NAME='zpm-0.7.1-beta.4.xml'
+          ASSET_NAME='zpm-0.7.2.xml'
           ASSET_URL=`wget --header "Authorization: token ${GITHUB_TOKEN}" -qO- https://api.github.com/repos/intersystems/ipm/releases | jq -r ".[].assets[] | select(.name == \"${ASSET_NAME}\") | .browser_download_url"`
           wget $ASSET_URL -O /tmp/zpm.xml
           CONTAINER=$(docker run --network zpm --rm -d ${{ steps.image.outputs.name }} ${{ steps.image.outputs.flags }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #364 Added ability to restrict the installation to IRIS or IRIS for Health platform to the SystemRequirements attribute
 - #518 Added ability to show source file location when running `list-installed`. E.g., `zpm "list-installed -showsource"`.
+- #469 Added ability to include an `IPMVersion` in `SystemRequirement` of module.xml
 
 ### Changed
 - IPM is now namespace-specific rather than being installed in %SYS and being available instance-wide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #454: IPM 0.9.x+ uses different globals for storage vs. 0.7.0 and previous. Installation will automatically migrate data from the old globals to the new ones. The old globals are left around in case the user decides to revert to an earlier version.
 
 ### Fixed
+- HSIEO-11006: Fix conditions for marking code as deployed
 - HSIEO-9269, HSIEO-9402: % percent perforce directories are no longer necessary
 - HSIEO-9269, HSIEO-9404: Repo check should happen in the order to repo creation, not by repo name
 - HSIEO-9269, HSIEO-9411: Make sure can load and export xml Package-type resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #364 Added ability to restrict the installation to IRIS or IRIS for Health platform to the SystemRequirements attribute
 - #518 Added ability to show source file location when running `list-installed`. E.g., `zpm "list-installed -showsource"`.
-- #469 Added a `CustomPhase` attribute to `<Invoke>` that doesn't require a corresponding %method in lifecycle class.
+- #530 Added a `CustomPhase` attribute to `<Invoke>` that doesn't require a corresponding %method in lifecycle class.
 
 ### Changed
 - IPM is now namespace-specific rather than being installed in %SYS and being available instance-wide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #474 Added compatibility to load ".tar.gz" archives in addition to ".tgz"
 - #469 Added ability to include an `IPMVersion` in `SystemRequirement` of module.xml
 - #530 Added a `CustomPhase` attribute to `<Invoke>` that doesn't require a corresponding %method in lifecycle class.
+- #582 Added functionality to optionally see time of last update and server version of each package
 
 ### Changed
 - IPM is now namespace-specific rather than being installed in %SYS and being available instance-wide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #364 Added ability to restrict the installation to IRIS or IRIS for Health platform to the SystemRequirements attribute
 - #518 Added ability to show source file location when running `list-installed`. E.g., `zpm "list-installed -showsource"`.
+- #469 Added a `CustomPhase` attribute to `<Invoke>` that doesn't require a corresponding %method in lifecycle class.
 
 ### Changed
 - IPM is now namespace-specific rather than being installed in %SYS and being available instance-wide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #364 Added ability to restrict the installation to IRIS or IRIS for Health platform to the SystemRequirements attribute
 - #518 Added ability to show source file location when running `list-installed`. E.g., `zpm "list-installed -showsource"`.
+- #474 Added compatibility to load ".tar.gz" archives in addition to ".tgz"
 
 ### Changed
 - IPM is now namespace-specific rather than being installed in %SYS and being available instance-wide.
@@ -49,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #224: When updating zpm, existing configuration won't be reset
 - #482: Reenabled deployed code support without impact on embedded source control (reworks HSIEO-9277)
 - #487: When loading a package, relative paths staring with prefix "http" won't be mistaken for git repo
+- #474: When loading a .tgz/.tar.gz package, automatically locate the top-most module.xml in case there is nested directory structure (e.g., GitHub releases)
 
 ### Security
 -

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -55,8 +55,11 @@ Method OnAfterResourceProcessing(pPhase As %String, ByRef pParams) As %Status
 
 Method %DispatchMethod(pMethod As %String, ByRef pParams, Args...) [ ServerOnly = 1 ]
 {
-	if $listfind(..#PHASES,pMethod)=0 do $zu(96,3,$$$ERNOMETHOD,1,"","method "_pMethod_" of class "_$classname())
-	quit ..Module.ExecutePhases(..Module.Name,$lb(pMethod),1,.pParams)
+	// Match method name with CamelCased lifecycle method
+	set convertedMethod = ..MatchSinglePhase(pMethod)
+
+	if $listfind(..#PHASES,convertedMethod)=0 do $zu(96,3,$$$ERNOMETHOD,1,"","method "_convertedMethod_" of class "_$classname())
+	quit ..Module.ExecutePhases(..Module.Name,$lb(convertedMethod),1,.pParams)
 }
 
 /// Merges default parameters into pParams
@@ -131,22 +134,48 @@ ClassMethod GetCompletePhases(pPhases As %List) As %List
 /// This method defines what a complete phase means for a given phase
 ClassMethod GetCompletePhasesForOne(pOnePhase As %String) As %List
 {
+	set pOnePhase = $ZCONVERT(pOnePhase, "L")
+
 	Quit $Case(pOnePhase,
-		"Clean":		$ListBuild("Clean"),
-		"Reload":		$ListBuild("Reload","*"),
-		"Validate":		$ListBuild("Reload","*","Validate"),
-		"ExportData":	$ListBuild("ExportData"),
-		"Compile":		$ListBuild("Reload","*","Validate","Compile"),
-		"Activate":		$ListBuild("Reload","*","Validate","Compile","Activate"),
-		"Document":		$ListBuild("Document"),
-		"MakeDeployed":	$ListBuild("MakeDeployed"),
-		"Test":			$ListBuild("Reload","*","Validate","Compile","Activate","Test"),
-		"Package":		$ListBuild("Reload","*","Validate","Compile","Activate","Package"),
-		"Verify":		$ListBuild("Reload","*","Validate","Compile","Activate","Package","Verify"),
-		"Register":		$ListBuild("Reload","*","Validate","Compile","Activate","Package","Register"),
-		"Publish":		$ListBuild("Reload","*","Validate","Compile","Activate","Package","Register","Publish"),
-		"Configure":	$ListBuild("Configure"),
-		"Unconfigure":	$ListBuild("Unconfigure"),
+		"clean":		$ListBuild("Clean"),
+		"reload":		$ListBuild("Reload","*"),
+		"validate":		$ListBuild("Reload","*","Validate"),
+		"exportdata":	$ListBuild("ExportData"),
+		"compile":		$ListBuild("Reload","*","Validate","Compile"),
+		"activate":		$ListBuild("Reload","*","Validate","Compile","Activate"),
+		"document":		$ListBuild("Document"),
+		"makedeployed":	$ListBuild("MakeDeployed"),
+		"test":			$ListBuild("Reload","*","Validate","Compile","Activate","Test"),
+		"package":		$ListBuild("Reload","*","Validate","Compile","Activate","Package"),
+		"verify":		$ListBuild("Reload","*","Validate","Compile","Activate","Package","Verify"),
+		"register":		$ListBuild("Reload","*","Validate","Compile","Activate","Package","Register"),
+		"publish":		$ListBuild("Reload","*","Validate","Compile","Activate","Package","Register","Publish"),
+		"configure":	$ListBuild("Configure"),
+		"unconfigure":	$ListBuild("Unconfigure"),
+		:				""
+	)
+}
+
+/// Match single inputted phase to the correctly CamelCased lifecycle phase <br/>
+ClassMethod MatchSinglePhase(pOnePhase As %String) As %String
+{
+	set pOnePhase = $ZCONVERT(pOnePhase, "L")
+	Quit $Case(pOnePhase,
+		"clean":		"Clean",
+		"reload":		"Reload",
+		"validate":		"Validate",
+		"exportdata":	"ExportData",
+		"compile":		"Compile",
+		"activate":		"Activate",
+		"document":		"Document",
+		"makedeployed":	"MakeDeployed",
+		"test":			"Test",
+		"package":		"Package",
+		"verify":		"Verify",
+		"register":		"Register",
+		"publish":		"Publish",
+		"configure":	"Configure",
+		"unconfigure":	"Unconfigure",
 		:				""
 	)
 }
@@ -1400,13 +1429,18 @@ Method %MakeDeployed(ByRef pParams) As %Status
 	Try {
 		Set tDev = ..Module.DeveloperMode
 		Set tVerbose = $Get(pParams("Verbose"))
+
+		// If the recurse parameter is set, then this lifecycle method should recursively deploy all of the 
+		// module's dependencies marked for deployment
+		Set tLockedDependencies = $Get(pParams("Recurse"),0) // Indicates whether entire dependency graph should be traversed and deployed
+
 		If tDev && tVerbose {
 		  Write !,"Module is in developer mode; will only report what WOULD be deployed unless packaging, in which case items WILL be deployed."
 		}
 		
 		// Default implementation: see which resources are expicitly flagged with Deploy = true.
 		// Build an array of those, then mark them as deployed.
-		$$$ThrowOnError(..Module.GetResolvedReferences(.tResourceArray,1,..PhaseList,1,.pDependencyGraph))
+		$$$ThrowOnError(..Module.GetResolvedReferences(.tResourceArray,tLockedDependencies,..PhaseList,1,.pDependencyGraph))
 		
 		Set tResourceKey = ""
 		For {

--- a/src/cls/IPM/Lifecycle/Module.cls
+++ b/src/cls/IPM/Lifecycle/Module.cls
@@ -38,16 +38,6 @@ Method %Activate(ByRef pParams) As %Status
 		
 		Set tSC = ..Configure(.pParams)
 		$$$ThrowOnError(tSC)
-
-		If '$ListFind(..PhaseList,"Package") {
-			// Code cannot be deployed if it is to be reexported and packaged.
-      Set tDevMode = $Get(pParams("DeveloperMode"), ..Module.DeveloperMode)
-      Set isKitBuild = $Get(pParams("IsKitBuild"),0)
-      If ('tDevMode && isKitBuild) {
-			  Set tSC = ..MakeDeployed(.pParams)
-			  $$$ThrowOnError(tSC)
-      		}
-		}
 		
 		// Create Studio project for package if it is loaded in developer mode and no explicit statement to not create it
 		Set tNoStudioProject = $Get(pParams("NoStudioProject"), 0)

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -469,6 +469,7 @@ run C:\Temp\MyCommands.json, where contents of the file are as follows:
 <modifier name="description" aliases="d" dataAlias="Desc" dataValue="1" description="Additional information is displayed for each module." />
 <modifier name="showsource" aliases="ss" description="If specified, show dependency list with local source for installed modules." />
 <modifier name="showtime" aliases="st" description="If specified, show the time of last update for each module" />
+<modifier name="showupstream" aliases="su" value="true" description="If specified, show the lastest registry version for each module" />
 <modifier name="repository" aliases="repo" value="true" description="If specified, only show modules installed that belong to the provided repository." />
 
 </command>
@@ -2952,25 +2953,36 @@ ClassMethod DisplayModules(ByRef pList, pNumbered As %Boolean = 0, pWithNamespac
     $ListBuild("Repository", $$$Blue)
   )
 
+  Kill serverVersions
+  If $Data(pModifiers("showupstream"), repoName) && ##class(%IPM.Repo.Definition).ServerDefinitionKeyExists(repoName) {
+    Set query = "SELECT Name,Version FROM %IPM_Utils.Module_GetModuleList(?,?) "
+    Set rs = ##class(%SQL.Statement).%ExecDirect(, query, repoName, 0)
+    While rs.%Next() {
+		Set serverVersions(rs.%Get("Name")) = rs.%Get("Version")
+	}
+  }
+  For i=1:1:pList {
   Set width = $Get(pList("width")) + 1
   Set tIndent = pIndent
   Set tIndent = $Select(pIndent > 0: pIndent, 1: width)
-  For i=1:1:pList {
     Set info = pList(i)
     Set developerMode = 0
     Set root = ""
     Set $ListBuild(name, version, externalName, developerMode, root, lastUpdated) = info
     Write:i>1 !,?pIndent
     Write $$$FormattedLinePadRight($$$Green, name, width), $$$FormattedLine($$$Blue, version)
+    If $Data(pModifiers("showupstream")) && ($Data(serverVersions(name), version) # 2) {
+      Write " ", $$$FormattedLine($$$Blue, "(ServerSide: "_version_")")
+    }
     If $Get(developerMode) {
       Write " ", $$$FormattedLine($$$Red, "(DeveloperMode)")
     }
     If $Data(pModifiers("showsource")) {
       Write " ", $$$FormattedLine($$$Magenta, root)
     }
-	If $Data(pModifiers("showtime")) {
-	  Write " ", $$$FormattedLine($$$Yellow, lastUpdated)
-	}
+    If $Data(pModifiers("showtime")) {
+      Write " ", $$$FormattedLine($$$Yellow, lastUpdated)
+    }
 
     Set ptr = 0 
     While $ListNext(extraColumns, ptr, column) {

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -241,6 +241,7 @@ repositories configured with the 'repo' command.
 <example description="Loads the module described in C:\module\root\path\module.xml">
 load C:\module\root\path\
 load C:\module\root\path\module-0.0.1.tgz
+load C:\module\root\path\module-0.0.1.tar.gz
 </example>
 <example description="Loads the module described in C:\module\root\path\module.xml in developer mode and with verbose output.">
 load -dev -verbose C:\module\root\path\
@@ -1871,7 +1872,7 @@ ClassMethod Load(ByRef pCommandInfo) [ Internal ]
 	If ##class(%File).DirectoryExists(tDirectoryName) {
 		Set tParams("DeveloperMode") = $Get(tParams("DeveloperMode"), 1)
 		$$$ThrowOnError(##class(%IPM.Utils.Module).LoadNewModule(tDirectoryName,.tParams))
-	} ElseIf ##class(%File).Exists(tDirectoryName),$$$lcase($Piece(tDirectoryName, ".", *)) = "tgz" {
+	} ElseIf ##class(%File).Exists(tDirectoryName) && (($$$lcase($Piece(tDirectoryName,".", *))="tgz") || ($$$lcase($Piece(tDirectoryName,".", *-1, *))="tar.gz")) {
 		Set tTargetDirectory = $$$FileTempDirSys
 		Set tSC = ##class(%IPM.General.Archive).Extract(tDirectoryName, tTargetDirectory)
 		$$$ThrowOnError(##class(%IPM.Utils.Module).LoadNewModule(tTargetDirectory, .tParams))

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -7,7 +7,7 @@ Class %IPM.Main Extends %IPM.CLI
 
 Parameter DOMAIN = "ZPM";
 
-Parameter STANDARDPHASES = {$ListBuild("reload","compile","test","package","verify","publish")};
+Parameter STANDARDPHASES = {$ListBuild("reload","compile","test","package","verify","publish","makedeployed")};
 
 /// Description of commands to use for this CLI
 XData Commands [ XMLNamespace = "http://www.intersystems.com/PackageManager/CLI" ]
@@ -45,6 +45,7 @@ resources exported to the filesystem (and possible to source control) are consis
 with what is in the database.
 * compile: compiles all resources within the module.
 * activate: performs post-compilation installation/configuration steps.
+* makedeployed: deploys resources within the module for which deployment is enabled.
 * document: regenerates the API documentation for the module
 * test: runs any unit tests associated with the module, in the current namespace.
 * package: exports the module's resources and bundles them into a module artifact (.tgz file).
@@ -152,6 +153,18 @@ This command is an alias for `module-action module-name publish`
 <parameter name="module" required="true" description="Name of module on which to perform publish actions" />
 <modifier name="only" aliases="o" description="Only runs the specified phase (publish), rather than also running predecessors." />
 <modifier name="dev" dataAlias="DeveloperMode" dataValue="1" description="Sets the DeveloperMode flag for the module's lifecycle. Key consequences of this are that ^Sources will be configured for resources in the module, and installer methods will be called with the dev mode flag set." />
+<modifier name="quiet" aliases="q" dataAlias="Verbose" dataValue="0" description="Produces minimal output from the command." />
+<modifier name="verbose" aliases="v" dataAlias="Verbose" dataValue="1" description="Produces verbose output from the command." />
+</command>
+
+<command name="makedeployed">
+<description>
+This command is an alias for `module-action module-name makedeployed`
+</description>
+<parameter name="module" required="true" description="Name of module on which to perform reload action" />
+<modifier name="dev" dataAlias="DeveloperMode" dataValue="1" description="Sets the DeveloperMode flag for the module's lifecycle. Key consequences of this are that ^Sources will be configured for resources in the module, and installer methods will be called with the dev mode flag set." />
+<modifier name="only" aliases="o" description="Only runs the specified phase (makedeployed), rather than also running predecessors." />
+<modifier name="recurse" aliases="r" description="Runs the specified phase (makedeployed) on the module and all of its dependencies." />
 <modifier name="quiet" aliases="q" dataAlias="Verbose" dataValue="0" description="Produces minimal output from the command." />
 <modifier name="verbose" aliases="v" dataAlias="Verbose" dataValue="1" description="Produces verbose output from the command." />
 </command>
@@ -2037,7 +2050,8 @@ ClassMethod RunOnePhase(ByRef pCommandInfo) [ Internal ]
 	Set tModName = $Get(pCommandInfo("parameters","module"))
 	Set tPhases = $ListBuild($ZConvert(pCommandInfo, "w"))
 	Set tIsComplete = '$$$HasModifier(pCommandInfo,"only")
-  Set tParams("cmd") = pCommandInfo
+  	Set tParams("Recurse") = $$$HasModifier(pCommandInfo,"recurse")
+	Set tParams("cmd") = pCommandInfo
 	Merge tParams = pCommandInfo("data")
 	$$$ThrowOnError(##class(%IPM.Storage.Module).ExecutePhases(tModName,tPhases,tIsComplete,.tParams))
 }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1890,9 +1890,14 @@ ClassMethod Load(ByRef pCommandInfo) [ Internal ]
 			Set tModuleFilePath = $ListGet(tList(tCount), *)
 			Set tTargetDirectory = ##class(%File).GetDirectory(tModuleFilePath, 1)
 			If $Get(pCommandInfo("data", "Verbose")) {
-				Write !,"Found "_tCount_" results. They are: ", !
-				Zwrite tList
-				Write "Using module.xml file at ", tModuleFilePath
+				Write !,"Found "_tCount_" results. They are: "
+				Set idx = ""
+				For {
+					Set idx = $Order(tList(idx))
+					Quit:(idx="")
+					Write !, $Char(9), $List(tList(idx), *)
+				}
+				Write !, "Using module.xml file at ", tModuleFilePath
 			}
 		}
 		$$$ThrowOnError(##class(%IPM.Utils.Module).LoadNewModule(tTargetDirectory, .tParams))

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1874,7 +1874,27 @@ ClassMethod Load(ByRef pCommandInfo) [ Internal ]
 		$$$ThrowOnError(##class(%IPM.Utils.Module).LoadNewModule(tDirectoryName,.tParams))
 	} ElseIf ##class(%File).Exists(tDirectoryName) && (($$$lcase($Piece(tDirectoryName,".", *))="tgz") || ($$$lcase($Piece(tDirectoryName,".", *-1, *))="tar.gz")) {
 		Set tTargetDirectory = $$$FileTempDirSys
-		Set tSC = ##class(%IPM.General.Archive).Extract(tDirectoryName, tTargetDirectory)
+		If $Get(pCommandInfo("data", "Verbose")) {
+			Write !,"Extracting archive to ",tTargetDirectory
+		}
+		$$$ThrowOnError(##class(%IPM.General.Archive).Extract(tDirectoryName, tTargetDirectory))
+		// Try to locate the top-level module.xml file
+		If $Get(pCommandInfo("data", "Verbose")) {
+			Write !,"Trying to locate module.xml file in ", tTargetDirectory
+		}
+		Set tCount = ##class(%IPM.Utils.File).FindFiles(tTargetDirectory, "module.xml", .tList)
+		If (tCount = 0) {
+			$$$ThrowStatus($$$ERROR($$$GeneralError,"No module.xml file found in archive."))
+		} Else {
+			// The top-level module.xml is the last one in tList, assuming ##class(%File).FileSetFunc returns directory first
+			Set tModuleFilePath = $ListGet(tList(tCount), *)
+			Set tTargetDirectory = ##class(%File).GetDirectory(tModuleFilePath, 1)
+			If $Get(pCommandInfo("data", "Verbose")) {
+				Write !,"Found "_tCount_" results. They are: ", !
+				Zwrite tList
+				Write "Using module.xml file at ", tModuleFilePath
+			}
+		}
 		$$$ThrowOnError(##class(%IPM.Utils.Module).LoadNewModule(tTargetDirectory, .tParams))
 	}
 }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -468,6 +468,7 @@ run C:\Temp\MyCommands.json, where contents of the file are as follows:
 <modifier name="tree" aliases="t" description="If specified, show dependency tree for installed modules." />
 <modifier name="description" aliases="d" dataAlias="Desc" dataValue="1" description="Additional information is displayed for each module." />
 <modifier name="showsource" aliases="ss" description="If specified, show dependency list with local source for installed modules." />
+<modifier name="showtime" aliases="st" description="If specified, show the time of last update for each module" />
 <modifier name="repository" aliases="repo" value="true" description="If specified, only show modules installed that belong to the provided repository." />
 
 </command>
@@ -949,7 +950,7 @@ ClassMethod GetListModules(pNamespace As %String = {$Namespace}, pSearch As %Str
     Quit
   }
   Set tArgs = 0
-	Set tQuery = "SELECT Name,VersionString,Description,ExternalName,DeveloperMode,Root FROM %IPM_Storage.ModuleItem WHERE 1=1 "
+	Set tQuery = "SELECT Name,VersionString,Description,ExternalName,DeveloperMode,Root,LastUpdated FROM %IPM_Storage.ModuleItem WHERE 1=1 "
   Set pSearch = $ZStrip(pSearch, "<>WC")
   If pSearch'="" {
     If pSearch["," {
@@ -982,7 +983,7 @@ ClassMethod GetListModules(pNamespace As %String = {$Namespace}, pSearch As %Str
 		$$$ThrowOnError(tSC)
     Set name = tRes.Name
     Set list = list + 1
-		Set list(list) = $ListBuild(name, tRes.VersionString, tRes.ExternalName, tRes.DeveloperMode, tRes.Root)
+		Set list(list) = $ListBuild(name, tRes.VersionString, tRes.ExternalName, tRes.DeveloperMode, tRes.Root, tRes.LastUpdated)
 		If maxWidth<$Length(name) {
       Set maxWidth = $Length(name)
     }
@@ -2179,7 +2180,7 @@ ClassMethod ListInstalled(ByRef pCommandInfo) [ Private ]
 	} Else {
     Set showFields = ""
     If +$Get(pCommandInfo("data","Desc")) {
-      Set showFields = $ListBuild(
+      Set showFields = showFields_$ListBuild(
         "Description",
         "Author.CopyrightDate", 
         "Author.License", 
@@ -2958,7 +2959,7 @@ ClassMethod DisplayModules(ByRef pList, pNumbered As %Boolean = 0, pWithNamespac
     Set info = pList(i)
     Set developerMode = 0
     Set root = ""
-    Set $ListBuild(name, version, externalName, developerMode, root) = info
+    Set $ListBuild(name, version, externalName, developerMode, root, lastUpdated) = info
     Write:i>1 !,?pIndent
     Write $$$FormattedLinePadRight($$$Green, name, width), $$$FormattedLine($$$Blue, version)
     If $Get(developerMode) {
@@ -2967,6 +2968,9 @@ ClassMethod DisplayModules(ByRef pList, pNumbered As %Boolean = 0, pWithNamespac
     If $Data(pModifiers("showsource")) {
       Write " ", $$$FormattedLine($$$Magenta, root)
     }
+	If $Data(pModifiers("showtime")) {
+	  Write " ", $$$FormattedLine($$$Yellow, lastUpdated)
+	}
 
     Set ptr = 0 
     While $ListNext(extraColumns, ptr, column) {

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -469,7 +469,7 @@ run C:\Temp\MyCommands.json, where contents of the file are as follows:
 <modifier name="description" aliases="d" dataAlias="Desc" dataValue="1" description="Additional information is displayed for each module." />
 <modifier name="showsource" aliases="ss" description="If specified, show dependency list with local source for installed modules." />
 <modifier name="showtime" aliases="st" description="If specified, show the time of last update for each module" />
-<modifier name="showupstream" aliases="su" value="true" description="If specified, show the lastest registry version for each module" />
+<modifier name="showupstream" aliases="su" description="If specified, show the latest version for each module in configured repos if it's different than the local version." />
 <modifier name="repository" aliases="repo" value="true" description="If specified, only show modules installed that belong to the provided repository." />
 
 </command>
@@ -2954,13 +2954,24 @@ ClassMethod DisplayModules(ByRef pList, pNumbered As %Boolean = 0, pWithNamespac
   )
 
   Kill serverVersions
-  If $Data(pModifiers("showupstream"), repoName) && ##class(%IPM.Repo.Definition).ServerDefinitionKeyExists(repoName) {
-    Set query = "SELECT Name,Version FROM %IPM_Utils.Module_GetModuleList(?,?) "
-    Set rs = ##class(%SQL.Statement).%ExecDirect(, query, repoName, 0)
-    While rs.%Next() {
-		Set serverVersions(rs.%Get("Name")) = rs.%Get("Version")
-	}
+  If $Data(pModifiers("showupstream")) {
+    Set query = "SELECT %DLIST(Name) AS Repos FROM %IPM_Repo.Definition"
+    Set rs = ##class(%SQL.Statement).%ExecDirect(, query)
+    $$$ThrowSQLIfError(rs.%SQLCODE, rs.%Message)
+    If rs.%Next() {
+      Set repos = rs.%Get("Repos")
+    }
+
+    Set ptr = 0
+    While $ListNext(repos, ptr, r) {
+      Set query = "SELECT Name,Version FROM %IPM_Utils.Module_GetModuleList(?,?) "
+      Set rs = ##class(%SQL.Statement).%ExecDirect(, query, r, 0)
+      While rs.%Next() {
+        Set serverVersions(rs.%Get("Name"), r) = rs.%Get("Version")
+      }
+    }
   }
+
   Set width = $Get(pList("width")) + 1
   Set tIndent = pIndent
   Set tIndent = $Select(pIndent > 0: pIndent, 1: width)
@@ -2971,8 +2982,21 @@ ClassMethod DisplayModules(ByRef pList, pNumbered As %Boolean = 0, pWithNamespac
     Set $ListBuild(name, version, externalName, developerMode, root, lastUpdated) = info
     Write:i>1 !,?pIndent
     Write $$$FormattedLinePadRight($$$Green, name, width), $$$FormattedLine($$$Blue, version)
-    If $Data(pModifiers("showupstream")) && ($Data(serverVersions(name), version) # 2) {
-      Write " ", $$$FormattedLine($$$Blue, "(ServerSide: "_version_")")
+    If $Data(pModifiers("showupstream")) && ($Data(serverVersions(name)) / 10) {
+      Set r = ""
+      Set diffs = ""
+      For {
+        Set r = $Order(serverVersions(name, r), 1, sVer)
+        If r = "" {
+          Quit
+        }
+        If sVer '= version {
+          Set diffs = diffs_$ListBuild($$$FormatText("%1: %2", r, sVer))
+        }
+      }
+      If diffs '= "" {
+        Write " ", $$$FormattedLine($$$Blue, "(" _ $ListToString(diffs, ", ") _ ")")
+      }
     }
     If $Get(developerMode) {
       Write " ", $$$FormattedLine($$$Red, "(DeveloperMode)")

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2955,21 +2955,7 @@ ClassMethod DisplayModules(ByRef pList, pNumbered As %Boolean = 0, pWithNamespac
 
   Kill serverVersions
   If $Data(pModifiers("showupstream")) {
-    Set query = "SELECT %DLIST(Name) AS Repos FROM %IPM_Repo.Definition"
-    Set rs = ##class(%SQL.Statement).%ExecDirect(, query)
-    $$$ThrowSQLIfError(rs.%SQLCODE, rs.%Message)
-    If rs.%Next() {
-      Set repos = rs.%Get("Repos")
-    }
-
-    Set ptr = 0
-    While $ListNext(repos, ptr, r) {
-      Set query = "SELECT Name,Version FROM %IPM_Utils.Module_GetModuleList(?,?) "
-      Set rs = ##class(%SQL.Statement).%ExecDirect(, query, r, 0)
-      While rs.%Next() {
-        Set serverVersions(rs.%Get("Name"), r) = rs.%Get("Version")
-      }
-    }
+    Do ..GetUpstreamPackageVersions(.serverVersions)
   }
 
   Set width = $Get(pList("width")) + 1
@@ -3018,6 +3004,25 @@ ClassMethod DisplayModules(ByRef pList, pNumbered As %Boolean = 0, pWithNamespac
         Write !,?tIndent
         Do ..DrawColumn($$$FormattedLine(color, colName _ ": ") _ value)
       }
+    }
+  }
+}
+
+ClassMethod GetUpstreamPackageVersions(Output list)
+{
+  Set query = "SELECT %DLIST(Name) AS Repos FROM %IPM_Repo.Definition"
+  Set rs = ##class(%SQL.Statement).%ExecDirect(, query)
+  $$$ThrowSQLIfError(rs.%SQLCODE, rs.%Message)
+  If rs.%Next() {
+    Set repos = rs.%Get("Repos")
+  }
+
+  Set ptr = 0
+  While $ListNext(repos, ptr, r) {
+    Set query = "SELECT Name,Version FROM %IPM_Utils.Module_GetModuleList(?,?) "
+    Set rs = ##class(%SQL.Statement).%ExecDirect(, query, r, 0)
+    While rs.%Next() {
+      Set list(rs.%Get("Name"), r) = rs.%Get("Version")
     }
   }
 }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2961,10 +2961,10 @@ ClassMethod DisplayModules(ByRef pList, pNumbered As %Boolean = 0, pWithNamespac
 		Set serverVersions(rs.%Get("Name")) = rs.%Get("Version")
 	}
   }
-  For i=1:1:pList {
   Set width = $Get(pList("width")) + 1
   Set tIndent = pIndent
   Set tIndent = $Select(pIndent > 0: pIndent, 1: width)
+  For i=1:1:pList {
     Set info = pList(i)
     Set developerMode = 0
     Set root = ""

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -951,7 +951,16 @@ ClassMethod GetListModules(pNamespace As %String = {$Namespace}, pSearch As %Str
     Quit
   }
   Set tArgs = 0
-	Set tQuery = "SELECT Name,VersionString,Description,ExternalName,DeveloperMode,Root,LastUpdated FROM %IPM_Storage.ModuleItem WHERE 1=1 "
+  // HACK: Certain IRIS kit, e.g., irishealth-community 2024.1 comes with %IPM in HSLIB and HSSYS namespaces
+  // The caveat is that the %IPM.Storage.Module doesn't have an "LastUpdated" property
+  // So, we need to check if the property exists before querying it
+  $$$ThrowOnError(##class(%SYSTEM.SQL.Schema).GetAllColumns("%IPM_Storage.ModuleItem", .columns))
+  Set checkUpdateTime = $Data(columns("LastUpdated"))
+  Set tQuery = "SELECT Name,VersionString,Description,ExternalName,DeveloperMode,Root"
+  If checkUpdateTime {
+	Set tQuery = tQuery _ ",LastUpdated"
+  }
+  Set tQuery = tQuery _ " FROM %IPM_Storage.ModuleItem WHERE 1=1 "
   Set pSearch = $ZStrip(pSearch, "<>WC")
   If pSearch'="" {
     If pSearch["," {
@@ -984,7 +993,10 @@ ClassMethod GetListModules(pNamespace As %String = {$Namespace}, pSearch As %Str
 		$$$ThrowOnError(tSC)
     Set name = tRes.Name
     Set list = list + 1
-		Set list(list) = $ListBuild(name, tRes.VersionString, tRes.ExternalName, tRes.DeveloperMode, tRes.Root, tRes.LastUpdated)
+		Set list(list) = $ListBuild(name, tRes.VersionString, tRes.ExternalName, tRes.DeveloperMode, tRes.Root)
+		If checkUpdateTime {
+			Set list(list) = list(list) _ $ListBuild(tRes.LastUpdated)
+		}
 		If maxWidth<$Length(name) {
       Set maxWidth = $Length(name)
     }
@@ -2990,7 +3002,7 @@ ClassMethod DisplayModules(ByRef pList, pNumbered As %Boolean = 0, pWithNamespac
     If $Data(pModifiers("showsource")) {
       Write " ", $$$FormattedLine($$$Magenta, root)
     }
-    If $Data(pModifiers("showtime")) {
+    If $Data(pModifiers("showtime")) && ($Data(lastUpdated) # 2) {
       Write " ", $$$FormattedLine($$$Yellow, lastUpdated)
     }
 

--- a/src/cls/IPM/Repo/Definition.cls
+++ b/src/cls/IPM/Repo/Definition.cls
@@ -15,6 +15,10 @@ Parameter MONIKER As STRING [ Abstract ];
 
 Parameter MONIKERALIAS As STRING [ Abstract ];
 
+/// The maximum number of tabs to display for padding purposes.
+/// Override this in subclasses to provide more padding.
+Parameter MaxDisplayTabCount As INTEGER = 3;
+
 Index ServerDefinitionKey On Name [ Unique ];
 
 Property Name As %String(MAXLEN = 100) [ Required ];
@@ -79,17 +83,31 @@ ClassMethod SortOrder(pID As %String) As %Integer [ SqlProc ]
 	Quit tServer.GetSortOrder()
 }
 
+/// Get a number of TABs (ascii 9) for display padding purposes.
+/// A total of (..#MaxDisplayTabCount - pDecrement) tabs are returned
+/// This is used to align output in the package manager shell.
+/// If a new option is added to the display, only the parameter `#MaxDisplayTabCount` needs to be changed.
+ClassMethod Padding(pDecrement As %Integer = 0) As %String [ Internal ]
+{
+	Set pDecrement = ..#MaxDisplayTabCount - pDecrement
+	Set tTabs = ""
+	For i = 1:1:pDecrement {
+		Set tTabs = tTabs_$Char(9)
+	}
+	Return tTabs
+}
+
 /// Outputs information about this server to the current device.
 /// Subclasses may override to show additional information, but should typically call ##super() at the beginning.
 Method Display()
 {
 	Write !,..Name
-	Write !,$c(9),"Source: ",$c(9),$c(9),..Details
-	Write !,$c(9),"Enabled?",$c(9),$c(9),$$$YesNo(..Enabled)
-	Write !,$c(9),"Available?",$c(9),$c(9),$$$YesNo(..GetPackageService().IsAvailable())
-	Write !,$c(9),"Use for Snapshots?",$c(9),$$$YesNo(..Snapshots)
-	Write !,$c(9),"Use for Prereleases?",$c(9),$$$YesNo(..Prereleases)
-	Write !,$c(9),"Is Read-Only?",$c(9),$c(9),$$$YesNo(..ReadOnly)
+	Write !,$c(9),"Source: ",..Padding(1),..Details
+	Write !,$c(9),"Enabled?",..Padding(1),$$$YesNo(..Enabled)
+	Write !,$c(9),"Available?",..Padding(1),$$$YesNo(..GetPackageService().IsAvailable())
+	Write !,$c(9),"Use for Snapshots?",..Padding(2),$$$YesNo(..Snapshots)
+	Write !,$c(9),"Use for Prereleases?",..Padding(2),$$$YesNo(..Prereleases)
+	Write !,$c(9),"Is Read-Only?",..Padding(1),$$$YesNo(..ReadOnly)
 }
 
 /// Called from package manager shell to create or update an instance of this class.

--- a/src/cls/IPM/Repo/Filesystem/Cache.cls
+++ b/src/cls/IPM/Repo/Filesystem/Cache.cls
@@ -37,7 +37,7 @@ ClassMethod %OnBeforeBuildIndices(ByRef indexlist As %String(MAXLEN="") = "") As
 	Quit $$$OK
 }
 
-Query OrderedMatches(pRoot As %String = "", pName As %String = "", pVersionExpression As %String = "*", pParameters As %String = "") As %Query(ROWSPEC = "Name:%String,VersionString:%String") [ SqlProc ]
+Query OrderedMatches(pRoot As %String = "", pName As %String = "", pVersionExpression As %String = "*", pParameters As %String = "") As %Query(ROWSPEC = "Name:%String,VersionString:%String,Version_Major:%String,Version_Minor:%String,Version_Patch:%String,Version_Prerelease:%String,Version_Build:%String") [ SqlProc ]
 {
 }
 
@@ -62,7 +62,7 @@ ClassMethod OrderedMatchesFetch(ByRef qHandle As %Binary, ByRef Row As %List, By
 		}
 		Set tRoot = ..RootGetStored($ListGet(tRow))
 		If (tRoot = qHandle("root")) {
-			Set Row = $ListBuild(..NameGetStored($ListGet(tRow)),..VersionStringGetStored($ListGet(tRow)))
+			Set Row = $ListBuild(..NameGetStored($ListGet(tRow)),..VersionStringGetStored($ListGet(tRow)))_..VersionGetStored($ListGet(tRow))
 			Quit
 		}
 	}

--- a/src/cls/IPM/Repo/Remote/Definition.cls
+++ b/src/cls/IPM/Repo/Remote/Definition.cls
@@ -7,6 +7,10 @@ Parameter MONIKER As STRING = "registry";
 
 Parameter MONIKERALIAS As STRING = "remote";
 
+/// The maximum number of tabs to display for padding purposes.
+/// Override this in subclasses to provide more padding.
+Parameter MaxDisplayTabCount As INTEGER = 4;
+
 Property Details As %String(MAXLEN = "") [ SqlComputeCode = {Set {*} = {URL}}, SqlComputed, SqlComputeOnChange = (%%INSERT, %%UPDATE) ];
 
 Index URL On URL [ Unique ];
@@ -109,16 +113,16 @@ Method Display()
 {
 	Do ##super()
 
-  Write !,$c(9),"Deployment Enabled? ",$c(9),$Case(..DeploymentEnabled,1:"Yes",:"No")
+	Write !,$c(9),"Default Deployment Registry? ",..Padding(3),$Case(..DeploymentEnabled,1:"Yes",:"No")
 
 	If (..Username '= "") {
-		Write !,$c(9),"Username: ",$c(9),$c(9),..Username
+		Write !,$c(9),"Username: ",..Padding(1),..Username
 	}
 	If (..Password '= "") {
-		Write !,$c(9),"Password: ",$c(9),$c(9),$Case(..Password,"":"<unset>",:"<set>")
+		Write !,$c(9),"Password: ",..Padding(1),$Case(..Password,"":"<unset>",:"<set>")
 	}
 	If (..Token '= "") {
-		Write !,$c(9),"Token: ",$c(9),$c(9),$c(9),$Case(..Token,"":"<unset>",:"<set>")
+		Write !,$c(9),"Token: ",..Padding(0),$Case(..Token,"":"<unset>",:"<set>")
 	}
 }
 

--- a/src/cls/IPM/Repo/Utils.cls
+++ b/src/cls/IPM/Repo/Utils.cls
@@ -105,7 +105,8 @@ ClassMethod moduleSqlToList(pQuery As %String, pSearchCriteria As %IPM.Repo.Sear
 		Set tOrderByParts = tOrderByParts_$ListBuild("case m.VersionString when ? then 0 else 1 end")
 		Set tArgs($i(tArgs)) = pSearchCriteria.VersionExpression
 	}
-	
+	Set tOrderByParts = tOrderByParts_$ListBuild("m.Name")
+	Set tOrderByParts = tOrderByParts_$ListBuild("m.Version_Major desc", "m.Version_Minor desc", "m.Version_Patch desc", "m.Version_Prerelease desc", "m.Version_Build desc")
 	If (tKeywordList '= "") {
 		// TODO: Find some way to order by max similarity (or just similarity of latest version of the module) instead?
 		Set tOrderByParts = tOrderByParts_$ListBuild("%SIMILARITY(Manifest,?) desc")
@@ -122,7 +123,7 @@ ClassMethod moduleSqlToList(pQuery As %String, pSearchCriteria As %IPM.Repo.Sear
 		}
 	}
 	
-	Set tList = ##class(%Library.ListOfObjects).%New()
+	Set tArray = ##class(%Library.ArrayOfObjects).%New()
 	Set tRes = ##class(%SQL.Statement).%ExecDirect(,pQuery,tArgs...)
 	If (tRes.%SQLCODE < 0) {
 		$$$ThrowStatus($$$ERROR($$$SQLCode,tRes.%SQLCODE,tRes.%Message))
@@ -131,14 +132,33 @@ ClassMethod moduleSqlToList(pQuery As %String, pSearchCriteria As %IPM.Repo.Sear
 		If $$$ISERR(tStatus) {
 			Quit
 		}
-		
-		Set tModRef = ##class(%IPM.Storage.ModuleInfo).%New()
-		Set tModRef.Name = tRes.%Get("Name")
-		Set tModRef.VersionString = tRes.%Get("VersionString")
-		Do tList.Insert(tModRef)
+		Set Name = tRes.%Get("Name")
+		Set VersionString = tRes.%Get("VersionString")
+
+		Set tModRef = tArray.GetAt(tRes.%Get("Name")) 
+		If tModRef = "" {
+			Set tModRef = ##class(%IPM.Storage.ModuleInfo).%New()
+			Set tModRef.Name = tRes.%Get("Name")
+			Set tModRef.VersionString = tRes.%Get("VersionString")
+			If pSearchCriteria.AllVersions {
+				Set tModRef.AllVersions = VersionString
+			}
+			Do tArray.SetAt(tModRef, Name)
+		} ElseIf pSearchCriteria.AllVersions {
+			Set tModRef.AllVersions = tModRef.AllVersions_", "_VersionString
+		}
 	}
 	If $$$ISERR(tStatus) {
 		$$$ThrowStatus(tStatus)
+	}
+	Set tList = ##class(%Library.ListOfObjects).%New()
+	Set key = ""
+	For {
+		Set mod = tArray.GetNext(.key)
+		If (key = "") {
+			Quit
+		}
+		Do tList.Insert(mod)
 	}
 	Quit tList
 }

--- a/src/cls/IPM/Storage/InvokeReference.cls
+++ b/src/cls/IPM/Storage/InvokeReference.cls
@@ -11,6 +11,9 @@ Property Method As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE") [ Required
 
 Property Phase As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE") [ InitialExpression = "Configure" ];
 
+/// If provided, overrides the Phase property will be ignored. This CustomPhase will be used and no cooresponding lifecycle is required.
+Property CustomPhase As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE");
+
 Property When As %String(MAXLEN = 255, VALUELIST = ",Before,After", XMLPROJECTION = "ATTRIBUTE") [ InitialExpression = "After", SqlFieldName = _WHEN ];
 
 Property CheckStatus As %Boolean(XMLPROJECTION = "ATTRIBUTE") [ InitialExpression = 0 ];
@@ -44,7 +47,8 @@ Method GetArgsArray(pParams, Output args) As %Status
 
 Method OnBeforePhase(pPhase As %String, ByRef pParams) As %Status
 {
-  If (pPhase '= ..Phase) || ("Before" '= ..When) {
+  Set tPhase = $Select(..CustomPhase'="":..CustomPhase,1:..Phase)
+  If (pPhase '= tPhase) || ("Before" '= ..When) {
 	  Quit $$$OK
   }
 
@@ -53,7 +57,8 @@ Method OnBeforePhase(pPhase As %String, ByRef pParams) As %Status
 
 Method OnAfterPhase(pPhase As %String, ByRef pParams) As %Status
 {
-  If (pPhase '= ..Phase) || ("After" '= ..When) {
+  Set tPhase = $Select(..CustomPhase'="":..CustomPhase,1:..Phase)
+  If (pPhase '= tPhase) || ("After" '= ..When) {
 	  Quit $$$OK
   }
 
@@ -101,6 +106,9 @@ Storage Default
 </Value>
 <Value name="7">
 <Value>When</Value>
+</Value>
+<Value name="8">
+<Value>CustomPhase</Value>
 </Value>
 </Data>
 <DataLocation>{%%PARENT}("Invokes")</DataLocation>

--- a/src/cls/IPM/Storage/InvokeReference.cls
+++ b/src/cls/IPM/Storage/InvokeReference.cls
@@ -11,7 +11,7 @@ Property Method As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE") [ Required
 
 Property Phase As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE") [ InitialExpression = "Configure" ];
 
-/// If provided, overrides the Phase property will be ignored. This CustomPhase will be used and no cooresponding lifecycle is required.
+/// If provided, the Phase property will be ignored. This CustomPhase will be used and no corresponding lifecycle is required.
 Property CustomPhase As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE");
 
 Property When As %String(MAXLEN = 255, VALUELIST = ",Before,After", XMLPROJECTION = "ATTRIBUTE") [ InitialExpression = "After", SqlFieldName = _WHEN ];

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -257,7 +257,7 @@ ClassMethod ExecutePhases(pModuleName As %String, pPhases As %List, pIsComplete 
 				Set tPhases = $ListBuild("PrepareDeploy") _ tPhases
 			}
 		} Else {
-			Set tPhases = pPhases
+			Set tPhases = $ListBuild(##class(%IPM.Lifecycle.Base).MatchSinglePhase($LISTTOSTRING(pPhases)))
 		}
 		
 		// Lifecycle-provided default parameters
@@ -330,7 +330,7 @@ ClassMethod ExecutePhases(pModuleName As %String, pPhases As %List, pIsComplete 
 						Quit
 					}
 					If $IsObject(tResource.Processor) {
-            Do tResource.Processor.SetParams(.pParams)
+            			Do tResource.Processor.SetParams(.pParams)
 						Set tSC = $Method(tResource.Processor,"OnBeforePhase",tOnePhase,.pParams)
 						$$$ThrowOnError(tSC)
 					}
@@ -503,6 +503,7 @@ Method GetDefaultParameters(Output pParams)
 	}
 }
 
+/// Returns whether pScope is in the list of pPhases <br />
 ClassMethod HasScope(pPhases As %List, pScope As %String) [ Private ]
 {
 	If (pScope = "") {
@@ -940,6 +941,13 @@ ClassMethod GetKnownDependencies(pModuleName As %String) As %List
 	Quit tKnownDependencyList
 }
 
+/// Builds a module's immediate dependency graph and array of resources.<br />
+/// Optionally loads uninstalled dependency modules and recurses over each module in the dependency graph.<br />
+/// @Argument	pReferenceArray		Array of all module's resources (including resources that compose a resource) that contain the appropriate phase scope.<br />
+/// @Argument	pLockedDependencies	Whether method should be recursively applied to the module's dependencies (true = yes).<br />
+/// @Argument	pPhases				List of IPM lifecycle phases to be applied to the current module.<br />
+/// @Argument	pSkipDependencies	Whether to skip loading uninstalled dependency modules.<br />
+/// @Argument	pDependencyGraph 	Tree of module's dependencies.<br />
 Method GetResolvedReferences(Output pReferenceArray, pLockedDependencies As %Boolean = 0, pPhases As %List = "", pSkipDependencies As %Boolean = 0, ByRef pDependencyGraph) As %Status
 {
 	Set tSC = $$$OK

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -164,6 +164,33 @@ Method CompareWithRelationships(pModuleObj As %IPM.Storage.Module, pIgnoreProper
 	Return isEqual
 }
 
+/// Returns a list of custom phases defined by the module's invokes.
+/// Custom phases do not have corresponding %method implementation in the lifecycle class.
+Method GetCustomPhases() As %List
+{
+    Set tree = ""
+    Set tKey = ""
+    For {
+        Set tInvoke = ..Invokes.GetNext(.tKey)
+        Quit:(tKey = "")
+        If (tInvoke.CustomPhase '= "") {
+            Set tree(tInvoke.CustomPhase) = ""
+        }
+    }
+
+    // Deduplicate
+    Set output = ""
+    Set phase = ""
+    For {
+        Set phase = $Order(tree(phase), 1)
+        If phase = "" {
+            Quit
+        }
+        Set output = output _ $lb(phase)
+    }
+    Quit output
+}
+
 /// Execute multiple lifecycle phases in sequence. Execution is terminated if one fails.
 /// Example: $ListBuild("Clean","Test") or $ListBuild("Test","Install")
 /// @API.Method
@@ -273,7 +300,9 @@ ClassMethod ExecutePhases(pModuleName As %String, pPhases As %List, pIsComplete 
 		Set tLifecycle.PhaseList = tPhases
 		Set tPointer = 0
 		Set tFullStart = $zh
+        Set tCustomPhases = tModule.GetCustomPhases()
 		While $ListNext(tPhases,tPointer,tOnePhase) {
+            Set tIsCustomPhase = $ListFind(tCustomPhases, tOnePhase)
 			Set tStart = $zh
 			If tOnePhase="*" {
 				Kill tModule,tLifecycle
@@ -324,12 +353,14 @@ ClassMethod ExecutePhases(pModuleName As %String, pPhases As %List, pIsComplete 
           Quit:$$$ISERR(tSC)
         }
         Quit:$$$ISERR(tSC)
-				
-				// Lifecycle before / (phase) / after
-				$$$ThrowOnError(tLifecycle.OnBeforePhase(tOnePhase,.pParams))
-				$$$ThrowOnError($Method(tLifecycle,"%"_tOnePhase,.pParams))
-				$$$ThrowOnError(tLifecycle.OnAfterPhase(tOnePhase,.pParams))
-				
+
+        If 'tIsCustomPhase {
+            // Lifecycle before / (phase) / after
+            $$$ThrowOnError(tLifecycle.OnBeforePhase(tOnePhase,.pParams))
+            $$$ThrowOnError($Method(tLifecycle,"%"_tOnePhase,.pParams))
+            $$$ThrowOnError(tLifecycle.OnAfterPhase(tOnePhase,.pParams))
+        }
+
         #; Call Invoke Methods After Phase	
         Set tKey = ""
         For {

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -29,6 +29,8 @@ Property Packaging As %String [ Required ];
 
 Property Dependencies As list Of %IPM.Storage.ModuleReference(STORAGEDEFAULT = "array");
 
+Property LastUpdated As %TimeStamp;
+
 Relationship Resources As %IPM.Storage.ResourceReference(XMLIO = "IN", XMLITEMNAME = "Resource", XMLPROJECTION = "WRAPPED", XMLREFERENCE = "COMPLETE") [ Cardinality = children, Inverse = Module ];
 
 /// Calculated property used for XML output of Resources relationship (in a reasonable order:
@@ -1458,6 +1460,19 @@ Method %Evaluate(pAttrValue As %String, ByRef pParams) As %String [ Internal ]
 	Return attrValue
 }
 
+/// This callback method is invoked by the <METHOD>%Save</METHOD> method to 
+/// provide notification that the object is being saved. It is called before 
+/// any data is written to disk.
+/// 
+/// <P><VAR>insert</VAR> will be set to 1 if this object is being saved for the first time.
+/// 
+/// <P>If this method returns an error then the call to <METHOD>%Save</METHOD> will fail.
+Method %OnBeforeSave(insert As %Boolean) As %Status [ Private, ServerOnly = 1 ]
+{
+	Set ..LastUpdated = $ZDateTime($Horolog, 3)
+	Quit $$$OK
+}
+
 Storage Default
 {
 <Data name="Defaults">
@@ -1551,6 +1566,9 @@ Storage Default
 </Value>
 <Value name="27">
 <Value>AvailabilityClass</Value>
+</Value>
+<Value name="28">
+<Value>LastUpdated</Value>
 </Value>
 </Data>
 <DataLocation>^IPM.Storage.ModuleD</DataLocation>

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -169,7 +169,7 @@ Method CompareWithRelationships(pModuleObj As %IPM.Storage.Module, pIgnoreProper
 /// Custom phases do not have corresponding %method implementation in the lifecycle class.
 Method GetCustomPhases(Output pPhases)
 {
-	Kill pPhases
+    Kill pPhases
     Set pPhases = ""
     Set key = ""
     For {

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -169,6 +169,7 @@ Method CompareWithRelationships(pModuleObj As %IPM.Storage.Module, pIgnoreProper
 /// Custom phases do not have corresponding %method implementation in the lifecycle class.
 Method GetCustomPhases(Output pPhases)
 {
+	Kill pPhases
     Set pPhases = ""
     Set key = ""
     For {

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -164,31 +164,20 @@ Method CompareWithRelationships(pModuleObj As %IPM.Storage.Module, pIgnoreProper
 	Return isEqual
 }
 
-/// Returns a list of custom phases defined by the module's invokes.
+/// Returns a multidimensional array of custom phases defined by the module's invokes,
+/// where the keys are the custom phase names and the values are empty strings.
 /// Custom phases do not have corresponding %method implementation in the lifecycle class.
-Method GetCustomPhases() As %List
+Method GetCustomPhases(Output pPhases)
 {
-    Set tree = ""
-    Set tKey = ""
+    Set pPhases = ""
+    Set key = ""
     For {
-        Set tInvoke = ..Invokes.GetNext(.tKey)
-        Quit:(tKey = "")
+        Set tInvoke = ..Invokes.GetNext(.key)
+        Quit:(key = "")
         If (tInvoke.CustomPhase '= "") {
-            Set tree(tInvoke.CustomPhase) = ""
+            Set pPhases(tInvoke.CustomPhase) = ""
         }
     }
-
-    // Deduplicate
-    Set output = ""
-    Set phase = ""
-    For {
-        Set phase = $Order(tree(phase), 1)
-        If phase = "" {
-            Quit
-        }
-        Set output = output _ $lb(phase)
-    }
-    Quit output
 }
 
 /// Execute multiple lifecycle phases in sequence. Execution is terminated if one fails.
@@ -300,9 +289,9 @@ ClassMethod ExecutePhases(pModuleName As %String, pPhases As %List, pIsComplete 
 		Set tLifecycle.PhaseList = tPhases
 		Set tPointer = 0
 		Set tFullStart = $zh
-        Set tCustomPhases = tModule.GetCustomPhases()
+		Do tModule.GetCustomPhases(.tCustomPhases)
 		While $ListNext(tPhases,tPointer,tOnePhase) {
-            Set tIsCustomPhase = $ListFind(tCustomPhases, tOnePhase)
+            Set tIsCustomPhase = $Data(tCustomPhases(tOnePhase)) # 2
 			Set tStart = $zh
 			If tOnePhase="*" {
 				Kill tModule,tLifecycle

--- a/src/cls/IPM/Storage/SystemRequirements.cls
+++ b/src/cls/IPM/Storage/SystemRequirements.cls
@@ -21,12 +21,15 @@ Property Interoperability As %String(VALUELIST = ",enabled,disabled", XMLPROJECT
 
 Property Health As %Boolean(XMLPROJECTION = "ATTRIBUTE");
 
+Property IPMVersion As %String(MAXLEN = 256, XMLPROJECTION = "ATTRIBUTE");
+
 Method CheckRequirements() As %Status
 {
 	Set tSC = $$$OK
 	Set tSC = $SYSTEM.Status.AppendStatus(tSC,..CheckVersion())
 	Set tSC = $SYSTEM.Status.AppendStatus(tSC,..CheckInteroperability())
 	Set tSC = $SYSTEM.Status.AppendStatus(tSC,..CheckHealth())
+	Set tSC = $SYSTEM.Status.AppendStatus(tSC,..CheckIPMVersion())
 	Return tSC
 }
 
@@ -69,6 +72,20 @@ Method CheckHealth() As %Status
 	Return $$$OK
 }
 
+Method CheckIPMVersion() As %Status
+{
+	If ..IPMVersion = "" {
+		Return $$$OK
+	}
+	Do ##class(%IPM.Main).GetVersion("zpm",.out)	
+	Set tVersion = ##class(%IPM.General.SemanticVersion).FromString($ListGet(out("zpm"), 2))
+	$$$ThrowOnError(##class(%IPM.General.SemanticVersionExpression).FromString(..IPMVersion,.tExpression))
+	If tVersion.Satisfies(tExpression) {
+		Return $$$OK
+	}
+	Return $$$ERROR($$$GeneralError, "The module requires IPM version "_..IPMVersion_". Current IPM version is "_tVersion.ToString())
+}
+
 ClassMethod IsHealthInstance() As %Boolean
 {
   set cls = "%ZHSLIB.HealthShareMgr", mthd = "IsHealthShareInstance"
@@ -100,6 +117,9 @@ Storage Default
 </Value>
 <Value name="6">
 <Value>Health</Value>
+</Value>
+<Value name="7">
+<Value>IPMVersion</Value>
 </Value>
 </Data>
 <DataLocation>^IPM.Storage.SystemRequirementsD</DataLocation>

--- a/src/cls/IPM/StudioDocument/Module.cls
+++ b/src/cls/IPM/StudioDocument/Module.cls
@@ -55,7 +55,7 @@ ClassMethod UpdatePersistentFromStream(pStream As %IPM.StudioDocument.ModuleStre
 				Quit
 			}
 
-			Set tSC = tReader.OpenStream(pStream.Contents)
+			Set tSC = tReader.OpenStream(tTransformedStream)
 			If $$$ISERR(tSC) {
 				Quit
 			}

--- a/src/cls/IPM/StudioDocument/Module.cls
+++ b/src/cls/IPM/StudioDocument/Module.cls
@@ -22,7 +22,7 @@ Method Load() As %Status
 			Quit
 		}
 		Set tName = $Piece(..Name,".",1,*-1)
-    Set tModule = ##class(%IPM.Storage.Module).NameOpen(tName,,.tSC)
+		Set tModule = ##class(%IPM.Storage.Module).NameOpen(tName,,.tSC)
 		If $$$ISOK(tSC) && ($IsObject(tModule)) {
 			Set tSC = $$$OK
 			
@@ -89,7 +89,7 @@ ClassMethod UpdatePersistentFromStream(pStream As %IPM.StudioDocument.ModuleStre
 			Do pModule.Resources.Clear()
 			Do pModule.Defaults.Clear()
 			Do pModule.Mappings.Clear()
-      Do pModule.Invokes.Clear()
+			Do pModule.Invokes.Clear()
 			
 			If (pModule.%Id() '= "") {
 				// Save to prevent unique index violations on re-insert of things that weren't actually removed.
@@ -422,7 +422,7 @@ XData InternalXSL
 <xsl:stylesheet version="1.0" xmlns:ext="http://exslt.org/common" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:output omit-xml-declaration="yes" method="xml" encoding="utf-8" indent="yes" />
   <xsl:strip-space elements="*" />
-	
+
   <xsl:variable name="vrtfPass1">
     <xsl:apply-templates />
   </xsl:variable>
@@ -453,12 +453,12 @@ XData InternalXSL
   </xsl:template>
   <xsl:template name="resource">
     <xsl:param name="name" />
-		<xsl:element name="Resource">
-			<xsl:copy-of select="@*"/>
-			<xsl:if test="not(name()='Resource')">
-				<xsl:attribute name="ProcessorClass">
-					<xsl:value-of select="name()" />
-				</xsl:attribute>
+    <xsl:element name="Resource">
+      <xsl:copy-of select="@*"/>
+      <xsl:if test="not(name()='Resource')">
+        <xsl:attribute name="ProcessorClass">
+          <xsl:value-of select="name()" />
+        </xsl:attribute>
       </xsl:if>
       <xsl:attribute name="Name">
         <xsl:value-of select="@*[name()=$name]" />
@@ -507,8 +507,8 @@ XData InternalXSL
     <xsl:call-template name="resource">
       <xsl:with-param name="name" select="'Name'" />
     </xsl:call-template>
-	</xsl:template>
-	<xsl:template match="Module" mode="pass2">
+  </xsl:template>
+  <xsl:template match="Module" mode="pass2">
     <xsl:copy>
       <xsl:apply-templates select="./@*" mode="pass2" />
       <xsl:apply-templates mode="pass2" />

--- a/src/cls/IPM/StudioDocument/Module.cls
+++ b/src/cls/IPM/StudioDocument/Module.cls
@@ -11,39 +11,6 @@ Parameter INFOGLOBAL = "^IPM.StuDoc.Module";
 
 Parameter STREAMCLASS = "%IPM.StudioDocument.ModuleStream";
 
-/// Load the module definition <property>Name</property> into the stream <property>Code</property>
-Method Load() As %Status
-{
-	$$$SuspendErrorCount
-	Set tSC = $$$OK
-	Try {
-		Set tSC = ..%ValidateName(..Name)
-		If $$$ISERR(tSC) {
-			Quit
-		}
-		Set tName = $Piece(..Name,".",1,*-1)
-		Set tModule = ##class(%IPM.Storage.Module).NameOpen(tName,,.tSC)
-		If $$$ISOK(tSC) && ($IsObject(tModule)) {
-			Set tSC = $$$OK
-			
-			Do ..Code.WriteLine("<?xml version=""1.0""?>")
-			Set tSC = tModule.XMLExportToStream(..Code,,"literal,indent")
-			If $$$ISERR(tSC) {
-				Quit
-			}
-		} Else {
-		  Set tModStream = ##class(%IPM.StudioDocument.ModuleStream).NameOpen(tName,,.tSC)
-			If $$$ISERR(tSC) {
-				Quit
-			}
-			Set tSC = ..Code.CopyFrom(tModStream.Contents)
-		}
-	} Catch e {
-		Set tSC = e.AsStatus()
-	}
-	Quit tSC
-}
-
 /// Save the module definition document.
 Method Save() As %Status
 {
@@ -372,6 +339,7 @@ Method ImportFromXML(stream As %RegisteredObject, flags As %String) As %Status
 		quit $$$OK
 	}
 	Do ..Code.Clear()
+	Do ..Code.Write("<?xml version=""1.0""?>")
 	Do ..Code.CopyFrom(stream)
 	Quit $$$OK
 }

--- a/src/cls/IPM/StudioDocument/Module.cls
+++ b/src/cls/IPM/StudioDocument/Module.cls
@@ -79,6 +79,15 @@ ClassMethod UpdatePersistentFromStream(pStream As %IPM.StudioDocument.ModuleStre
 		} Else {
 			Set tReader = ##class(%XML.Reader).%New()
 			Do pStream.Contents.Rewind()
+			// Preprocess the pStream contents to apply InternalXSL
+			Set tXSL = ##class(%Dictionary.CompiledXData).%OpenId(..%ClassName(1)_"||InternalXSL").Data
+			Set tTransformedStream = ##class(%Stream.GlobalCharacter).%New()
+			Set tTransformedStream.LineTerminator = $Char(10)
+			Set tSC = ##class(%XML.XSLT.Transformer).TransformStream(pStream.Contents, tXSL, .tTransformedStream)
+			If $$$ISERR(tSC) {
+				Quit
+			}
+
 			Set tSC = tReader.OpenStream(pStream.Contents)
 			If $$$ISERR(tSC) {
 				Quit
@@ -359,21 +368,11 @@ Method ExportToXML(flags As %String) As %Status
 /// Import from the stream in XML format
 Method ImportFromXML(stream As %RegisteredObject, flags As %String) As %Status
 {
-  if ('stream.Size) {
-    quit $$$OK
-  }
-	Set tXSL = ##class(%Dictionary.CompiledXData).%OpenId(..%ClassName(1)_"||InternalXSL").Data
-
-  Set tOutput = ##class(%Stream.GlobalCharacter).%New()
-  Set tOutput.LineTerminator = $Char(10)
-	Set tSC = ##class(%XML.XSLT.Transformer).TransformStream(stream, tXSL, .tOutput)
-	If $$$ISERR(tSC) Quit tSC
-  #; while 'tOutput.AtEnd { Write !,tOutput.ReadLine() }
-	
+	if ('stream.Size) {
+		quit $$$OK
+	}
 	Do ..Code.Clear()
-	#; Do ..Code.WriteLine("<?xml version=""1.0""?>") //add XML header
-	Do ..Code.CopyFrom(tOutput)
-
+	Do ..Code.CopyFrom(stream)
 	Quit $$$OK
 }
 

--- a/src/cls/IPM/StudioDocument/Module.cls
+++ b/src/cls/IPM/StudioDocument/Module.cls
@@ -102,7 +102,7 @@ ClassMethod UpdatePersistentFromStream(pStream As %IPM.StudioDocument.ModuleStre
 			
 			Set $$$ZPMStudioDocumentModule = pModule //Stash for use in %IPM.Storage.Module:XMLNew
 			Do tReader.Correlate("Module","%IPM.Storage.Module")
-			Do tReader.Next(.tModule,.tSC)
+			Do tReader.Next(.pModule,.tSC)
 			If $$$ISERR(tSC) {
 				Quit
 			}

--- a/tests/integration_tests/Test/PM/Integration/Base.cls
+++ b/tests/integration_tests/Test/PM/Integration/Base.cls
@@ -125,4 +125,20 @@ ClassMethod GetModuleDir(subfolders... As %String) As %String
   Quit tModuleDir
 }
 
+/// Returns whether a substring is found in any element of a multi-dimensional array
+ClassMethod FindStringInMultiDimArray(pString As %String, ByRef pArray) As %Boolean
+{
+	set sub = ""
+	For {
+		Set sub = $Order(pArray(sub), 1, element)
+		If sub = "" {
+			Quit
+		}
+		If element [ pString {
+			Return 1
+		}
+	}
+	Return 0
+}
+
 }

--- a/tests/integration_tests/Test/PM/Integration/CustomPhase.cls
+++ b/tests/integration_tests/Test/PM/Integration/CustomPhase.cls
@@ -1,0 +1,17 @@
+Class Test.PM.Integration.CustomPhase Extends Test.PM.Integration.Base
+{
+
+Parameter TargetModuleName As STRING = "custom-phase-without-lifecycle";
+
+Method TestCustomPhaseWithoutLifecycle()
+{
+    Set tModuleDir = ..GetModuleDir(..#TargetModuleName)
+    Set tSC = ##class(%IPM.Main).Shell("load -verbose " _ tModuleDir)
+    Do $$$AssertStatusOK(tSC,"Loaded module successfully")
+    Set tSC = ##class(%IPM.Main).Shell(..#TargetModuleName _ " greeting -only")
+    Do $$$AssertStatusOK(tSC,"Custom phase greeting executed successfully")
+    Set tSC = ##class(%IPM.Main).Shell("uninstall -verbose " _ ..#TargetModuleName)
+    Do $$$AssertStatusOK(tSC,"Deleted module succesfully")
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/CustomPhase.cls
+++ b/tests/integration_tests/Test/PM/Integration/CustomPhase.cls
@@ -6,11 +6,26 @@ Parameter TargetModuleName As STRING = "custom-phase-without-lifecycle";
 Method TestCustomPhaseWithoutLifecycle()
 {
     Set tModuleDir = ..GetModuleDir(..#TargetModuleName)
+
+    // Custom phase should not be executed during load
+    Do ##class(%IPM.Utils.Module).BeginCaptureOutput(.tCookie)
     Set tSC = ##class(%IPM.Main).Shell("load -verbose " _ tModuleDir)
+    Do ##class(%IPM.Utils.Module).EndCaptureOutput(tCookie,.pLoadOutput)
+    Do $$$AssertNotTrue(..FindStringInMultiDimArray("Hello", .pLoadOutput))
     Do $$$AssertStatusOK(tSC,"Loaded module successfully")
+
+    // Custom phase should be executed during module-actions
+    Do ##class(%IPM.Utils.Module).BeginCaptureOutput(.tCookie)
     Set tSC = ##class(%IPM.Main).Shell(..#TargetModuleName _ " greeting -only")
+    Do ##class(%IPM.Utils.Module).EndCaptureOutput(tCookie,.pModuleActionOutput)
+    Do $$$AssertTrue(..FindStringInMultiDimArray("Hello", .pModuleActionOutput))
     Do $$$AssertStatusOK(tSC,"Custom phase greeting executed successfully")
+
+    // Custom phase should not be executed during uninstall
+    Do ##class(%IPM.Utils.Module).BeginCaptureOutput(.tCookie)
     Set tSC = ##class(%IPM.Main).Shell("uninstall -verbose " _ ..#TargetModuleName)
+    Do ##class(%IPM.Utils.Module).EndCaptureOutput(tCookie,.pUninstallOutput)
+    Do $$$AssertNotTrue(..FindStringInMultiDimArray("Hello", .pUninstallOutput))
     Do $$$AssertStatusOK(tSC,"Deleted module succesfully")
 }
 

--- a/tests/integration_tests/Test/PM/Integration/IPMVersionReq.cls
+++ b/tests/integration_tests/Test/PM/Integration/IPMVersionReq.cls
@@ -1,0 +1,27 @@
+Class Test.PM.Integration.IPMVersionReq Extends Test.PM.Integration.Base
+{
+
+Parameter CommonPathPrefix As STRING = "ipm-version-req-test";
+
+Method TestInteroperabilityEnabled()
+{
+  Set tCases = $ListBuild( 
+    $ListBuild("version-req-missing", 1),
+    $ListBuild("version-req-satisified", 1),
+    $ListBuild("version-req-too-high", 0),
+    $ListBuild("version-req-too-low", 0)
+  )
+  Set ptr = 0
+  While $ListNext(tCases, ptr, case) {
+    set $ListBuild(subfolder, expected) = case
+    Set tModuleDir = ..GetModuleDir(..#CommonPathPrefix, subfolder)
+    Set tSC = ##class(%IPM.Main).Shell("load " _ tModuleDir)
+    If expected = 1 {
+      Do $$$AssertStatusOK(tSC,"Loaded module successfully (" _ subfolder _ ")")
+    } Else {
+      Do $$$AssertStatusNotOK(tSC, "Load modules failed as expected (" _ subfolder _ ")")
+    }
+  }
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/custom-phase-without-lifecycle/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/custom-phase-without-lifecycle/module.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="custom-phase-without-lifecycle.ZPM">
+    <Module>
+      <Name>custom-phase-without-lifecycle</Name>
+      <Version>0.0.1-snapshot</Version>
+      <Packaging>module</Packaging>
+      <SourcesRoot>src</SourcesRoot>
+      <Resource Name="CustomPhaseWithoutLifecycle.Manager.CLS"/>
+      <!-- CustomPhase invoke should work without a corresponding lifecycle method -->
+      <Invoke Class="CustomPhaseWithoutLifecycle.Manager" Method="SayHello" CustomPhase="Greeting" When="Before"/>
+      <!-- CustomPhase invoke shouldn't be called during load/install -->
+      <Invoke Class="CustomPhaseWithoutLifecycle.Manager" Method="ReturnError" CustomPhase="Error" CheckStatus="true"/>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/custom-phase-without-lifecycle/src/CustomPhaseWithoutLifecycle/Manager.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/custom-phase-without-lifecycle/src/CustomPhaseWithoutLifecycle/Manager.cls
@@ -1,0 +1,15 @@
+Class CustomPhaseWithoutLifecycle.Manager
+{
+
+ClassMethod SayHello() As %Status
+{
+    Write !, "Hello from CustomPhaseWithoutLifecycle.Manager"
+    Quit $$$OK
+}
+
+ClassMethod ReturnError() As %Status
+{
+    Quit $$$ERROR($$$GeneralError, "Error from CustomPhaseWithoutLifecycle.Manager")
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/custom-phase-without-lifecycle/src/CustomPhaseWithoutLifecycle/Manager.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/custom-phase-without-lifecycle/src/CustomPhaseWithoutLifecycle/Manager.cls
@@ -1,10 +1,9 @@
 Class CustomPhaseWithoutLifecycle.Manager
 {
 
-ClassMethod SayHello() As %Status
+ClassMethod SayHello()
 {
     Write !, "Hello from CustomPhaseWithoutLifecycle.Manager"
-    Quit $$$OK
 }
 
 ClassMethod ReturnError() As %Status

--- a/tests/integration_tests/Test/PM/Integration/_data/ipm-version-req-test/version-req-missing/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/ipm-version-req-test/version-req-missing/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="version-req-missing.ZPM">
+    <Module>
+      <Name>version-req-missing</Name>
+      <Version>0.0.1+snapshot</Version>
+      <Packaging>module</Packaging>
+      <SystemRequirements/>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/ipm-version-req-test/version-req-satisfied/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/ipm-version-req-test/version-req-satisfied/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="version-req-satisfied.ZPM">
+    <Module>
+      <Name>version-req-satisfied</Name>
+      <Version>0.0.1+snapshot</Version>
+      <Packaging>module</Packaging>
+      <SystemRequirements IPMVersion=">=0.9.0-0"/>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/ipm-version-req-test/version-req-too-high/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/ipm-version-req-test/version-req-too-high/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="version-req-too-high.ZPM">
+    <Module>
+      <Name>version-req-too-high</Name>
+      <Version>0.0.1+snapshot</Version>
+      <Packaging>module</Packaging>
+      <SystemRequirements IPMVersion=">=9999.9999.9999"/>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/ipm-version-req-test/version-req-too-low/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/ipm-version-req-test/version-req-too-low/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="version-req-too-low.ZPM">
+    <Module>
+      <Name>version-req-too-low</Name>
+      <Version>0.0.1+snapshot</Version>
+      <Packaging>module</Packaging>
+      <SystemRequirements IPMVersion="&lt;0.0.1"/>
+    </Module>
+  </Document>
+</Export>


### PR DESCRIPTION
Overview of changes:

1. Removing the call to the MakeDeployed lifecycle method from the Activate lifecycle method (in IPM.Lifecycle.Module.cls). In HS methods that build our kits and images, we now independently call MakeDeployed via the IPM shell command.
2. Adding a "makedeployed" shell command and a "recurse" flag option that recursively deploys all those resources in the module and its dependencies that are marked as deployed.
3. Updating some methods that match an inputted phase to the correct lifecycle method to account for CamelCased lifecycle phases (e.g. ExportData, MakeDeployed).

Tested makedeployed -only, activate -only, and package commands before and after updates.