### PR TITLE
fix: always export static files if existent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased - 0.9.2+snapshot]
+### Fixed
+- #680 Always export static files (README.md, LICENSE, requirements.txt) if existent
+
 ## [0.9.1] - 2024-12-18
 
 ### Added

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -1184,9 +1184,9 @@ Method %Export(ByRef pParams, ByRef pTargetDirectory As %String, Output pDepende
 		}
     /// Always keep these files
      Set staticFiles = $ListBuild(
-    //   "readme.md",
-    //   "license",
-    //   "requirements.txt",
+       "readme.md",
+       "license",
+       "requirements.txt",
     )
     Set tRes = ##class(%File).FileSetFunc(..Module.Root)
     While tRes.%Next() {

--- a/tests/integration_tests/Test/PM/Integration/StaticFileExport.cls
+++ b/tests/integration_tests/Test/PM/Integration/StaticFileExport.cls
@@ -1,0 +1,29 @@
+Include %IPM.Common
+
+Class Test.PM.Integration.StaticFileExport Extends Test.PM.Integration.Base
+{
+
+Method TestWSGIApp()
+{
+  Set tSC = $$$OK
+  Try {
+    Set tTestRoot = ##class(%File).NormalizeDirectory($Get(^UnitTestRoot))
+    set tModuleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(tTestRoot)_"/_data/static-file-export-test/")
+    Set tSC = ##class(%IPM.Main).Shell("load -verbose " _ tModuleDir)
+    Do $$$AssertStatusOK(tSC,"Module successfully. " _ tModuleDir)
+    Set exportDir = ##class(%File).NormalizeDirectory($$$FileTempDirSys)
+    Set tSC = ##class(%IPM.Main).Shell("static-file-export-test package -DPath="_exportDir)
+    Do $$$AssertStatusOK(tSC,"Exported to directory " _ exportDir _ " successfully.")
+    Do $$$AssertTrue(##class(%File).DirectoryExists(exportDir))
+    For file = "LICENSE","README.md","requirements.txt" {
+      Set tFile = ##class(%File).NormalizeFilename(file, exportDir)
+      If '$$$AssertTrue(##class(%File).Exists(tFile)) {
+        Do $$$LogMessage("File "_tFile_" does not exist.")
+      }
+    }
+  } Catch e {
+    Do $$$AssertStatusOK(e.AsStatus(), "An exception occurred.")
+  }
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/static-file-export-test/LICENSE
+++ b/tests/integration_tests/Test/PM/Integration/_data/static-file-export-test/LICENSE
@@ -1,0 +1,1 @@
+This is a license

--- a/tests/integration_tests/Test/PM/Integration/_data/static-file-export-test/README.md
+++ b/tests/integration_tests/Test/PM/Integration/_data/static-file-export-test/README.md
@@ -1,0 +1,1 @@
+This is a readme

--- a/tests/integration_tests/Test/PM/Integration/_data/static-file-export-test/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/static-file-export-test/module.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="static-file-export-test.ZPM">
+    <Module>
+      <Name>static-file-export-test</Name>
+      <Version>1.0.0</Version>
+      <Description>Test whether static files (readme.md, licence, requirements.txt) are properly exported</Description>
+      <Packaging>module</Packaging>
+      <AfterInstallMessage>Module installed successfully!</AfterInstallMessage>     
+    </Module>    
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/static-file-export-test/requirements.txt
+++ b/tests/integration_tests/Test/PM/Integration/_data/static-file-export-test/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
Fix #679 
Make sure to export README.md, LICENSE, and requirements.txt if found. 