### PR TITLE
Make `package` part of `publish`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #754 Deployed items are now exported together into a single `studio-project/Deployed.xml` instead of individual `.deploy` files.
 - #756 External name of packages are now unqiue and can no longer conflict with the real name of another packages.
 - #751: Blue terminal output replaced with default (white)
-0 #769: Lifecycle phase `Package` is now run as part of `Publish`.
+- #769: Lifecycle phase `Package` is now run as part of `Publish`.
 
 ### Fixed
 - #474: When loading a .tgz/.tar.gz package, automatically locate the top-most module.xml in case there is nested directory structure (e.g., GitHub releases)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #754: Support publishing and installing deployed items for ORAS repository
 - #755: Added an `info` command which prints external name (optionally including the real name) of top-level packages without the `build` part of semver. 
 - #756: Support running commands using external names of packages.
-- #767: Allow skipping the reload phase when packaging and publishing, useful for packaging/publishing after running `module-version`
+- #769: Allow `publish <module> -only` to publish a module without running `reload`
 
 ### Changed
 - #702 Preload now happens as part of the new `Initialize` lifecycle phase. `zpm "<module> reload -only"` will no longer auto compile resources in `/preload` directory.
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #754 Deployed items are now exported together into a single `studio-project/Deployed.xml` instead of individual `.deploy` files.
 - #756 External name of packages are now unqiue and can no longer conflict with the real name of another packages.
 - #751: Blue terminal output replaced with default (white)
+0 #769: Lifecycle phase `Package` is now run as part of `Publish`.
 
 ### Fixed
 - #474: When loading a .tgz/.tar.gz package, automatically locate the top-most module.xml in case there is nested directory structure (e.g., GitHub releases)

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -1296,6 +1296,11 @@ Method %Publish(ByRef pParams) As %Status
 {
 	Set tSC = $$$OK
 	Try {
+		// Perform the "Package" phase to prepare the module for publishing
+		$$$ThrowOnError(..OnBeforePhase("Package", .pParams))
+		$$$ThrowOnError(..%Package(.pParams))
+		$$$ThrowOnError(..OnAfterPhase("Package", .pParams))
+
 		Set tVerbose = $Get(pParams("Verbose"))
 		Set tRelease = $Get(pParams("Release"),$Get(pParams("zpm","Release"),0))
 		Set tPublishTo = $Get(pParams("PublishTo"),$Get(pParams("zpm","PublishTo"),""))

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -121,7 +121,6 @@ This command is an alias for `module-action module-name package`
 <parameter name="module" required="true" description="Name of module on which to perform package actions" />
 <modifier name="path" aliases="p" dataAlias="Path" value="true" description="the specified path to export package." />
 <modifier name="export-deps" value="true" valueList="0,1" dataAlias="ExportDependencies" description="If specified, controls whether dependencies are exported. If omitted, defaults to the value of the #EXPORTDEPENDENCIES in lifecycle class. This modifier is only used in &quot;Package&quot; and &quot;Publish&quot; lifecycles." />
-<modifier name="skip-reload" dataAlias="SkipPhases" dataValue="reload" description="Skip the 'Reload' lifecycle phase before publishing" />
 </command>
 
 <command name="verify" dataPrefix="D">
@@ -138,7 +137,6 @@ This command is an alias for `module-action module-name publish`
 <parameter name="module" required="true" description="Name of module on which to perform publish actions" />
 <modifier name="repo" aliases="r" dataAlias="PublishTo" description="Namespace-unique name for the module to publish to (if deployment is enabled)" />
 <modifier name="use-external-name" aliases="use-ext" dataAlias="UseExternalName" dataValue="1" description="Publish the package under the &lt;ExternalName&gt; of the package. If ExternalName is unspecified or illegal, an error will be thrown."/>
-<modifier name="skip-reload" dataAlias="SkipPhases" dataValue="reload" description="Skip the 'Reload' lifecycle phase before publishing" />
 </command>
 
 <command name="makedeployed">

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -274,33 +274,12 @@ ClassMethod ExecutePhases(pModuleName As %String, pPhases As %List, pIsComplete 
   
 		If pIsComplete {
 			Set tPhases = tLifecycle.GetCompletePhases(pPhases)
-			If ($ListFind(tPhases, "Package") && tModule.HaveToDeploy()) {
+			If (($ListFind(tPhases, "Package") || $ListFind(tPhases, "Publish")) && tModule.HaveToDeploy()) {
 				Set tPhases = $ListBuild("PrepareDeploy") _ tPhases
 			}
-		} ElseIf pPhases = $ListBuild("Publish") {
-			// 'Publish' depends on 'Package', so we need to at least run 'Package' first.
-			$$$ThrowStatus($$$ERROR($$$GeneralError,"'Publish' phase cannot be run with '-only'."))
 		} Else {
 			Set tPhases = $ListBuild(##class(%IPM.Lifecycle.Base).MatchSinglePhase($LISTTOSTRING(pPhases)))
 		}
-
-		// Skip the phases specified in pParams("SkipPhases")
-		Set skipPhases = $ListFromString($Get(pParams("SkipPhases")))
-		Set ptr = 0
-		While $ListNext(skipPhases, ptr, phase) {
-			Set phase = ##class(%IPM.Lifecycle.Base).MatchSinglePhase(phase)
-			Set skipPhases(phase) = ""
-		}
-		Set ptr = 0
-
-		Set tFilteredPhases = ""
-		While $ListNext(tPhases, ptr, phase) {
-			If $Data(skipPhases(phase)) {
-				Continue
-			}
-			Set tFilteredPhases = tFilteredPhases_ $ListBuild(phase)
-		}
-		Set tPhases = tFilteredPhases
 		
 		// Lifecycle-provided default parameters
 		Do tLifecycle.GetDefaultParameters(.tParams, tPhases)

--- a/tests/integration_tests/Test/PM/Integration/OrasVersionAnnotations.cls
+++ b/tests/integration_tests/Test/PM/Integration/OrasVersionAnnotations.cls
@@ -34,7 +34,7 @@ Method TestOrasVersionAnnotations()
 
     Do ..AssertVersion(..#UpdatedVersion)
 
-    Set sc = ##class(%IPM.Main).Shell("publish "_..#Module_" -r oras -verbose -skip-reload")
+    Set sc = ##class(%IPM.Main).Shell("publish "_..#Module_" -r oras -verbose -only")
     Do $$$AssertStatusOK(sc,"Published module successfully")
 
     Do ..AssertVersion(..#UpdatedVersion)


### PR DESCRIPTION
Catch up fix to #767; Implement #769 

With this change, `%Package` is part of `%Publish` and will be called during `publish <module> -only`. This allows publishing the package without running `%Reload` phase. 