### PR TITLE
fix: improve banner display in interactive zpm shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #682 When downloading IPM via the `enable` command from a remote registry, allow user to pass in the registry name (or get the only existent one), instead of the deployment enabled registry.
 
 ### Fixed
+- #684 Fixed banner display issues in interactive `zpm` shell.
 - #682 When enabling IPM in a namespace using local IPM caches, check for existence of `<iris-root>/lib/ipm/` beforing querying it.
 - #682 Use more standard wording of mapping when enabling IPM
 - #681 Convert specified namespaces to upper case for `enable` and `unmap` commands.

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -779,10 +779,15 @@ ClassMethod ShellInternal(pCommand As %String, Output pException As %Exception.A
 		Set tOneCommand = 1
 	}
 	do ##class(%IPM.Main).GetVersion("zpm",.out)	
+	If $Get(out) = "" {
+		Set registryInfo = $$$FormattedLine($$$Cyan, "No registry configured")
+	} Else {
+		Set registryInfo = "Current registry "_$$$FormattedLine($$$Cyan, out)
+	}
 	Set introMessageList = $ListBuild(
 		"Welcome to the Package Manager Shell (ZPM). Version: "_$$$FormattedLine($$$Green, ..GetVersionModule("zpm")),
 		"Enter q/quit to exit the shell. Enter ?/help to view available commands",
-		"Current registry "_$$$FormattedLine($$$Cyan,$g(out))
+		registryInfo
 	)
 	Set tInShell = 0
 	For {
@@ -1204,11 +1209,12 @@ ClassMethod GetVersionModule(name, namespace = {$namespace})
 {
 	New $Namespace
 	Set $Namespace=namespace
-	Do ..GetListModules(name,.list)
-	If $Data(list(name)) {
-			quit $ListGet(list(name),1)
+	Try {
+		Do ..GetListModules(,name,.list)
+		Return $ListGet(list(1), 2)
+	} Catch ex {
+		Return ""
 	}
-	quit ""
 }
 
 /// @API.Method


### PR DESCRIPTION
Fix #675 

The current result looks like this 

For instances with registry configured:
<img width="845" alt="image" src="https://github.com/user-attachments/assets/278a2fdb-8915-4ecb-90e3-127fc0618006" />

For instances without registry configured: 
<img width="826" alt="image" src="https://github.com/user-attachments/assets/d7347445-7b7c-4b27-9245-5d82a6579cf1" />
