### PR TITLE
Main fix bump ci

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -39,4 +39,8 @@ jobs:
             done
           done;
           echo images="[${images%?}]" >> $GITHUB_OUTPUT
-          echo main=${images%%,*} >> $GITHUB_OUTPUT
+
+          # The syntax GitHub expects is `main=string`, rather than `main="string"`
+          main=$(echo ${images%%,*} | awk -F'"' '{print $2}')
+          echo "main=$main" >> $GITHUB_OUTPUT
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,8 +221,8 @@ jobs:
           docker stop $CONTAINER
           docker stop registry
           docker network rm zpm
-      - uses: actions/upload-artifact@v3
-        if: matrix.image == ${{ needs.prepare.outputs.main }}
+      - uses: actions/upload-artifact@v4
+        if: matrix.image == needs.prepare.outputs.main
         with:
           name: zpm-${{ needs.prepare.outputs.version }}
           path: zpm-${{ needs.prepare.outputs.version }}.xml
@@ -238,7 +238,7 @@ jobs:
         if: github.event_name == 'release'
         with:
           ref: main
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: zpm-${{ needs.prepare.outputs.version }}
       - name: Create Beta Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,3 +95,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - #593 CSPApplication is deprecated in favor of WebApplication. User will be warned when installing a package containing CSPApplication.
 
+


### PR DESCRIPTION
* Bump upload-artifact and download-artifact from v3 to v4
* Properly handle GitHub CI output format (use `var=string` instead of `var="string"`)
