### PR TITLE
Fail early when publishing package under illegal external name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #702 Added a `<CPF/>` resource, which can be used for CPF merge before/after a specified lifecycle phase or in a custom lifecycle phase.
 - #704 Added support for passing in env files via `-env /path/to/env1.json;/path/to/env2.json` syntax
 - #710 Added support for `module-version` command which updates the version of a module
-- #716 Added support to publish under external name by passing `-use-external-name` or `-use-ext`. 
+- #716,#733 Added support to publish under external name by passing `-use-external-name` or `-use-ext`. Fail early if external name is illegal / empty.
 
 ### Changed
 - #702 Preload now happens as part of the new `Initialize` lifecycle phase. `zpm "<module> reload -only"` will no longer auto compile resources in `/preload` directory.

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -1403,6 +1403,10 @@ Method %Publish(ByRef pParams) As %Status
 		}
 		Set tModule = ##class(%IPM.Repo.Remote.ModuleInfo).%New()
 		Set tModule.Name = $Select(tUseExternalName: ..Module.ExternalName, 1: ..Module.Name)
+		// Apparently, an empty name can pass the %IPM.DataType.ModuleName:IsValid check
+		If tModule.Name = "" {
+			$$$ThrowStatus($$$ERROR($$$GeneralError, "Cannot publish module with empty name."))
+		}
 		If '##class(%IPM.DataType.ModuleName).IsValid(tModule.Name) {
 			$$$ThrowStatus($$$ERROR($$$GeneralError,$$$FormatText("Module name '%1' is invalid for publishing",tModule.Name)))
 		}


### PR DESCRIPTION
Fix #730

Somehow the empty string is allowable as a package name. This PR will force failure early and give a meaningful error message.