### PR TITLE
Fix sm-versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #731: Issue upgrading from v0.9.x due to refactor of repo classes
 - #718: Upload zpm.xml (without the version) as an artifact to provide a more stable URL to latest release artifact on GitHub
 - #722: Unified modifiers between ModuleAction and RunOnePhase
+- #735: Prerelease now properly allows alphanumeric tags with zeros
 
 ### Security
 -

--- a/src/cls/IPM/General/SemanticVersion.cls
+++ b/src/cls/IPM/General/SemanticVersion.cls
@@ -87,8 +87,8 @@ Method %OnValidateObject() As %Status [ Private, ServerOnly = 1 ]
 	Set tPointer = 0
 	Set tPreIdentifiers = $ListFromString(..Prerelease,".")
 	While $ListNext(tPreIdentifiers,tPointer,tIdentifier) {
-		Set tNumeric = $ZStrip(tIdentifier, "*ACPW")
-		If (+tNumeric > 0) && (+tNumeric '= tNumeric) {
+		// Cannot have a numeric identifier with a leading zeroes (leading zeroes in an alphanumeric are OK)
+		if ($locate(tIdentifier,"^0[0-9]+$")) {
 			Set tSC = $$$ERROR($$$GeneralError,$$$FormatText("Numeric identifier (%1) in version's prerelease (%2) cannot contain leading zeros.",tIdentifier,..Prerelease))
 		}
 	}

--- a/tests/unit_tests/Test/PM/Unit/SemVer/Versions.cls
+++ b/tests/unit_tests/Test/PM/Unit/SemVer/Versions.cls
@@ -37,6 +37,8 @@ Method TestVersions()
 	Do ..AssertVersionValid("1.0.0+20130313144700", 1, 0, 0, , "20130313144700")
 	Do ..AssertVersionValid("1.0.0-beta+exp.sha.5114f85", 1, 0, 0, "beta", "exp.sha.5114f85")
 	Do ..AssertVersionValid("1.0.0-beta-alpha-delta+exp.sha-5114f85", 1, 0, 0, "beta-alpha-delta", "exp.sha-5114f85")
+	Do ..AssertVersionValid("1.0.0-test-C0008", 1, 0, 0, "test-C0008")
+	Do ..AssertVersionValid("1.0.0-0008ABC", 1, 0, 0, "0008ABC")
 	
 	Do ..AssertVersionNotValid("01.1.0")
 	Do ..AssertVersionNotValid("1.01.0")
@@ -46,7 +48,13 @@ Method TestVersions()
 	Do ..AssertVersionNotValid("1.1.1-alpha?")
 }
 
-Method AssertVersionValid(pVersion As %String, pMajor As %String = "", pMinor As %String = "", pPatch As %String = "", pPrerelease As %String = "", pBuild As %String = "")
+Method AssertVersionValid(
+	pVersion As %String,
+	pMajor As %String = "",
+	pMinor As %String = "",
+	pPatch As %String = "",
+	pPrerelease As %String = "",
+	pBuild As %String = "")
 {
 	Set tSC = ##class(%IPM.General.SemanticVersion).IsValid(pVersion, .tSemVer)
 	If '$$$AssertStatusOK(tSC,pVersion_" is accepted as a valid semantic version.") {
@@ -66,14 +74,18 @@ Method AssertVersionNotValid(pVersion As %String)
 	Do $$$AssertStatusNotOK(##class(%IPM.General.SemanticVersion).IsValid(pVersion),pVersion_" is not accepted as a valid semantic version.")
 }
 
-Method AssertFollows(pVersion1 As %String, pVersion2 As %String)
+Method AssertFollows(
+	pVersion1 As %String,
+	pVersion2 As %String)
 {
 	Set tSemVer1 = ##class(%IPM.General.SemanticVersion).FromString(pVersion1)
 	Set tSemVer2 = ##class(%IPM.General.SemanticVersion).FromString(pVersion2)
 	Do $$$AssertEquals(tSemVer1.Follows(tSemVer2), 1, pVersion1_" follows "_pVersion2)
 }
 
-Method AssertNotFollows(pVersion1 As %String, pVersion2 As %String)
+Method AssertNotFollows(
+	pVersion1 As %String,
+	pVersion2 As %String)
 {
 	Set tSemVer1 = ##class(%IPM.General.SemanticVersion).FromString(pVersion1)
 	Set tSemVer2 = ##class(%IPM.General.SemanticVersion).FromString(pVersion2)

--- a/tests/unit_tests/Test/PM/Unit/SemVer/Versions.cls
+++ b/tests/unit_tests/Test/PM/Unit/SemVer/Versions.cls
@@ -48,13 +48,7 @@ Method TestVersions()
 	Do ..AssertVersionNotValid("1.1.1-alpha?")
 }
 
-Method AssertVersionValid(
-	pVersion As %String,
-	pMajor As %String = "",
-	pMinor As %String = "",
-	pPatch As %String = "",
-	pPrerelease As %String = "",
-	pBuild As %String = "")
+Method AssertVersionValid(pVersion As %String, pMajor As %String = "", pMinor As %String = "", pPatch As %String = "", pPrerelease As %String = "", pBuild As %String = "")
 {
 	Set tSC = ##class(%IPM.General.SemanticVersion).IsValid(pVersion, .tSemVer)
 	If '$$$AssertStatusOK(tSC,pVersion_" is accepted as a valid semantic version.") {
@@ -74,18 +68,14 @@ Method AssertVersionNotValid(pVersion As %String)
 	Do $$$AssertStatusNotOK(##class(%IPM.General.SemanticVersion).IsValid(pVersion),pVersion_" is not accepted as a valid semantic version.")
 }
 
-Method AssertFollows(
-	pVersion1 As %String,
-	pVersion2 As %String)
+Method AssertFollows(pVersion1 As %String, pVersion2 As %String)
 {
 	Set tSemVer1 = ##class(%IPM.General.SemanticVersion).FromString(pVersion1)
 	Set tSemVer2 = ##class(%IPM.General.SemanticVersion).FromString(pVersion2)
 	Do $$$AssertEquals(tSemVer1.Follows(tSemVer2), 1, pVersion1_" follows "_pVersion2)
 }
 
-Method AssertNotFollows(
-	pVersion1 As %String,
-	pVersion2 As %String)
+Method AssertNotFollows(pVersion1 As %String, pVersion2 As %String)
 {
 	Set tSemVer1 = ##class(%IPM.General.SemanticVersion).FromString(pVersion1)
 	Set tSemVer2 = ##class(%IPM.General.SemanticVersion).FromString(pVersion2)


### PR DESCRIPTION
Fixes #735, making sure pre-release version does not contain leading zero only for numeric pre-release tag.