### PR TITLE
V0.10.x feat oras version annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #754: Support publishing and installing deployed items for ORAS repository
 - #755: Added an `info` command which prints external name (optionally including the real name) of top-level packages without the `build` part of semver. 
 - #756: Support running commands using external names of packages.
+- #767: Allow skipping the reload phase when packaging and publishing, useful for packaging/publishing after running `module-version`
 
 ### Changed
 - #702 Preload now happens as part of the new `Initialize` lifecycle phase. `zpm "<module> reload -only"` will no longer auto compile resources in `/preload` directory.

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -121,6 +121,7 @@ This command is an alias for `module-action module-name package`
 <parameter name="module" required="true" description="Name of module on which to perform package actions" />
 <modifier name="path" aliases="p" dataAlias="Path" value="true" description="the specified path to export package." />
 <modifier name="export-deps" value="true" valueList="0,1" dataAlias="ExportDependencies" description="If specified, controls whether dependencies are exported. If omitted, defaults to the value of the #EXPORTDEPENDENCIES in lifecycle class. This modifier is only used in &quot;Package&quot; and &quot;Publish&quot; lifecycles." />
+<modifier name="skip-reload" dataAlias="SkipPhases" dataValue="reload" description="Skip the 'Reload' lifecycle phase before publishing" />
 </command>
 
 <command name="verify" dataPrefix="D">
@@ -137,6 +138,7 @@ This command is an alias for `module-action module-name publish`
 <parameter name="module" required="true" description="Name of module on which to perform publish actions" />
 <modifier name="repo" aliases="r" dataAlias="PublishTo" description="Namespace-unique name for the module to publish to (if deployment is enabled)" />
 <modifier name="use-external-name" aliases="use-ext" dataAlias="UseExternalName" dataValue="1" description="Publish the package under the &lt;ExternalName&gt; of the package. If ExternalName is unspecified or illegal, an error will be thrown."/>
+<modifier name="skip-reload" dataAlias="SkipPhases" dataValue="reload" description="Skip the 'Reload' lifecycle phase before publishing" />
 </command>
 
 <command name="makedeployed">

--- a/src/cls/IPM/Repo/Oras/PackageService.cls
+++ b/src/cls/IPM/Repo/Oras/PackageService.cls
@@ -70,56 +70,16 @@ Method HasModule(pModuleReference As %IPM.Storage.ModuleInfo) As %Boolean
 ClassMethod AggregatePlatformVersions(tagsList As %List, Output aggregatedPlatformVersion As %String) As %List
 {
 	Set ptr = 0
-	Set sorter = ""
-	Set order = ""
 	While $ListNext(tagsList, ptr, tag) {
 		// aggregate
 		Set $ListBuild(version, platformVersion) = $ListFromString(tag, $$$OrasTagPlatformSeparator)
 		Set value = $Get(aggregatedPlatformVersion(version))
 		Set aggregatedPlatformVersion(version) = value _ $ListBuild(platformVersion) 
-
-		// prepare for sorting
-		Set semver = ##class(%IPM.General.SemanticVersion).FromString($$$Tag2Semver(version))
-		Set sorter(+semver.Major, +semver.Minor, +semver.Patch, " "_semver.Prerelease, " "_semver.Build) = version
 	}
 
-	Set major = ""
-	For {
-		Set major = $Order(sorter(major), -1)
-		If major = "" {
-			Quit
-		}
-		Set minor = ""
-		For {
-			Set minor = $Order(sorter(major, minor), -1)
-			If minor = "" {
-				Quit
-			}
-			Set patch = ""
-			For {
-				Set patch = $Order(sorter(major, minor, patch), -1)
-				If patch = "" {
-					Quit
-				}
-				Set prerelease = ""
-				For {
-					Set prerelease = $Order(sorter(major, minor, patch, prerelease), -1)
-					If prerelease = "" {
-						Quit
-					}
-					Set build = ""
-					For {
-						Set build = $Order(sorter(major, minor, patch, prerelease, build), -1, version)
-						If build = "" {
-							Quit
-						}
-						Set order = order _ $ListBuild(version)
-					}
-				}
-			}
-		}
-	}
-	Return order
+	Set pyList = ##class(%SYS.Python).ToList(tagsList)
+	Set sortedTags = ##class(%IPM.Utils.EmbeddedPython).SortOCITags(pyList, 1)
+	Return ##class(%IPM.Utils.EmbeddedPython).FromPythonList(sortedTags)
 }
 
 Method ListModulesFromTagString(allTagsString As %String, semverExpr As %IPM.General.SemanticVersionExpression, package As %String, client As %SYS.Python, moduleList As %ListOfObjects, searchCriteria As %IPM.Repo.SearchCriteria, name As %String)
@@ -430,7 +390,7 @@ ClassMethod GetAllTagsPy(registry As %String, package As %String, namespace As %
 		tags = client.get_tags(target)
 
 		# flip list so higher versions are first
-		tags.reverse()
+		tags = iris.cls("%IPM.Utils.EmbeddedPython").SortOCITags(tags, 1)
 		
 		# convert from list to comma separated string
 		return ", ".join(str(x) for x in tags)

--- a/src/cls/IPM/Repo/Oras/PackageService.cls
+++ b/src/cls/IPM/Repo/Oras/PackageService.cls
@@ -77,8 +77,17 @@ ClassMethod AggregatePlatformVersions(tagsList As %List, Output aggregatedPlatfo
 		Set aggregatedPlatformVersion(version) = value _ $ListBuild(platformVersion) 
 	}
 
-	Set pyList = ##class(%SYS.Python).ToList(tagsList)
-	Set sortedTags = ##class(%IPM.Utils.EmbeddedPython).SortOCITags(pyList, 1)
+	Set version = "", versionList = ""
+	For {
+		Set version = $Order(aggregatedPlatformVersion(version))
+		If version = "" {
+			Quit
+		}
+		Set versionList = versionList _ $ListBuild(version)
+	}
+	
+	Set pyList = ##class(%SYS.Python).ToList(versionList)
+	Set sortedTags = ##class(%IPM.Utils.EmbeddedPython).SortVersions(pyList, 1)
 	Return ##class(%IPM.Utils.EmbeddedPython).FromPythonList(sortedTags)
 }
 

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -277,9 +277,30 @@ ClassMethod ExecutePhases(pModuleName As %String, pPhases As %List, pIsComplete 
 			If ($ListFind(tPhases, "Package") && tModule.HaveToDeploy()) {
 				Set tPhases = $ListBuild("PrepareDeploy") _ tPhases
 			}
+		} ElseIf pPhases = $ListBuild("Publish") {
+			// 'Publish' depends on 'Package', so we need to at least run 'Package' first.
+			$$$ThrowStatus($$$ERROR($$$GeneralError,"'Publish' phase cannot be run with '-only'."))
 		} Else {
 			Set tPhases = $ListBuild(##class(%IPM.Lifecycle.Base).MatchSinglePhase($LISTTOSTRING(pPhases)))
 		}
+
+		// Skip the phases specified in pParams("SkipPhases")
+		Set skipPhases = $ListFromString($Get(pParams("SkipPhases")))
+		Set ptr = 0
+		While $ListNext(skipPhases, ptr, phase) {
+			Set phase = ##class(%IPM.Lifecycle.Base).MatchSinglePhase(phase)
+			Set skipPhases(phase) = ""
+		}
+		Set ptr = 0
+
+		Set tFilteredPhases = ""
+		While $ListNext(tPhases, ptr, phase) {
+			If $Data(skipPhases(phase)) {
+				Continue
+			}
+			Set tFilteredPhases = tFilteredPhases_ $ListBuild(phase)
+		}
+		Set tPhases = tFilteredPhases
 		
 		// Lifecycle-provided default parameters
 		Do tLifecycle.GetDefaultParameters(.tParams, tPhases)

--- a/src/cls/IPM/Utils/EmbeddedPython.cls
+++ b/src/cls/IPM/Utils/EmbeddedPython.cls
@@ -35,9 +35,23 @@ ClassMethod CompareVersionTotalOrder(ver1 As %String, ver2 As %String) As %Integ
     return -1 if build1 < build2 else 1
 }
 
+/// <parameter>versions</parameter> is a python `list` of strings.
+/// Sorts the versions and return a new python `list`.
+/// If <parameter>reverse</parameter> is a truthy value, sort in descending order
+ClassMethod SortVersions(versions As %SYS.Python, reverse As %SYS.Python = 0) As %SYS.Python
+{
+    import iris
+    from functools import cmp_to_key
+
+    assert isinstance(versions, list)
+
+    keyfunc = cmp_to_key(iris.cls("%IPM.Utils.EmbeddedPython").CompareVersionTotalOrder)
+    return list(sorted(versions, key=keyfunc, reverse=reverse))
+}
+
 /// <parameter>tags</parameter> is a python `list` of strings.
-/// Sorts the OCI tags and return in a new python `list`.
-/// If reverse is a truthy value, sort in descending order
+/// Sorts the OCI tags and return a new python `list`.
+/// If <parameter>reverse</parameter> is a truthy value, sort in descending order
 ClassMethod SortOCITags(tags As %SYS.Python, reverse As %SYS.Python = 0) As %SYS.Python
 {
     import iris
@@ -50,7 +64,7 @@ ClassMethod SortOCITags(tags As %SYS.Python, reverse As %SYS.Python = 0) As %SYS
     tag2ver = {t: t.split(OrasTagPlatformSeparator)[0].replace("_", "+") for t in tags}
 
     keyfunc = cmp_to_key(iris.cls("%IPM.Utils.EmbeddedPython").CompareVersionTotalOrder)
-    sorted_pairs = sorted(tag2ver.items(), key=lambda p: keyfunc(p[1]), reverse=bool(reverse))
+    sorted_pairs = sorted(tag2ver.items(), key=lambda p: keyfunc(p[1]), reverse=reverse)
     return [t for t, _ in sorted_pairs]
 }
 

--- a/src/cls/IPM/Utils/EmbeddedPython.cls
+++ b/src/cls/IPM/Utils/EmbeddedPython.cls
@@ -1,0 +1,53 @@
+/// Helper methods in Python for efficient manipulation of %SYS.Python objects
+Class %IPM.Utils.EmbeddedPython [ Language = python ]
+{
+
+/// This method returns a total order, instead of a partial order.
+/// In other words, v1.2.3-alpha and v4.5.6-beta should be comparable.
+ClassMethod CompareVersionTotalOrder(ver1 As %String, ver2 As %String) As %Integer
+{
+    import iris
+
+    semver1 = iris.cls("%IPM.General.SemanticVersion").FromString(ver1)
+    semver2 = iris.cls("%IPM.General.SemanticVersion").FromString(ver2)
+    mmp1 = (semver1.Major, semver1.Minor, semver1.Patch)
+    mmp2 = (semver2.Major, semver2.Minor, semver2.Patch)
+    if mmp1 < mmp2:
+        return -1
+    if mmp1 > mmp2:
+        return 1
+    
+    # empty prerelease indicates higher version
+    pre1, pre2 = semver1.Prerelease, semver2.Prerelease
+    if pre1 != pre2:
+        if pre1 == "":
+            return 1
+        if pre2 == "":
+            return -1
+        return -1 if pre1 < pre2 else 1
+    
+    # Unlike for prerelease, treat empty build as lower (alphabetical order)
+    build1, build2 = semver1.Build, semver2.Build
+    if build1 == build2:
+        return 0
+    return -1 if build1 < build2 else 1
+}
+
+/// <parameter>tags</parameter> is a python `list` of strings.
+/// Sorts the OCI tags and return in a new python `list`.
+/// If reverse is a truthy value, sort in descending order
+ClassMethod SortOCITags(tags As %SYS.Python, reverse As %SYS.Python = 0) As %SYS.Python
+{
+    import iris
+    from functools import cmp_to_key
+
+    # maps tag to its version. E.g., "1.2.3-alpha_build__2024.1" -> "1.2.3-alpha+build"
+    OrasTagPlatformSeparator = "__"
+    tag2ver = {t: t.split(OrasTagPlatformSeparator)[0].replace("_", "+") for t in tags}
+
+    keyfunc = cmp_to_key(iris.cls("%IPM.Utils.EmbeddedPython").CompareVersionTotalOrder)
+    sorted_pairs = sorted(tag2ver.items(), key=lambda p: keyfunc(p[1]), reverse=bool(reverse))
+    return [t for t, _ in sorted_pairs]
+}
+
+}

--- a/src/cls/IPM/Utils/EmbeddedPython.cls
+++ b/src/cls/IPM/Utils/EmbeddedPython.cls
@@ -8,6 +8,8 @@ ClassMethod CompareVersionTotalOrder(ver1 As %String, ver2 As %String) As %Integ
 {
     import iris
 
+    assert isinstance(ver1, str) and isinstance(ver2, str)
+
     semver1 = iris.cls("%IPM.General.SemanticVersion").FromString(ver1)
     semver2 = iris.cls("%IPM.General.SemanticVersion").FromString(ver2)
     mmp1 = (semver1.Major, semver1.Minor, semver1.Patch)
@@ -41,6 +43,8 @@ ClassMethod SortOCITags(tags As %SYS.Python, reverse As %SYS.Python = 0) As %SYS
     import iris
     from functools import cmp_to_key
 
+    assert isinstance(tags, list)
+
     # maps tag to its version. E.g., "1.2.3-alpha_build__2024.1" -> "1.2.3-alpha+build"
     OrasTagPlatformSeparator = "__"
     tag2ver = {t: t.split(OrasTagPlatformSeparator)[0].replace("_", "+") for t in tags}
@@ -48,6 +52,20 @@ ClassMethod SortOCITags(tags As %SYS.Python, reverse As %SYS.Python = 0) As %SYS
     keyfunc = cmp_to_key(iris.cls("%IPM.Utils.EmbeddedPython").CompareVersionTotalOrder)
     sorted_pairs = sorted(tag2ver.items(), key=lambda p: keyfunc(p[1]), reverse=bool(reverse))
     return [t for t, _ in sorted_pairs]
+}
+
+ClassMethod FromPythonList(list As %SYS.Python) As %List [ Language = objectscript ]
+{
+    Set builtins = ##class(%SYS.Python).Builtins()
+    Set output = ""
+    For i = 0:1:list."__len__"()-1 {
+        Set item = list."__getitem__"(i)
+        If builtins.isinstance(item, builtins.list){
+            Set item = ..FromPythonList(item)
+        }
+        Set output = output _ $ListBuild(item)
+    }
+    Quit output
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/OrasVersionAnnotations.cls
+++ b/tests/integration_tests/Test/PM/Integration/OrasVersionAnnotations.cls
@@ -1,0 +1,71 @@
+Class Test.PM.Integration.OrasVersionAnnotations Extends Test.PM.Integration.Base
+{
+
+Parameter Folder = "oras-version-annotations";
+
+Parameter Module = "oras-version-annotations";
+
+Parameter OrignalVersion = "1.0.0-prerelease+build";
+
+Parameter UpdatedVersion = "1.0.0";
+
+Method TestOrasVersionAnnotations()
+{
+    Set folder = ..GetModuleDir(..#Folder)
+
+    Set sc = ##class(%IPM.Main).Shell("load " _ folder)
+    Do $$$AssertStatusOK(sc, "Successfully loaded module at "_folder)
+
+    Do ..AssertVersion(..#OrignalVersion)
+
+    Set sc = ##class(%IPM.Main).Shell("repo -delete-all")
+    Do $$$AssertStatusOK(sc,"Deleted repos successfully")
+
+    Set sc = ##class(%IPM.Main).Shell("repo -o -name oras -url http://oras:5000 -publish 1")
+    Do $$$AssertStatusOK(sc,"Set up oras module successfully")
+
+    Set sc = ##class(%IPM.Main).Shell("publish "_..#Module_" -r oras -verbose")
+    Do $$$AssertStatusOK(sc,"Published module successfully")
+
+    Do ..AssertVersion(..#OrignalVersion)
+
+    Set sc = ##class(%IPM.Main).Shell("modver "_..#Module_" "_..#UpdatedVersion_" -force")
+    Do $$$AssertStatusOK(sc,"Updated module version to "_..#UpdatedVersion)
+
+    Do ..AssertVersion(..#UpdatedVersion)
+
+    Set sc = ##class(%IPM.Main).Shell("publish "_..#Module_" -r oras -verbose -skip-reload")
+    Do $$$AssertStatusOK(sc,"Published module successfully")
+
+    Do ..AssertVersion(..#UpdatedVersion)
+
+    Set sc = ##class(%IPM.Main).Shell("uninstall "_..#Module)
+    Do $$$AssertStatusOK(sc,"Uninstalled module successfully")
+
+    Set sc = ##class(%IPM.Main).Shell("install "_..#Module)
+    Do $$$AssertStatusOK(sc,"Installed module from ORAS registry successfully")
+
+    Do ..AssertVersion(..#UpdatedVersion)
+
+    Set sc = ##class(%IPM.Main).Shell("repo -delete-all")
+    Do $$$AssertStatusOK(sc,"Deleted repos successfully")
+
+    Set sc = ##class(%IPM.Main).Shell("repo -reset-defaults")
+    Do $$$AssertStatusOK(sc,"Reset repos to default successfully")
+}
+
+Method AssertVersion(ver As %String) As %Boolean
+{
+    Set query = "SELECT Name FROM %IPM_Storage.ModuleItem WHERE Name = ?"
+    Set rs = ##class(%SQL.Statement).%ExecDirect(, query, ..#Module)
+    If '$$$AssertTrue(rs.%Next(), "Module "_..#Module_" found in SQL") {
+        Return 0
+    }
+    Set module = ##class(%IPM.Storage.Module).NameOpen(rs.%Get("Name"))
+    If '$$$AssertNotEquals(module, "", "Module set") {
+        Return 0
+    }
+    Return $$$AssertEquals(module.VersionString, ver) && $$$AssertEquals(module.Version.ToString(), ver)
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/oras-version-annotations/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/oras-version-annotations/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="oras-version-annotations.ZPM">
+    <Module>
+      <Name>oras-version-annotations</Name>
+      <Version>1.0.0-prerelease+build</Version>
+      <Packaging>module</Packaging>
+    </Module>
+  </Document>
+</Export>

--- a/tests/unit_tests/Test/PM/Unit/EmbeddedPython.cls
+++ b/tests/unit_tests/Test/PM/Unit/EmbeddedPython.cls
@@ -51,31 +51,26 @@ Method TestSortOCITags()
     Set expected = ##class(%SYS.Python).ToList(expected)
 
     Set output = ##class(%IPM.Utils.EmbeddedPython).SortOCITags(tags)
-    If '..AssertPythonListsEqual(output, expected) {
-        Do $$$LogMessage("Failed for ascending order. Expected: "_..FromPythonList(expected)_" but got: "_..FromPythonList(output))
-    }
+    Do ..AssertPythonListsEqual(output, expected) 
 
     Set expected = builtins.list(builtins.reversed(expected))
 
     Set output = ##class(%IPM.Utils.EmbeddedPython).SortOCITags(tags, 1)
-    If '..AssertPythonListsEqual(output, expected) {
-        Do $$$LogMessage("Failed for descending order. Expected: "_..FromPythonList(expected)_" but got: "_..FromPythonList(output))
-    }
+    Do ..AssertPythonListsEqual(output, expected)
 }
 
-ClassMethod FromPythonList(list As %SYS.Python) As %List
+Method TestFromPythonList(list As %SYS.Python) As %List
 {
-    Set output = ""
-    For i = 0:1:list."__len__"()-1 {
-       Set output = output _ $ListBuild(list."__getitem__"(i))
-    }
-    Return output
+    Set original = $ListBuild($ListBuild(1, 2, 3), $ListBuild(4, 5, 6), $ListBuild($ListBuild(7, 8, 9), 10, 11))
+    Set input = ##class(%SYS.Python).ToList(original)
+    Set output = ##class(%IPM.Utils.EmbeddedPython).FromPythonList(input)
+    Do $$$AssertEquals(output, original)
 }
 
 Method AssertPythonListsEqual(list1 As %SYS.Python, list2 As %SYS.Python) As %Boolean
 {
-    Set list1 = ..FromPythonList(list1)
-    Set list2 = ..FromPythonList(list2)
+    Set list1 = ##class(%IPM.Utils.EmbeddedPython).FromPythonList(list1)
+    Set list2 = ##class(%IPM.Utils.EmbeddedPython).FromPythonList(list2)
     Return $$$AssertEquals(list1, list2)
 }
 

--- a/tests/unit_tests/Test/PM/Unit/EmbeddedPython.cls
+++ b/tests/unit_tests/Test/PM/Unit/EmbeddedPython.cls
@@ -28,6 +28,36 @@ Method TestCompareVersionTotalOrder()
     }
 }
 
+Method TestSortVersions()
+{
+    Set builtins = ##class(%SYS.Python).Builtins()
+    Set versions = $ListBuild(
+        "1.3.0",
+        "1.2.3+build",
+        "2.3.1",
+        "1.2.4",
+        "1.2.3",
+        "1.2.3-alpha+build"
+    )
+    Set versions = ##class(%SYS.Python).ToList(versions)
+
+    Set expected = $ListBuild(
+        "1.2.3-alpha+build",
+        "1.2.3",
+        "1.2.3+build",
+        "1.2.4",
+        "1.3.0",
+        "2.3.1"
+    )
+    Set expected = ##class(%SYS.Python).ToList(expected)
+    Set output = ##class(%IPM.Utils.EmbeddedPython).SortVersions(versions)
+    Do ..AssertPythonListsEqual(output, expected)
+
+    Set expected = builtins.list(builtins.reversed(expected))
+    Set output = ##class(%IPM.Utils.EmbeddedPython).SortVersions(versions, 1)
+    Do ..AssertPythonListsEqual(output, expected)
+}
+
 Method TestSortOCITags()
 {
     Set builtins = ##class(%SYS.Python).Builtins()

--- a/tests/unit_tests/Test/PM/Unit/EmbeddedPython.cls
+++ b/tests/unit_tests/Test/PM/Unit/EmbeddedPython.cls
@@ -1,0 +1,82 @@
+Class Test.PM.Unit.EmbeddedPython Extends %UnitTest.TestCase
+{
+
+Method TestCompareVersionTotalOrder()
+{
+    // format: (ver1, ver2, result), where result = 0 if ver1 = ver2; result = -1 if ver1 < ver2; result = 1 if ver1 > ver2
+    Set list = $ListBuild(
+        $ListBuild("1.2.3-alpha+build", "1.2.3-alpha+build", 0),
+        $ListBuild("1.2.3", "1.2.3-alpha+build", 1),
+        $ListBuild("1.2.3-alpha+build", "1.2.3+build", -1),
+        $ListBuild("1.2.3-alpha+build", "4.5.6+build", -1),
+        $ListBuild("4.5.6", "4.5.6+build", -1)
+    )
+
+    Set ptr = 0
+    While $ListNext(list, ptr, tuple) {
+        Set $ListBuild(ver1, ver2, expected) = tuple
+        For reverse = 0, 1 {
+            If reverse {
+                Set $Listbuild(ver2, ver1, expected) = $Listbuild(ver1, ver2, -expected)
+            }
+
+            Set output = ##class(%IPM.Utils.EmbeddedPython).CompareVersionTotalOrder(ver1, ver2)
+            If '$$$AssertEquals(output, expected) {
+                Do $$$LogMessage("Failed for "_ver1_" and "_ver2_" with expected "_expected_" but got "_output)
+            }
+        }
+    }
+}
+
+Method TestSortOCITags()
+{
+    Set builtins = ##class(%SYS.Python).Builtins()
+
+    Set tags = $ListBuild(
+        "4.5.6_build", 
+        "1.2.3-alpha_build__2024.1", 
+        "1.0.0_build__2024.2", 
+        "4.5.6",
+        "1.0.0-alpha_build__2024.2"
+    )
+    Set tags = ##class(%SYS.Python).ToList(tags)
+
+    Set expected = $ListBuild(
+        "1.0.0-alpha_build__2024.2",
+        "1.0.0_build__2024.2",
+        "1.2.3-alpha_build__2024.1",
+        "4.5.6",
+        "4.5.6_build"
+    )
+    Set expected = ##class(%SYS.Python).ToList(expected)
+
+    Set output = ##class(%IPM.Utils.EmbeddedPython).SortOCITags(tags)
+    If '..AssertPythonListsEqual(output, expected) {
+        Do $$$LogMessage("Failed for ascending order. Expected: "_..FromPythonList(expected)_" but got: "_..FromPythonList(output))
+    }
+
+    Set expected = builtins.list(builtins.reversed(expected))
+
+    Set output = ##class(%IPM.Utils.EmbeddedPython).SortOCITags(tags, 1)
+    If '..AssertPythonListsEqual(output, expected) {
+        Do $$$LogMessage("Failed for descending order. Expected: "_..FromPythonList(expected)_" but got: "_..FromPythonList(output))
+    }
+}
+
+ClassMethod FromPythonList(list As %SYS.Python) As %List
+{
+    Set output = ""
+    For i = 0:1:list."__len__"()-1 {
+       Set output = output _ $ListBuild(list."__getitem__"(i))
+    }
+    Return output
+}
+
+Method AssertPythonListsEqual(list1 As %SYS.Python, list2 As %SYS.Python) As %Boolean
+{
+    Set list1 = ..FromPythonList(list1)
+    Set list2 = ..FromPythonList(list2)
+    Return $$$AssertEquals(list1, list2)
+}
+
+}


### PR DESCRIPTION
Fix #766 
* Sort ORAS image tags correctly such that `list-modules` shows the highest version number by default
* Support `-skip-reload` for `package` and `publish` so that module version won't be clobbered (useful when running after `module-action`)

