### PR TITLE
fix: fix a bug where errors during publication isn't shown

### DIFF
--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -1407,7 +1407,7 @@ Method %Publish(ByRef pParams) As %Status
 		}
 
 
-		Do tPublishClient.PublishModule(tModule)
+		$$$ThrowOnError(tPublishClient.PublishModule(tModule))
 		
 
 		// May need to update the version of the currently-installed module.

--- a/src/cls/IPM/Repo/Oras/PublishService.cls
+++ b/src/cls/IPM/Repo/Oras/PublishService.cls
@@ -1,7 +1,7 @@
 Class %IPM.Repo.Oras.PublishService Extends (%IPM.Repo.Oras.PackageService, %IPM.Repo.IPublishService)
 {
 
-Method PublishModule(pModule As %IPM.Repo.Remote.ModuleInfo) As %Boolean
+Method PublishModule(pModule As %IPM.Repo.Remote.ModuleInfo) As %Status
 {
 	Set status = $$$OK
     Try {


### PR DESCRIPTION
Somehow we have been ignoring the status of `tPublishClient.PublishModule(tModule)` for a while ... 