### PR TITLE
fix: preserve user-side changes to lang. ext. outside of comment tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased - 0.10.0+snapshot]
+### Fixed
+- #678 Only update comment-flagged part of the language extension, allowing users to keep their custom code when upgrading
+
 ## [0.9.1] - 2024-12-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - 0.10.0+snapshot]
+## [Unreleased - 0.9.2+snapshot]
 ### Fixed
 - #678 Only update comment-flagged part of the language extension, allowing users to keep their custom code when upgrading
 

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2723,7 +2723,10 @@ ClassMethod UpdateLanguageExtensionsOne(RoutineName As %String, pTestOnly As %Bo
         For i=1:1:tGenLines {
           Set tRtnLines($Increment(tRtnLines)) = tGenLines(i)
         }
-      }
+      } Else { 
+        // outside of the tags, just copy the lines to preserve users' custom code
+        Set tRtnLines($Increment(tRtnLines)) = tLine
+	  }
     }
     If 'tEnded {
       Set tRtnLines($Increment(tRtnLines)) = $$$ENDTAGQ

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2711,7 +2711,6 @@ ClassMethod UpdateLanguageExtensionsOne(RoutineName As %String, pTestOnly As %Bo
 {
 	Set tRtn = ##class(%Routine).%New(RoutineName)
 	If ##class(%Routine).Exists(RoutineName) {
-    Set tEnded = 1
     While 'tRtn.AtEnd {
       Set tLine = tRtn.ReadLine()
       If $Match(tLine,$$$STARTTAGREGEX) {
@@ -2728,9 +2727,7 @@ ClassMethod UpdateLanguageExtensionsOne(RoutineName As %String, pTestOnly As %Bo
         Set tRtnLines($Increment(tRtnLines)) = tLine
 	  }
     }
-    If 'tEnded {
-      Set tRtnLines($Increment(tRtnLines)) = $$$ENDTAGQ
-    } ElseIf 'pFound {
+    If 'pFound {
       For i=1:1:tGenLines {
         Set tRtnLines($Increment(tRtnLines)) = tGenLines(i)
       }

--- a/tests/unit_tests/Test/PM/Unit/LanguageExtension/Abstract.cls
+++ b/tests/unit_tests/Test/PM/Unit/LanguageExtension/Abstract.cls
@@ -1,0 +1,168 @@
+Include %IPM.Common
+
+Class Test.PM.Unit.LanguageExtension.Abstract Extends %UnitTest.TestCase
+{
+
+/// Controls whether the test case will be run. Only the Abstract case should have this set to 1.
+Parameter IsAbstractTestCase As Boolean = 1;
+
+/// Name of the routine to be tested.
+Parameter TestRoutine = "DummyRoutineForIPMTest.MAC";
+
+/// Constant string to be used as custom code in the test cases.
+Parameter CustomCode = " // This is some custom code";
+
+/// Run by <B>RunTest</B> immediately before each test method in the test class is run.<br>
+/// <dl>
+/// <dt><i>testname</i>
+/// <dd>Name of the test to be run. Required. 
+/// </dl> 
+Method OnBeforeOneTest(testname As %String) As %Status
+{
+    If ##class(%Routine).Exists(..#TestRoutine) {
+        Quit ##class(%Routine).Delete(..#TestRoutine)
+    }
+    Quit $$$OK
+}
+
+/// Run by <B>RunTest</B> immediately after each test method in the test class is run.<br>
+/// <dl>
+/// <dt><i>testname</i>
+/// <dd>Name of the test to be run. Required. 
+/// </dl> 
+Method OnAfterOneTest(testname As %String) As %Status
+{
+    Quit ..OnBeforeOneTest(testname)
+}
+
+ClassMethod AppendLangExt1(ByRef content)
+{
+    Set content($Increment(content)) = "ZPMDUMMYLANGUAGEEXTENSION(pArgs...)"
+    Set content($Increment(content)) = " Set x = 1"
+}
+
+ClassMethod AppendLangExt2(ByRef content)
+{
+    Set content($Increment(content)) = "ZPMDUMMYLANGUAGEEXTENSION(pArgs...)"
+    Set content($Increment(content)) = " Set y = 2"
+}
+
+ClassMethod AppendLegacyStart(ByRef content)
+{
+    Set content($Increment(content)) = $Replace($$$STARTTAGQ, "%IPM.Main", "%ZPM.PackageManager")
+}
+
+ClassMethod AppendLegacyEnd(ByRef content)
+{
+    Set content($Increment(content)) = $Replace($$$ENDTAGQ, "%IPM.Main", "%ZPM.PackageManager")
+}
+
+ClassMethod AppendStart(ByRef content)
+{
+    Set content($Increment(content)) = $$$STARTTAGQ
+}
+
+ClassMethod AppendEnd(ByRef content)
+{
+    Set content($Increment(content)) = $$$ENDTAGQ
+}
+
+ClassMethod AppendContent(ByRef dest, ByRef src)
+{
+    For i = 1:1:$Get(src) {
+        Set dest($Increment(dest)) = src(i)
+    }
+}
+
+/// Open TestRoutine, clear it, and write to it. The input should be a multi-dimensional array.
+ClassMethod WriteToRoutine(ByRef input)
+{
+    // Creating and saving an empty routine causes the routine to contain a whitespace, which causes tests to fail.
+    If '$Data(input) {
+        Quit
+    }
+    Set routine = ##class(%Routine).%New(..#TestRoutine)
+    Do routine.Clear()
+    For i = 1:1:$Get(input) {
+        Do routine.WriteLine(input(i))
+    }
+    $$$ThrowOnError(routine.Save())
+}
+
+/// Get the content of TestRoutine as a multi-dimensional array
+ClassMethod ReadFromRoutine(Output output)
+{
+    Kill output
+
+    If '##class(%Routine).Exists(..#TestRoutine) {
+        Quit
+    }
+    Set routine = ##class(%Routine).%New(..#TestRoutine)
+    While ('routine.AtEnd) {
+        Set output($Increment(output)) = routine.ReadLine()
+    }
+}
+
+ClassMethod CompareContents(ByRef content1, ByRef content2) As %Boolean
+{
+    If $Data(content1) '= $Data(content2) {
+        Quit 0
+    }
+    For i = 1:1:$Get(content1) {
+        If content1(i) '= content2(i) {
+            Return 0
+        }
+    }
+    Return 1
+}
+
+ClassMethod ContentToString(ByRef content, LineSep As %String = "\n") As %String
+{
+    Set str = ""
+    For i = 1:1:$Get(content) {
+        Set str = str _ content(i) _ LineSep
+    }
+    Quit str
+}
+
+Method TestLanguageExtension()
+{
+    If ..#IsAbstractTestCase {
+        Do $$$AssertSkipped($classname() _ "is an abstract test case")
+        Quit
+    }
+    // Get initial content and write to it
+    Do ..GetInitial(.initialContent)
+    Do ..WriteToRoutine(.initialContent)
+
+    // Update language extension
+    Do ..AppendStart(.routineContent)
+    Do ..AppendLangExt2(.routineContent)
+    Do ..AppendEnd(.routineContent)
+    Do ##class(%IPM.Main).UpdateLanguageExtensionsOne(..#TestRoutine, 0, .found, .routineContent)
+
+    // Get expected content, and expected found
+    Do ..GetExpected(.expectedContent, .expectedFound)
+    
+    // Compare against routine content
+    Do ..ReadFromRoutine(.outputContent)
+    Do $$$AssertEquals((''found), (''expectedFound))
+    If '$$$AssertTrue(..CompareContents(.outputContent, .expectedContent)) {
+        Do $$$LogMessage("Output and expected content do not match !!!")
+        Do $$$LogMessage("Output    : " _ ..ContentToString(.outputContent))
+        Do $$$LogMessage("Expected  : " _ ..ContentToString(.expectedContent))
+    }
+}
+
+/// Construct the initial content of the routine. Could be empty.
+ClassMethod GetInitial(Output content)
+{
+}
+
+/// Construct the expected content of the routine after the language extension is updated.
+/// Also construct the expected "found" value indicating if an older language extension was found.
+ClassMethod GetExpected(Output content, Output found)
+{
+}
+
+}

--- a/tests/unit_tests/Test/PM/Unit/LanguageExtension/Abstract.cls
+++ b/tests/unit_tests/Test/PM/Unit/LanguageExtension/Abstract.cls
@@ -108,6 +108,9 @@ ClassMethod CompareContents(ByRef content1, ByRef content2) As %Boolean
     If $Data(content1) '= $Data(content2) {
         Quit 0
     }
+    If $Get(content1) '= $Get(content2) {
+        Quit 0
+    }
     For i = 1:1:$Get(content1) {
         If content1(i) '= content2(i) {
             Return 0

--- a/tests/unit_tests/Test/PM/Unit/LanguageExtension/FreshInstall.cls
+++ b/tests/unit_tests/Test/PM/Unit/LanguageExtension/FreshInstall.cls
@@ -1,0 +1,23 @@
+/// Simulate a fresh install of the language extension, assuming the routine is nonexistent at the time of install.
+Class Test.PM.Unit.LanguageExtension.FreshInstall Extends Test.PM.Unit.LanguageExtension.Abstract
+{
+
+Parameter IsAbstractTestCase As Boolean = 0;
+
+/// Construct the expected content of the routine after the language extension is updated.
+/// Also construct the expected "found" value indicating if an older language extension was found.
+ClassMethod GetExpected(Output content, Output found)
+{
+    Set found = 0
+
+    Do ..AppendStart(.content)
+    Do ..AppendLangExt2(.content)
+    Do ..AppendEnd(.content)
+}
+
+/// Construct the initial content of the routine. Could be empty.
+ClassMethod GetInitial(Output content)
+{
+}
+
+}

--- a/tests/unit_tests/Test/PM/Unit/LanguageExtension/FreshInstallWithCustomCode.cls
+++ b/tests/unit_tests/Test/PM/Unit/LanguageExtension/FreshInstallWithCustomCode.cls
@@ -1,0 +1,25 @@
+/// Simulate a fresh install of the language extension, assuming the routine contains only custom code at the time of install.
+Class Test.PM.Unit.LanguageExtension.FreshInstallWithCustomCode Extends Test.PM.Unit.LanguageExtension.Abstract
+{
+
+Parameter IsAbstractTestCase As Boolean = 0;
+
+/// Construct the expected content of the routine after the language extension is updated.
+/// Also construct the expected "found" value indicating if an older language extension was found.
+ClassMethod GetExpected(Output content, Output found)
+{
+    Set found = 0
+
+    Set content($Increment(content)) = ..#CustomCode
+    Do ..AppendStart(.content)
+    Do ..AppendLangExt2(.content)
+    Do ..AppendEnd(.content)
+}
+
+/// Construct the initial content of the routine. Could be empty.
+ClassMethod GetInitial(Output content)
+{
+    Set content($Increment(content)) = ..#CustomCode
+}
+
+}

--- a/tests/unit_tests/Test/PM/Unit/LanguageExtension/IllFormedTags.cls
+++ b/tests/unit_tests/Test/PM/Unit/LanguageExtension/IllFormedTags.cls
@@ -1,0 +1,28 @@
+/// Ill-formed test case with only start tag but no end tag.
+Class Test.PM.Unit.LanguageExtension.IllFormedTags Extends Test.PM.Unit.LanguageExtension.Abstract
+{
+
+Parameter IsAbstractTestCase As Boolean = 0;
+
+/// Construct the expected content of the routine after the language extension is updated.
+/// Also construct the expected "found" value indicating if an older language extension was found.
+ClassMethod GetExpected(Output content, Output found)
+{
+    Set found = 1
+
+    Set content($Increment(content)) = ..#CustomCode
+    Do ..AppendStart(.content)
+    Do ..AppendLangExt2(.content)
+    Do ..AppendEnd(.content)
+}
+
+/// Construct the initial content of the routine. Could be empty.
+ClassMethod GetInitial(Output content)
+{
+    Set content($Increment(content)) = ..#CustomCode
+    Do ..AppendStart(.content)
+    Do ..AppendLangExt1(.content)
+    Set content($Increment(content)) = ..#CustomCode
+}
+
+}

--- a/tests/unit_tests/Test/PM/Unit/LanguageExtension/UpgradeFromLegacy.cls
+++ b/tests/unit_tests/Test/PM/Unit/LanguageExtension/UpgradeFromLegacy.cls
@@ -1,0 +1,26 @@
+/// Simulate upgrading from an older version of the language extension, assuming the routine contains only the older language extension.
+Class Test.PM.Unit.LanguageExtension.UpgradeFromLegacy Extends Test.PM.Unit.LanguageExtension.Abstract
+{
+
+Parameter IsAbstractTestCase As Boolean = 0;
+
+/// Construct the expected content of the routine after the language extension is updated.
+/// Also construct the expected "found" value indicating if an older language extension was found.
+ClassMethod GetExpected(Output content, Output found)
+{
+    Set found = 1
+
+    Do ..AppendStart(.content)
+    Do ..AppendLangExt2(.content)
+    Do ..AppendEnd(.content)
+}
+
+/// Construct the initial content of the routine. Could be empty.
+ClassMethod GetInitial(Output content)
+{
+    Do ..AppendStart(.content)
+    Do ..AppendLangExt1(.content)
+    Do ..AppendEnd(.content)
+}
+
+}

--- a/tests/unit_tests/Test/PM/Unit/LanguageExtension/UpgradeFromLegacyWithCustomCode.cls
+++ b/tests/unit_tests/Test/PM/Unit/LanguageExtension/UpgradeFromLegacyWithCustomCode.cls
@@ -1,0 +1,30 @@
+/// Simulate upgrading from an older version of the language extension, assuming the routine contains both the older language extension and some custom code.
+Class Test.PM.Unit.LanguageExtension.UpgradeFromLegacyWithCustomCode Extends Test.PM.Unit.LanguageExtension.Abstract
+{
+
+Parameter IsAbstractTestCase As Boolean = 0;
+
+/// Construct the expected content of the routine after the language extension is updated.
+/// Also construct the expected "found" value indicating if an older language extension was found.
+ClassMethod GetExpected(Output content, Output found)
+{
+    Set found = 1
+
+    Set content($Increment(content)) = ..#CustomCode
+    Do ..AppendStart(.content)
+    Do ..AppendLangExt2(.content)
+    Do ..AppendEnd(.content)
+    Set content($Increment(content)) = ..#CustomCode
+}
+
+/// Construct the initial content of the routine. Could be empty.
+ClassMethod GetInitial(Output content)
+{
+    Set content($Increment(content)) = ..#CustomCode
+    Do ..AppendStart(.content)
+    Do ..AppendLangExt1(.content)
+    Do ..AppendEnd(.content)
+    Set content($Increment(content)) = ..#CustomCode
+}
+
+}


### PR DESCRIPTION
Fix #674 
Make sure we don't overwrite user custom code in language extensions. 