### PR TITLE
fix: http repo setup miscellany

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HSIEO-12012: Publishing modules with deployed code only run PrepareDeploy phase if module is in dev mode.
 - #782: Installer no longer includes unit tests
 - #781: Addressing an issue where file paths exceed 256 characters
+- #787: Publishing/unpublishing to remote registry broken
+- #649: Clear existing credentials when changing URL on remote HTTP registry
+- Reduced timeout when checking HTTP registry availability (fails faster rather than hanging for a long time and then failing)
 
 ## [0.9.2] - 2025-02-24
 

--- a/src/cls/IPM/Repo/Http/PackageService.cls
+++ b/src/cls/IPM/Repo/Http/PackageService.cls
@@ -13,7 +13,7 @@ Property Password As %String(MAXLEN = "");
 
 Property Token As %String(MAXLEN = "");
 
-Property TokenAuthMethod As %Boolean [ InitialExpression = 0 ];
+Property TokenAuthMethod As %Boolean [ InitialExpression = "apiKey" ];
 
 ClassMethod GetSSLConfiguration(name As %String) As %String
 {
@@ -68,7 +68,7 @@ Method GetHttpRequest(tLocation As %IPM.DataType.RepoLocation = {..Location}) As
 		If (..Token '= "") {
 			If ..TokenAuthMethod = "basic"{
 				Do tRequest.SetHeader("Authorization","Basic " _ ..Token)
-			} ElseIf ..TokenAuthMethod = "apiKey" {
+			} ElseIf (..TokenAuthMethod = "apiKey") || (..TokenAuthMethod = "") {
 				Do tRequest.SetHeader("apikey",..Token)
 			} ElseIf ..TokenAuthMethod = "bearer" {
 				Do tRequest.SetHeader("Authorization","Bearer " _ ..Token)

--- a/src/cls/IPM/Repo/Oras/Definition.cls
+++ b/src/cls/IPM/Repo/Oras/Definition.cls
@@ -54,6 +54,7 @@ Method GetPublishService() As %IPM.Repo.IPublishService
 	Set tClient.Username = ..Username
 	Set tClient.Password = ..Password
 	Set tClient.Token = ..Token
+	Set tClient.TokenAuthMethod = ..TokenAuthMethod
 	Quit tClient
 }
 

--- a/src/cls/IPM/Repo/Remote/Definition.cls
+++ b/src/cls/IPM/Repo/Remote/Definition.cls
@@ -52,6 +52,7 @@ Method GetPublishService() As %IPM.Repo.IPublishService
 	Set tClient.Username = ..Username
 	Set tClient.Password = ..Password
 	Set tClient.Token = ..Token
+	Set tClient.TokenAuthMethod = ..TokenAuthMethod
 	Quit tClient
 }
 
@@ -70,6 +71,13 @@ ClassMethod OnConfigure(pInstance As %IPM.Repo.Definition, pInteractive As %Bool
 			If (tResponse '= $$$SuccessResponse) {
 				$$$ThrowStatus($$$ERROR($$$GeneralError, "Operation cancelled."))
 			}
+		}
+		
+		If ( $$$lcase(tUrl) '= $$$lcase(pInstance.URL) ) {
+			// when repo URL changing - clear all existing credentials
+			Set pInstance.Username = ""
+			Set pInstance.Password = ""
+			Set pInstance.Token = ""
 		}
 		
 		If $Data(pModifiers("username"), tUsername) {

--- a/src/cls/IPM/Repo/Remote/PackageService.cls
+++ b/src/cls/IPM/Repo/Remote/PackageService.cls
@@ -266,7 +266,7 @@ Method IsAvailable() As %Boolean
   Set tAvailable = 0
   Set tRequest = ..GetHttpRequest()
   
-  Set tRequest.Timeout = 30
+  Set tRequest.Timeout = 3
   Set tSC = tRequest.Get($$$URLENCODE(tRequest.Location_"_ping"))
   If $$$ISOK(tSC), tRequest.HttpResponse.StatusCode = 401 {
      $$$ThrowStatus($$$ERROR($$$GeneralError, "Registry "_..Location_": authorization required."))

--- a/src/cls/IPM/Repo/Remote/PackageService.cls
+++ b/src/cls/IPM/Repo/Remote/PackageService.cls
@@ -266,6 +266,10 @@ Method IsAvailable() As %Boolean
   Set tAvailable = 0
   Set tRequest = ..GetHttpRequest()
   
+  // The three second timeout here is somewhat arbitrary, but reasonable:
+  // a well-behaving/stable registry will certainly respond within that time,
+  // and an unhealthy registry shouldn't be given e.g. 30 seconds (the default)
+  // which more likely indicates a setup issue on the client, like using the wrong URL.
   Set tRequest.Timeout = 3
   Set tSC = tRequest.Get($$$URLENCODE(tRequest.Location_"_ping"))
   If $$$ISOK(tSC), tRequest.HttpResponse.StatusCode = 401 {


### PR DESCRIPTION
Particularly, consistency around TokenAuthMethod that was breaking key legacy registry use cases. Also carries over #649 (closely related) to main.

Fixes #649 
Fixes #787 