### PR TITLE
Supporting `${EnvVar}` syntax in `env.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #541 Added support for ORAS repository
 - #702 Added a new lifecycle phase `Initialize` which is used for preload
 - #702 Added a `<CPF/>` resource, which can be used for CPF merge before/after a specified lifecycle phase or in a custom lifecycle phase.
-- #704 Added support for passing in env files via `-env /path/to/env1.json;/path/to/env2.json` syntax
+- #704,743 Added support for passing in env files via `-env /path/to/env1.json;/path/to/env2.json` syntax. Environment variables are also supported via ${var} syntax.
 - #710 Added support for `module-version` command which updates the version of a module
 - #716,#733 Added support to publish under external name by passing `-use-external-name` or `-use-ext`. Fail early if external name is illegal / empty.
 

--- a/src/cls/IPM/General/EnvironmentConfig.cls
+++ b/src/cls/IPM/General/EnvironmentConfig.cls
@@ -24,6 +24,7 @@ Method Load(path As %String)
             $$$ThrowStatus($$$ERROR($$$GeneralError, "Invalid configuration file. Expected a JSON object, not a JSON array"))
         }
         Do ..MergeDynamicObjects(..Config, newConfig)
+        Set ..Config = ..%Evaluate(..Config)
     } Catch ex {
         Do ..Clear()
         Throw ex
@@ -41,7 +42,7 @@ Method GetArg(package As %String, args... As %String) As %IPM.DataType.Any
         }
         Set obj = obj.%Get(args(i))
     }
-    Return ..%Evaluate(obj)
+    Return obj
 }
 
 /// The input could be a primitive type, a dynamic object, or a dynamic array

--- a/src/cls/IPM/General/EnvironmentConfig.cls
+++ b/src/cls/IPM/General/EnvironmentConfig.cls
@@ -41,7 +41,7 @@ Method GetArg(package As %String, args... As %String) As %IPM.DataType.Any
         }
         Set obj = obj.%Get(args(i))
     }
-    Return %Evaluate(obj)
+    Return ..%Evaluate(obj)
 }
 
 /// Recursively evaluate ${myVarName} to the value of the variable myVarName

--- a/src/cls/IPM/General/EnvironmentConfig.cls
+++ b/src/cls/IPM/General/EnvironmentConfig.cls
@@ -41,6 +41,38 @@ Method GetArg(package As %String, args... As %String) As %IPM.DataType.Any
         }
         Set obj = obj.%Get(args(i))
     }
+    Return %Evaluate(obj)
+}
+
+/// Recursively evaluate ${myVarName} to the value of the variable myVarName
+/// The input could be a primitive type, a dynamic object, or a dynamic array
+/// "CopyCreated" should only be used internally to avoid computation overhead. It should not be used by the any caller other than the recursive call in itself.
+ClassMethod %Evaluate(obj As %IPM.DataType.Any, CopyCreated As %Boolean = 0) As %IPM.DataType.Any [ Internal ]
+{
+    If '$IsObject(obj) {
+        // All numbers, bools, null, etc. will always fail this test. 
+        // Only strings of the form "${myVarName}" will pass
+        If ($Length(obj) > 3) && ($Extract(obj, 1, 2) = "${") && ($Extract(obj, *) = "}") {
+            Set varName = $Extract(obj, 3, *-1)
+            Set varName = $ZStrip(varName, "<>WC")
+            Return $System.Util.GetEnviron(varName)
+        }
+        Return obj
+    }
+
+    // If the object is already a copy, we don't need to create a new copy recursively
+    If 'CopyCreated {
+        Set obj = obj.%FromJSON(obj.%ToJSON())
+    }
+    Set iter = obj.%GetIterator()
+    While iter.%GetNext(.key, .value, .type) {
+        // type cannot be set for array / object
+        If (type = "object") || (type = "array") {
+            Set type = ""
+        }
+        // since we are already in a recursive call, we don't need to create a new copy
+        Do obj.%Set(key, ..%Evaluate(value, 1), type) 
+    }
     Return obj
 }
 

--- a/src/cls/IPM/General/EnvironmentConfig.cls
+++ b/src/cls/IPM/General/EnvironmentConfig.cls
@@ -44,10 +44,16 @@ Method GetArg(package As %String, args... As %String) As %IPM.DataType.Any
     Return ..%Evaluate(obj)
 }
 
-/// Recursively evaluate ${myVarName} to the value of the variable myVarName
 /// The input could be a primitive type, a dynamic object, or a dynamic array
-/// "CopyCreated" should only be used internally to avoid computation overhead. It should not be used by the any caller other than the recursive call in itself.
-ClassMethod %Evaluate(obj As %IPM.DataType.Any, CopyCreated As %Boolean = 0) As %IPM.DataType.Any [ Internal ]
+/// This function wll evaluate ${myVarName} to the value of the environment variable $myVarName
+/// If the environment variable is not set, it will be empty string
+ClassMethod %Evaluate(obj As %IPM.DataType.Any) As %IPM.DataType.Any
+{
+    Return ..%EvaluateHelper(obj, 0)
+}
+
+/// Acutal implementation of %Evaluate
+ClassMethod %EvaluateHelper(obj As %IPM.DataType.Any, copyCreated As %Boolean) As %IPM.DataType.Any [ Internal, Private ]
 {
     If '$IsObject(obj) {
         // All numbers, bools, null, etc. will always fail this test. 
@@ -61,7 +67,7 @@ ClassMethod %Evaluate(obj As %IPM.DataType.Any, CopyCreated As %Boolean = 0) As 
     }
 
     // If the object is already a copy, we don't need to create a new copy recursively
-    If 'CopyCreated {
+    If 'copyCreated {
         Set obj = obj.%FromJSON(obj.%ToJSON())
     }
     Set iter = obj.%GetIterator()
@@ -71,7 +77,7 @@ ClassMethod %Evaluate(obj As %IPM.DataType.Any, CopyCreated As %Boolean = 0) As 
             Set type = ""
         }
         // since we are already in a recursive call, we don't need to create a new copy
-        Do obj.%Set(key, ..%Evaluate(value, 1), type) 
+        Do obj.%Set(key, ..%EvaluateHelper(value, 1), type) 
     }
     Return obj
 }

--- a/src/cls/IPM/General/EnvironmentConfig.cls
+++ b/src/cls/IPM/General/EnvironmentConfig.cls
@@ -57,12 +57,14 @@ ClassMethod %Evaluate(obj As %IPM.DataType.Any) As %IPM.DataType.Any
 ClassMethod %EvaluateHelper(obj As %IPM.DataType.Any, copyCreated As %Boolean) As %IPM.DataType.Any [ Internal, Private ]
 {
     If '$IsObject(obj) {
-        // All numbers, bools, null, etc. will always fail this test. 
-        // Only strings of the form "${myVarName}" will pass
-        If ($Length(obj) > 3) && ($Extract(obj, 1, 2) = "${") && ($Extract(obj, *) = "}") {
-            Set varName = $Extract(obj, 3, *-1)
-            Set varName = $ZStrip(varName, "<>WC")
-            Return $System.Util.GetEnviron(varName)
+        Set regex= "\$\{([a-zA-Z0-9_]+)\}"
+        For {
+            Set matcher = ##class(%Regex.Matcher).%New(regex, obj)
+            If 'matcher.Locate() {
+                Quit
+            }
+            Set varName = $Extract(matcher.Group, 3, *-1)
+            Set obj = matcher.ReplaceFirst($System.Util.GetEnviron(varName))
         }
         Return obj
     }

--- a/tests/unit_tests/Test/PM/Unit/ParseEnvVarJSON.cls
+++ b/tests/unit_tests/Test/PM/Unit/ParseEnvVarJSON.cls
@@ -1,0 +1,87 @@
+Class Test.PM.Unit.ParseEnvVarJSON Extends %UnitTest.TestCase
+{
+
+Parameter ENVNAME = "mySecretEnvVarName";
+
+Parameter ENVVALUE = "This is a secret value";
+
+XData SampleJSON [ MimeType = application/json ]
+{
+{
+    "package": {
+        "nested": {
+            "key": "${mySecretEnvVarName}"
+        },
+        "other": [ 1, 2, 3 ]
+    }
+}
+}
+
+/// Run by <B>RunTest</B> immediately before each test method in the test class is run.<br>
+/// <dl>
+/// <dt><i>testname</i>
+/// <dd>Name of the test to be run. Required. 
+/// </dl> 
+Method OnBeforeOneTest(testname As %String) As %Status
+{
+    Try {
+        Do ..SetEnvironmentVariable()
+    } Catch ex {
+        Return ex.AsStatus()
+    }
+    Quit $$$OK
+}
+
+/// Run by <B>RunTest</B> immediately after each test method in the test class is run.<br>
+/// <dl>
+/// <dt><i>testname</i>
+/// <dd>Name of the test to be run. Required. 
+/// </dl> 
+Method OnAfterOneTest(testname As %String) As %Status
+{
+    Try {
+        Do ..UnsetEnvironmentVariable()
+    } Catch ex {
+        Return ex.AsStatus()
+    }
+    Quit $$$OK
+}
+
+ClassMethod SetEnvironmentVariable()
+{
+    // For lack of a better way, we'll set the environment variables using Embedded Python. 
+    // Will update once we have a pure COS way to do this.
+    Set os = ##class(%SYS.Python).Import("os")
+    // Note: the putenv only affects environment variables for the current process without any mapping to the actual environment variables.
+    Do os.putenv(..#ENVNAME, ..#ENVVALUE)
+}
+
+ClassMethod UnsetEnvironmentVariable()
+{
+    Set os = ##class(%SYS.Python).Import("os")
+    Do os.environ.pop(..#ENVNAME, "")
+}
+
+Method TestarseEnvVarJSON()
+{
+    Do ..SetEnvironmentVariable()
+
+    Set xdataID=$classname()_"||SampleJSON"
+    Set compiledXdata=##class(%Dictionary.CompiledXData).%OpenId(xdataID)
+    Set stream=compiledXdata.Data
+    Do $$$AssertTrue($IsObject(stream))
+
+    Set sampleJSON = {}.%FromJSON(stream)
+
+    Set output = ##class(%IPM.General.EnvironmentConfig).%Evaluate(sampleJSON).%ToJSON()
+    Set expected = $Replace(sampleJSON.%ToJSON(), "${"_..#ENVNAME_"}", ..#ENVVALUE)
+    Do $$$AssertEquals(output, expected)
+
+    Set output = ##class(%IPM.General.EnvironmentConfig).%Evaluate("${"_..#ENVNAME_"}")
+    Set expected = ..#ENVVALUE
+    Do $$$AssertEquals(output, expected)
+
+    Do ..UnsetEnvironmentVariable()
+}
+
+}

--- a/tests/unit_tests/Test/PM/Unit/ParseEnvVarJSON.cls
+++ b/tests/unit_tests/Test/PM/Unit/ParseEnvVarJSON.cls
@@ -62,7 +62,7 @@ ClassMethod UnsetEnvironmentVariable()
     Do os.environ.pop(..#ENVNAME, "")
 }
 
-Method TestarseEnvVarJSON()
+Method TestParseEnvVarJSON()
 {
     Do ..SetEnvironmentVariable()
 

--- a/tests/unit_tests/Test/PM/Unit/ParseEnvVarJSON.cls
+++ b/tests/unit_tests/Test/PM/Unit/ParseEnvVarJSON.cls
@@ -1,19 +1,33 @@
 Class Test.PM.Unit.ParseEnvVarJSON Extends %UnitTest.TestCase
 {
 
-Parameter ENVNAME = "mySecretEnvVarName";
+Parameter ENVNAME1 = "mySecretEnvVarName1";
 
-Parameter ENVVALUE = "This is a secret value";
+Parameter ENVNAME2 = "mySecretEnvVarName2";
+
+Parameter ENVNAME3 = "mySecretEnvVarName3";
+
+Parameter ENVNAME4 = "mySecretEnvVarName4";
+
+Parameter ENVVALUE1 = "This is a secret value 1 with "" ";
+
+Parameter ENVVALUE2 = "This is a secret value 2 with "" ";
+
+Parameter ENVVALUE3 = "This is a secret value 3 with "" ";
+
+Parameter ENVVALUE4 = "This is a secret value 4 with "" ";
 
 XData SampleJSON [ MimeType = application/json ]
 {
 {
     "package": {
         "nested": {
-            "key": "${mySecretEnvVarName}"
+            "key": "${mySecretEnvVarName1}"
         },
         "other": [ 1, 2, 3 ]
-    }
+    },
+    "toplevel": "${mySecretEnvVarName2}",
+    "arrayConcatenated": ["${mySecretEnvVarName3}${mySecretEnvVarName4}"]
 }
 }
 
@@ -53,33 +67,35 @@ ClassMethod SetEnvironmentVariable()
     // Will update once we have a pure COS way to do this.
     Set os = ##class(%SYS.Python).Import("os")
     // Note: the putenv only affects environment variables for the current process without any mapping to the actual environment variables.
-    Do os.putenv(..#ENVNAME, ..#ENVVALUE)
+    Do os.putenv(..#ENVNAME1, ..#ENVVALUE1)
+    Do os.putenv(..#ENVNAME2, ..#ENVVALUE2)
+    Do os.putenv(..#ENVNAME3, ..#ENVVALUE3)
+    Do os.putenv(..#ENVNAME4, ..#ENVVALUE4)
 }
 
 ClassMethod UnsetEnvironmentVariable()
 {
     Set os = ##class(%SYS.Python).Import("os")
-    Do os.environ.pop(..#ENVNAME, "")
+    Do os.environ.pop(..#ENVNAME1, "")
+    Do os.environ.pop(..#ENVNAME2, "")
+    Do os.environ.pop(..#ENVNAME3, "")
+    Do os.environ.pop(..#ENVNAME4, "")
 }
 
 Method TestParseEnvVarJSON()
 {
     Do ..SetEnvironmentVariable()
 
-    Set xdataID=$classname()_"||SampleJSON"
+    Set xdataID=$CLASSNAME()_"||SampleJSON"
     Set compiledXdata=##class(%Dictionary.CompiledXData).%OpenId(xdataID)
     Set stream=compiledXdata.Data
-    Do $$$AssertTrue($IsObject(stream))
-
+    Do $$$AssertTrue($ISOBJECT(stream))
     Set sampleJSON = {}.%FromJSON(stream)
 
-    Set output = ##class(%IPM.General.EnvironmentConfig).%Evaluate(sampleJSON).%ToJSON()
-    Set expected = $Replace(sampleJSON.%ToJSON(), "${"_..#ENVNAME_"}", ..#ENVVALUE)
-    Do $$$AssertEquals(output, expected)
-
-    Set output = ##class(%IPM.General.EnvironmentConfig).%Evaluate("${"_..#ENVNAME_"}")
-    Set expected = ..#ENVVALUE
-    Do $$$AssertEquals(output, expected)
+    Set parsedJSON = ##class(%IPM.General.EnvironmentConfig).%Evaluate(sampleJSON)
+    Do $$$AssertEquals(parsedJSON.package.nested.key, ..#ENVVALUE1)
+    Do $$$AssertEquals(parsedJSON.toplevel, ..#ENVVALUE2)
+    Do $$$AssertEquals(parsedJSON.arrayConcatenated."0", ..#ENVVALUE3_..#ENVVALUE4)
 
     Do ..UnsetEnvironmentVariable()
 }


### PR DESCRIPTION
Implement #742 

Environment variables can be included in env.json using `{secret: "${varname}"}` syntax. IPM will call $System.Util.GetEnviron() to populate the JSON object accordingly. 