### PR TITLE
Main CI Fix heredoc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
           CONTAINER=$(docker run --network zpm --rm -d ${{ steps.image.outputs.name }} ${{ steps.image.outputs.flags }})
           docker cp tests/migration/v0.7-to-v0.9/. $CONTAINER:/tmp/test-package/
           sleep 5; docker exec $CONTAINER /usr/irissys/dev/Cloud/ICM/waitISC.sh
-          docker exec -i $CONTAINER iris session iris -UUSER << EOF 
+          docker exec -i $CONTAINER iris session iris -UUSER << 'EOF'
             s version="0.7.4" s r=##class(%Net.HttpRequest).%New(),r.Server="pm.community.intersystems.com",r.SSLConfiguration="ISC.FeatureTracker.SSL.Config" d r.Get("/packages/zpm/"_version_"/installer"),$system.OBJ.LoadStream(r.HttpResponse.Data,"c")
             zpm "list":1
             zpm "install dsw":1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,3 +94,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 - #593 CSPApplication is deprecated in favor of WebApplication. User will be warned when installing a package containing CSPApplication.
+


### PR DESCRIPTION
Apparently, we have been expanding `$system` in `$system.OBJ.LoadStream` in the test CI for the past 2 weeks, causing the migration test to be effectively skipped