### PR TITLE
Additional debugging info in welcome banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #710 Added support for `module-version` command which updates the version of a module
 - #716,#733 Added support to publish under external name by passing `-use-external-name` or `-use-ext`. Fail early if external name is illegal / empty.
 - #746: Added support for loading modules synchronously without multiprocessing
+- #749: Added more debugging information in the welcome banner
 
 ### Changed
 - #702 Preload now happens as part of the new `Initialize` lifecycle phase. `zpm "<module> reload -only"` will no longer auto compile resources in `/preload` directory.

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -823,6 +823,47 @@ ClassMethod GetVersion(ModuleName, ByRef out, list)
 	Quit sc
 }
 
+ClassMethod GetSystemMode()
+{
+	New $Namespace
+	Set $Namespace = "%SYS"
+	If $$$ISOK(##class(Config.Startup).Get(.tProperties)) {
+		Quit $Get(tProperties("SystemMode")) 
+	}
+	Quit ""
+}
+
+ClassMethod BuildIntroMessages() As %List
+{
+	Do ##class(%IPM.Main).GetVersion("zpm",.out)	
+	If $Get(out) = "" {
+		Set registryInfo = $$$FormattedLine($$$Cyan, "No registry configured")
+	} Else {
+		Set registryInfo = "Current registry "_$$$FormattedLine($$$Cyan, out)
+	}
+	Set systemMode = ..GetSystemMode()
+	If systemMode = "" {
+		Set systemMode = "System Mode: <unset>"
+	} Else {
+		Set systemMode = "System Mode: " _ systemMode
+	}
+	Set cls = "%ZHSLIB.Version", mthd = "GetFullBuildNumber"
+	If $System.CLS.IsMthd(cls, mthd) {
+		Set version = "HealthShare: " _ $ClassMethod(cls, mthd)
+	} Else {
+		Set version = $zv
+	}
+	Write !, $ZVersion // $ZV is too long for the box
+	Set list = $ListBuild(
+		"Welcome to the Package Manager Shell (ZPM). Version: "_$$$FormattedLine($$$Green, ..GetVersionModule("zpm")),
+		"Enter q/quit to exit the shell. Enter ?/help to view available commands",
+		registryInfo,
+		version,
+		systemMode
+	)
+	Quit list
+}
+
 /// For use in unit tests that need to test if a command threw any exceptions.
 ClassMethod ShellInternal(pCommand As %String, Output pException As %Exception.AbstractException) [ Internal ]
 {
@@ -836,17 +877,7 @@ ClassMethod ShellInternal(pCommand As %String, Output pException As %Exception.A
 	If (tCommand '= "") {
 		Set tOneCommand = 1
 	}
-	do ##class(%IPM.Main).GetVersion("zpm",.out)	
-	If $Get(out) = "" {
-		Set registryInfo = $$$FormattedLine($$$Cyan, "No registry configured")
-	} Else {
-		Set registryInfo = "Current registry "_$$$FormattedLine($$$Cyan, out)
-	}
-	Set introMessageList = $ListBuild(
-		"Welcome to the Package Manager Shell (ZPM). Version: "_$$$FormattedLine($$$Green, ..GetVersionModule("zpm")),
-		"Enter q/quit to exit the shell. Enter ?/help to view available commands",
-		registryInfo
-	)
+	Set introMessageList = ..BuildIntroMessages()
 	Set tInShell = 0
 	For {
 		Kill $$$DeprecationWarned

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -833,33 +833,40 @@ ClassMethod GetSystemMode()
 	Quit ""
 }
 
-ClassMethod BuildIntroMessages() As %List
+/// Return a list of messages to display when the shell is first started
+/// For messages that are too long to fit in a box, they should be returned in the outOfBoxMessage parameter
+ClassMethod BuildIntroMessages(Output outOfBoxMessage As %String) As %List
 {
+	Set cls = "%ZHSLIB.HealthShareMgr", mthd = "VersionInfo"
+	If $System.CLS.IsMthd(cls, mthd) {
+		Set outOfBoxMessage = $ClassMethod(cls, mthd)
+	} Else {
+		Set outOfBoxMessage = $ZVersion
+	}
+
 	Do ##class(%IPM.Main).GetVersion("zpm",.out)	
 	If $Get(out) = "" {
 		Set registryInfo = $$$FormattedLine($$$Cyan, "No registry configured")
 	} Else {
 		Set registryInfo = "Current registry "_$$$FormattedLine($$$Cyan, out)
 	}
+
 	Set systemMode = ..GetSystemMode()
 	If systemMode = "" {
 		Set systemMode = "System Mode: <unset>"
 	} Else {
 		Set systemMode = "System Mode: " _ systemMode
 	}
-	Set cls = "%ZHSLIB.Version", mthd = "GetFullBuildNumber"
-	If $System.CLS.IsMthd(cls, mthd) {
-		Set version = "HealthShare: " _ $ClassMethod(cls, mthd)
-	} Else {
-		Set version = $zv
-	}
-	Write !, $ZVersion // $ZV is too long for the box
+
+	Set mirrorStatus = $System.Mirror.GetStatus()
+	Set mirrorStatus = "Mirror Status: " _ mirrorStatus
+
 	Set list = $ListBuild(
 		"Welcome to the Package Manager Shell (ZPM). Version: "_$$$FormattedLine($$$Green, ..GetVersionModule("zpm")),
 		"Enter q/quit to exit the shell. Enter ?/help to view available commands",
 		registryInfo,
-		version,
-		systemMode
+		systemMode,
+		mirrorStatus
 	)
 	Quit list
 }
@@ -877,7 +884,7 @@ ClassMethod ShellInternal(pCommand As %String, Output pException As %Exception.A
 	If (tCommand '= "") {
 		Set tOneCommand = 1
 	}
-	Set introMessageList = ..BuildIntroMessages()
+	Set introMessageList = ..BuildIntroMessages(.outOfBoxMessage)
 	Set tInShell = 0
 	For {
 		Kill $$$DeprecationWarned
@@ -887,6 +894,7 @@ ClassMethod ShellInternal(pCommand As %String, Output pException As %Exception.A
 			// Ensure not displayed if its just one command
 			If 'tInShell && 'tOneCommand {
 				Do ..DrawBorder(introMessageList, ..TerminalPromptColor())
+				Write $Get(outOfBoxMessage),! // Display long messages outside of the box
 				Set tInShell = 1
 			}
 			


### PR DESCRIPTION
Implement #613 

- [x] the results of $ZV or if in a HealthShare installation the full HealthShare version string
- [x] whether or not this is the primary mirror member if part of a mirror or if on a backup
- [x] the results of what is found in   `Set $Namespace = "%SYS" $$$THROWONERROR(tSC, ##class(Config.Startup).Get(.tProperties)) Set pSystemMode = $Get(tProperties("SystemMode"))` so that we could see if this is a TEST, STAGE or PROD environment.
- [x] Maybe some information about the %SYS("HealthShare","Instances" types so we can see if this might be an instance where HSANALYTICS, HSPI, the CV etc are currently installed. 