### PR TITLE
fix: convert namespaces to uppercase for `enable` and `unmap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased - 0.9.2+snapshot]
+### Fixed
+- #681 Convert specified namespaces to upper case for `enable` and `unmap` commands.
+
 ## [0.9.1] - 2024-12-18
 
 ### Added

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2871,6 +2871,7 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
 	Set localOnly = $$$HasModifier(pCommandInfo, "local-only")
 	Set version = $$$GetModifier(pCommandInfo, "version")
 	Set namespaces = $$$GetModifier(pCommandInfo, "namespaces")
+	Set namespaces = $$$ucase(namespaces)
 	Set allowUpgrade = $$$HasModifier(pCommandInfo,"allow-upgrade")
 	Set mapRepos = $$$HasModifier(pCommandInfo,"repos")
 	Set useLocal = 1			// var to store the final decision of whether to use local manifest or get from server
@@ -3206,6 +3207,7 @@ ClassMethod UnmapIPM(ByRef pCommandInfo)
 {
 	Set globally = $$$HasModifier(pCommandInfo,"globally")
 	Set namespaces = $ListFromString($$$GetModifier(pCommandInfo,"namespaces"), ",")
+	Set namespaces = $$$ucase(namespaces)
 	Set verbose = '$$$HasModifier(pCommandInfo,"quiet")
 	set reposOnly = $$$HasModifier(pCommandInfo,"repos-only")
 	// Sanity check


### PR DESCRIPTION
Fix #677. Always convert specified list of namespaces to uppercase for `enable` and `unmap` commands.