### PR TITLE
V0.10.x info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #720 Support offline installation of oras using fixed version of pure python wheels and an adaptor for rpds.
 - #746: Added support for loading modules synchronously without multiprocessing
 - #749: Added more debugging information in the welcome banner
+- #755: Added an `info` command which prints external name (optionally including the real name) of top-level packages without the `build` part of semver. 
 
 ### Changed
 - #702 Preload now happens as part of the new `Initialize` lifecycle phase. `zpm "<module> reload -only"` will no longer auto compile resources in `/preload` directory.

--- a/src/cls/IPM/General/SemanticVersion.cls
+++ b/src/cls/IPM/General/SemanticVersion.cls
@@ -32,6 +32,14 @@ _ $Case(..Prerelease, "": "", : "-" _ ..Prerelease)
 _ $Case(..Build, "": "", : "+" _ ..Build)
 }
 
+Method ToStringWithoutBuild() As %String [ CodeMode = expression ]
+{
+..Major 
+_ "." _ ..Minor 
+_ $Case(..Patch, "": "", : "." _ ..Patch) 
+_ $Case(..Prerelease, "": "", : "-" _ ..Prerelease)
+}
+
 ClassMethod FromString(pString As %String) As %IPM.General.SemanticVersion
 {
   Set tVer = ..%New()

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -3739,6 +3739,13 @@ ClassMethod Information(ByRef pCommandInfo)
 		}
 	}
 
+	Set messages = ..BuildIntroMessages(.outOfBoxMessage)
+	Set messages = messages _ $ListBuild(outOfBoxMessage)
+	Set ptr = 0
+	While $ListNext(messages, ptr, line) {
+		Write !, line
+	}
+	Write !!, "Currently installed top-level modules are listed below:", !
 	Do ..GetListModules(,,.list)
 	Set updatedList("width") = 0
 	For i = 1:1:list {

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -753,6 +753,17 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
 	</example>
 </command>
 
+<command name="information" aliases="info">
+	<description>Output information about the current ZPM environment.</description>
+	<modifier name="verbose" aliases="v" description="Show more detailed information"/>
+	<example description="Show basic information about the current ZPM environment">
+		info
+	</example>
+	<example description="Show detailed information about the current ZPM environment">
+		info -verbose
+	</example>
+</command>
+
 </commands>
 }
 
@@ -975,6 +986,8 @@ ClassMethod ShellInternal(pCommand As %String, Output pException As %Exception.A
 				Do ..UnmapIPM(.tCommandInfo)
 			} ElseIf (tCommandInfo = "module-version") {
 				Do ..ModuleVersion(.tCommandInfo)
+			} ElseIf (tCommandInfo = "information") {
+				Do ..Information(.tCommandInfo)
 			}
 		} Catch pException {
 			If (pException.Code = $$$ERCTRLC) {
@@ -3703,6 +3716,54 @@ ClassMethod GetUpstreamPackageVersions(Output list)
       Set list(rs.%Get("Name"), r) = rs.%Get("Version")
     }
   }
+}
+
+ClassMethod Information(ByRef pCommandInfo)
+{
+	Set verbose = $$$HasModifier(pCommandInfo,"verbose")
+	// Get all dependency modules
+	$$$ThrowOnError(##class(%IPM.Utils.Module).BuildAllDependencyGraphs(, .graph))
+	Set sub = "" 
+	For {
+		Set sub = $Order(graph(sub))
+		If sub = "" {
+			Quit
+		}
+		Set dep= ""
+		For {
+			Set dep= $Order(graph(sub, dep))
+			If dep= "" {
+				Quit
+			}
+			Set dependencies(dep) = ""
+		}
+	}
+
+	Do ..GetListModules(,,.list)
+	Set updatedList("width") = 0
+	For i = 1:1:list {
+		Set entry = list(i)
+		Set name = $ListGet(entry, 1)
+		// only list non-dependencies
+		If $Data(dependencies(name)) {
+			Continue
+		}
+		Set package = ##class(%IPM.Storage.Module).NameOpen(name, , .sc)
+		$$$ThrowOnError(sc)
+		If (package.ExternalName '= "") && (package.ExternalName '= name) {
+			If verbose {
+				Set $List(entry, 1) = package.ExternalName_" (" _ name _ ")"
+			} Else {
+				Set $List(entry, 1) = package.ExternalName
+			}
+		}
+		If updatedList("width") < $Length($ListGet(entry)) {
+			Set updatedList("width") = $Length($ListGet(entry))
+		}
+		Set $List(entry, 2) = package.Version.ToStringWithoutBuild()
+		Set updatedList($Increment(updatedList)) = entry
+	}
+	Do ..DisplayModules(.updatedList)
 }
 
 }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2536,6 +2536,19 @@ ClassMethod ListInstalled(ByRef pCommandInfo) [ Private ]
 		Set tDesc=+$Get(pCommandInfo("data","Desc"))
     Do ..GetListModules(,tSearchString, .list, showFields, $Get(pCommandInfo("modifiers", "repository")))
 	}
+  For i = 1:1:list {
+	Set entry = list(i)
+	Set name = $ListGet(entry,1)
+	Set externalName = $ListGet(entry,3)
+	Set displayName = $Select(externalName'= "":externalName, 1:name)
+	If (displayName '= name) {
+		Set displayName = displayName_" ("_name_")"
+	}
+	Set $List(list(i), 1) = displayName
+	If list("width") < $Length(displayName) {
+		Set list("width") = $Length(displayName)
+	}
+  }
   Merge tModifiers = pCommandInfo("modifiers")
   Do ..DisplayModules(.list,,,, .tModifiers)
 }
@@ -3755,19 +3768,19 @@ ClassMethod Information(ByRef pCommandInfo)
 		If $Data(dependencies(name)) {
 			Continue
 		}
-		Set package = ##class(%IPM.Storage.Module).NameOpen(name, , .sc)
-		$$$ThrowOnError(sc)
-		If (package.ExternalName '= "") && (package.ExternalName '= name) {
+		Set externalName = $List(entry, 3)
+		If (externalName '= "") && (externalName '= name) {
 			If verbose {
-				Set $List(entry, 1) = package.ExternalName_" (" _ name _ ")"
+				Set $List(entry, 1) = externalName_" (" _ name _ ")"
 			} Else {
-				Set $List(entry, 1) = package.ExternalName
+				Set $List(entry, 1) = externalName
 			}
 		}
 		If updatedList("width") < $Length($ListGet(entry)) {
 			Set updatedList("width") = $Length($ListGet(entry))
 		}
-		Set $List(entry, 2) = package.Version.ToStringWithoutBuild()
+		Set version = ##class(%IPM.General.SemanticVersion).FromString($List(entry, 2))
+		Set $List(entry, 2) = version.ToStringWithoutBuild()
 		Set updatedList($Increment(updatedList)) = entry
 	}
 	Do ..DisplayModules(.updatedList)

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2533,24 +2533,24 @@ ClassMethod ListInstalled(ByRef pCommandInfo) [ Private ]
         "Root"
       )
     }
-		Set tDesc=+$Get(pCommandInfo("data","Desc"))
+	Set tDesc=+$Get(pCommandInfo("data","Desc"))
     Do ..GetListModules(,tSearchString, .list, showFields, $Get(pCommandInfo("modifiers", "repository")))
+	For i = 1:1:list {
+		Set entry = list(i)
+		Set name = $ListGet(entry,1)
+		Set externalName = $ListGet(entry,3)
+		Set displayName = $Select(externalName'= "":externalName, 1:name)
+		If (displayName '= name) {
+			Set displayName = displayName_" ("_name_")"
+		}
+		Set $List(list(i), 1) = displayName
+		If list("width") < $Length(displayName) {
+			Set list("width") = $Length(displayName)
+		}
 	}
-  For i = 1:1:list {
-	Set entry = list(i)
-	Set name = $ListGet(entry,1)
-	Set externalName = $ListGet(entry,3)
-	Set displayName = $Select(externalName'= "":externalName, 1:name)
-	If (displayName '= name) {
-		Set displayName = displayName_" ("_name_")"
+	Merge tModifiers = pCommandInfo("modifiers")
+	Do ..DisplayModules(.list,,,, .tModifiers)
 	}
-	Set $List(list(i), 1) = displayName
-	If list("width") < $Length(displayName) {
-		Set list("width") = $Length(displayName)
-	}
-  }
-  Merge tModifiers = pCommandInfo("modifiers")
-  Do ..DisplayModules(.list,,,, .tModifiers)
 }
 
 /// Get module list in currently namespace


### PR DESCRIPTION
This PR adds an `info` command per #689 . It lists top level packages and their external name (if existent) and the semver without the `build` part. If a `-verbose/-v` modifier is passed, it will include default name in parentheses. 

<img width="669" alt="image" src="https://github.com/user-attachments/assets/b66941ba-734a-4df7-b023-6d50b5e17710" />
