### PR TITLE
chore: upload zpm.xml artifact as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -272,7 +272,7 @@ jobs:
           tag_name: v${{ needs.prepare.outputs.version }}
           release_name: v${{ needs.prepare.outputs.version }}
           prerelease: ${{ github.event_name != 'release' }}
-      - name: Upload Beta Release Asset
+      - name: Upload Beta Release Asset (versioned)
         uses: actions/upload-release-asset@v1
         if: github.event_name == 'push'
         env:
@@ -281,6 +281,16 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: zpm-${{ needs.prepare.outputs.version }}.xml
           asset_name: zpm-${{ needs.prepare.outputs.version }}.xml
+          asset_content_type: text/xml
+      - name: Upload Beta Release Asset (versionless)
+        uses: actions/upload-release-asset@v1
+        if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: zpm-${{ needs.prepare.outputs.version }}.xml
+          asset_name: zpm.xml
           asset_content_type: text/xml
       - name: Publish release
         if: github.event_name == 'release'
@@ -299,7 +309,7 @@ jobs:
             halt
           EOF
           docker stop $CONTAINER
-      - name: Upload Public Release Asset
+      - name: Upload Public Release Asset (versioned)
         uses: actions/upload-release-asset@v1
         if: github.event_name == 'release'
         env:
@@ -308,6 +318,16 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: zpm-${{ needs.prepare.outputs.version }}.xml
           asset_name: zpm-${{ needs.prepare.outputs.version }}.xml
+          asset_content_type: text/xml
+      - name: Upload Public Release Asset (versionless)
+        uses: actions/upload-release-asset@v1
+        if: github.event_name == 'release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: zpm-${{ needs.prepare.outputs.version }}.xml
+          asset_name: zpm.xml
           asset_content_type: text/xml
       - name: Bump Release number
         if: github.event_name == 'release'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #669: Work with a wider variety of ORAS repos (removes _catalog call)
 - #726: Fixed a bug where loading a tarball doesn't install dependencies from `.modules` subfolder even when it's available
 - #731: Issue upgrading from v0.9.x due to refactor of repo classes
+- #718: Upload zpm.xml (without the version) as an artifact to provide a more stable URL to latest release artifact on GitHub
 
 ### Security
 -


### PR DESCRIPTION
Fixes #718

The purpose of this is to provide a more stable URL to the latest artifact that doesn't have the version in it.

Internal ref: CRE-10211