### PR TITLE
Fix 786: Resources with scope should not be exported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HSIEO-12012: Publishing modules with deployed code only run PrepareDeploy phase if module is in dev mode.
 - #782: Installer no longer includes unit tests
 - #781: Addressing an issue where file paths exceed 256 characters
+- #786: Resources with scope should not be exported
 
 ## [0.9.2] - 2025-02-24
 

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -1770,9 +1770,7 @@ Method ExportSingleModule(ByRef pResourceArray, ByRef pTargetDirectory As %Strin
 			Merge tItemParams = pResourceArray(tFullResourceName)
 			Set tItemHandled = 0
 			Set tSC = tProcessor.OnExportItem(tFullPath,tFullResourceName,.tItemParams,.pParams,.tItemHandled)
-			If $$$ISERR(tSC) {
-				Quit
-			}
+			$$$ThrowOnError(tSC)
 			If tItemHandled {
 				Continue
 			}
@@ -1780,18 +1778,16 @@ Method ExportSingleModule(ByRef pResourceArray, ByRef pTargetDirectory As %Strin
 		If ($Extract(tFullResourceName) = "/") {
 			// Resources with paths are relative to the module root and are simply copied to the export directory.
 			Set tModule = ##class(%IPM.Storage.Module).NameOpen(tSrcModule,,.tSC)
-			If $$$ISERR(tSC) {
-				Quit
-			}
+			$$$ThrowOnError(tSC)
 			
 			If (tModule.Root = "") {
 				Set tSC = $$$ERROR($$$GeneralError,$$$FormatText("No module root configured for '%1'",tSrcModule))
-				Quit
+				$$$ThrowOnError(tSC)
 			}
 			
 			If '##class(%File).DirectoryExists(tModule.Root) {
 				Set tSC = $$$ERROR($$$GeneralError,$$$FormatText("Directory %2, listed as root for module '%1', does not exist.",tSrcModule,tModule.Root))
-				Quit
+				$$$ThrowOnError(tSC)
 			}
 			
 			Set tSourcePath = ##class(%File).NormalizeFilename(tModule.Root_tFullResourceName)
@@ -1805,7 +1801,7 @@ Method ExportSingleModule(ByRef pResourceArray, ByRef pTargetDirectory As %Strin
 				If 'tGood {
 					Set tLastErr = $Get(%objlasterror)
 					Set tSC = $$$EMBEDSC($$$ERROR($$$GeneralError,$$$FormatText("Error creating directory '%1': %2",tDirectory,tReturn)),tLastErr)
-					Quit
+					$$$ThrowOnError(tSC)
 				}
 				Write:pVerbose !,"Created ",tDirectory
 			}
@@ -1814,15 +1810,13 @@ Method ExportSingleModule(ByRef pResourceArray, ByRef pTargetDirectory As %Strin
 				Set tSourcePath = ##class(%File).NormalizeDirectory(tSourcePath)
 				Set tExportPath = ##class(%File).NormalizeDirectory(tExportPath)
 				Set tSC = ##class(%IPM.Utils.File).CopyDir(tSourcePath,tExportPath, , pVerbose)
-				If $$$ISERR(tSC) {
-					Quit
-				}
+				$$$ThrowOnError(tSC)
 				Write:pVerbose !,tSourcePath," -> ",tExportPath
 			} ElseIf ##class(%File).Exists(tSourcePath) {
 				Set tGood = ##class(%File).CopyFile(tSourcePath,tExportPath,1,.tReturn)
 				If 'tGood {
 					Set tSC = $$$ERROR($$$GeneralError,$$$FormatText("Error copying file '%1' to '%2': %3",tSourcePath,tExportPath,tReturn))
-					Quit
+					$$$ThrowOnError(tSC)
 				}
 				Write:pVerbose !,tSourcePath," -> ",tExportPath
 			}

--- a/src/cls/IPM/ResourceProcessor/Test.cls
+++ b/src/cls/IPM/ResourceProcessor/Test.cls
@@ -8,7 +8,7 @@ Parameter DESCRIPTION As STRING = "Loads unit tests (extending %UnitTest.TestCas
 Parameter ATTRIBUTES As STRING = "Phase,Package,Class,ManagerClass,Format,ExportFlags";
 
 /// Phase in which the unit tests run - "test" (dev namespace), "verify" (separate, clean namespace), or "test,verify" (to run in both cases).
-Property Phase As %String [ InitialExpression = "test", Required ];
+Property Phase As %IPM.DataType.ListOfOptions(VALUELIST = ",test,verify") [ InitialExpression = {$ListBuild("test")}, Required ];
 
 // NOTE: Either Package or Class MUST be defined.
 
@@ -83,7 +83,7 @@ Method TestsShouldRun(pPhase As %String, ByRef pParams) As %Boolean
 			// always equals 1
 		}
 	}
-	Quit tPathMatch && ($Find(..Phase,$ZConvert(pPhase,"L")) > 0)
+	Quit tPathMatch && ($ListFind(..Phase,$ZConvert(pPhase,"L")) > 0)
 }
 
 Method OnPhase(pPhase As %String, ByRef pParams, Output pResourceHandled As %Boolean = 0) As %Status
@@ -207,7 +207,7 @@ Method OnResolveChildren(ByRef pResourceArray) As %Status
 		Set tResourceInfo = tModuleName
 		Set tResourceInfo("Generated") = 0
 		Set tResourceInfo("Preload") = 0
-		Set tResourceInfo("Scope") = ..Phase
+		Set tResourceInfo("Scope") = $ListToString(..Phase, ",")
 		Set tResourceInfo("Deploy") = 0
 		Set tResourceInfo("Processor") = $This
 		Set tResourceInfo("UnitTest") = 1

--- a/src/cls/IPM/ResourceProcessor/Test.cls
+++ b/src/cls/IPM/ResourceProcessor/Test.cls
@@ -208,12 +208,15 @@ Method OnResolveChildren(ByRef pResourceArray) As %Status
 		Set tResourceInfo("Generated") = 0
 		Set tResourceInfo("Preload") = 0
 		Set tResourceInfo("Scope") = $ListToString(..Phase, ",")
+		zw tResourceInfo
+		break
 		Set tResourceInfo("Deploy") = 0
 		Set tResourceInfo("Processor") = $This
 		Set tResourceInfo("UnitTest") = 1
 		Set tResource = $Case(..Package '= "", 1: ..Package, : ..Class)_..Extension
 		$$$ThrowOnError(##class(%IPM.Storage.ResourceReference).GetChildren(tResource,tModuleName,1,.tResourceInfo,.pResourceArray))
 		$$$ThrowOnError(..EmbeddedProcessor.OnResolveChildren(.pResourceArray))
+		Merge pResourceArray = tResourceInfo
 	} Catch e {
 		Set tSC = e.AsStatus()
 	}

--- a/src/cls/IPM/ResourceProcessor/Test.cls
+++ b/src/cls/IPM/ResourceProcessor/Test.cls
@@ -208,8 +208,6 @@ Method OnResolveChildren(ByRef pResourceArray) As %Status
 		Set tResourceInfo("Generated") = 0
 		Set tResourceInfo("Preload") = 0
 		Set tResourceInfo("Scope") = $ListToString(..Phase, ",")
-		zw tResourceInfo
-		break
 		Set tResourceInfo("Deploy") = 0
 		Set tResourceInfo("Processor") = $This
 		Set tResourceInfo("UnitTest") = 1

--- a/src/cls/IPM/ResourceProcessor/Test.cls
+++ b/src/cls/IPM/ResourceProcessor/Test.cls
@@ -8,7 +8,7 @@ Parameter DESCRIPTION As STRING = "Loads unit tests (extending %UnitTest.TestCas
 Parameter ATTRIBUTES As STRING = "Phase,Package,Class,ManagerClass,Format,ExportFlags";
 
 /// Phase in which the unit tests run - "test" (dev namespace), "verify" (separate, clean namespace), or "test,verify" (to run in both cases).
-Property Phase As %IPM.DataType.ListOfOptions(VALUELIST = ",test,verify") [ InitialExpression = {$ListBuild("test")}, Required ];
+Property Phase As %String [ InitialExpression = "test", Required ];
 
 // NOTE: Either Package or Class MUST be defined.
 
@@ -83,7 +83,7 @@ Method TestsShouldRun(pPhase As %String, ByRef pParams) As %Boolean
 			// always equals 1
 		}
 	}
-	Quit tPathMatch && ($ListFind(..Phase,$ZConvert(pPhase,"L")) > 0)
+	Quit tPathMatch && ($Find(..Phase,$ZConvert(pPhase,"L")) > 0)
 }
 
 Method OnPhase(pPhase As %String, ByRef pParams, Output pResourceHandled As %Boolean = 0) As %Status

--- a/src/cls/IPM/ResourceProcessor/Test.cls
+++ b/src/cls/IPM/ResourceProcessor/Test.cls
@@ -207,7 +207,7 @@ Method OnResolveChildren(ByRef pResourceArray) As %Status
 		Set tResourceInfo = tModuleName
 		Set tResourceInfo("Generated") = 0
 		Set tResourceInfo("Preload") = 0
-		Set tResourceInfo("Scope") = $ListToString(..Phase, ",")
+		Set tResourceInfo("Scope") = ..Phase
 		Set tResourceInfo("Deploy") = 0
 		Set tResourceInfo("Processor") = $This
 		Set tResourceInfo("UnitTest") = 1

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -1016,7 +1016,8 @@ Method GetResolvedReferences(Output pReferenceArray, pLockedDependencies As %Boo
 			#dim tResource As %IPM.Storage.ResourceReference
 			Set tResource = ..Resources.GetNext(.tKey)
 			Quit:tKey=""
-			If '..HasScope(pPhases,tResource.Scope) {
+			Set tPhases = tResource.Attributes.GetAt("Phase")
+			If ('..HasScope(pPhases,tResource.Scope)) || ('..HasScope(pPhases,$Piece(tPhases, ",", 1))) || ('..HasScope(pPhases,$Piece(tPhases, ",", 2))) {
 				Continue
 			}
 			

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -552,12 +552,8 @@ ClassMethod HasScope(pPhases As %List, pScope As %String) [ Private ]
 	Set tPhases = $ZConvert(pPhases, "L")
 	If $ListValid(pScope) {
 		// Iterate through each item in pScope list
-		Set i = 0
-		For {
-			Set i = $ListNext(pScope, i, scopeItem)
-			If i = 0 {
-				Return 0
-			}
+		Set pointer = 0
+		While $ListNext(pScope, pointer, scopeItem) {
 			If $ListFind(tPhases, $ZConvert(scopeItem, "L")) {
 				Return 1
 			}
@@ -1032,7 +1028,6 @@ Method GetResolvedReferences(Output pReferenceArray, pLockedDependencies As %Boo
 			#dim tResource As %IPM.Storage.ResourceReference
 			Set tResource = ..Resources.GetNext(.tKey)
 			Quit:tKey=""
-			Set tPhases = tResource.Attributes.GetAt("Phase")
 			If '..HasScope(pPhases,tResource.Scope) {
 				Continue
 			}

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -549,20 +549,24 @@ ClassMethod HasScope(pPhases As %List, pScope As %String) [ Private ]
 	If (pScope = "") {
 		Quit 1
 	}
-	Set tPhases = $zcvt(pPhases,"L")
-	// If pScope contains a comma, treat it as a comma-separated list
-    If $Find(pScope, ",") {
-        For i = 1:1:$Length(pScope, ",") {
-            Set scopeItem = $ZConvert($Piece(pScope, ",", i), "L")
-            If $ListFind(tPhases, scopeItem) {
+	Set tPhases = $ZConvert(pPhases, "L")
+	If $ListValid(pScope) {
+		// Iterate through each item in pScope list
+		Set i = 0
+		For {
+			Set i = $ListNext(pScope, i, scopeItem)
+			If i = 0 {
+				Return 0
+			}
+			If $ListFind(tPhases, $ZConvert(scopeItem, "L")) {
 				Return 1
-            }
-        }
-        Quit 0
-    }
-    // If not a list, treat it as a single item
-    Set pScope = $ZConvert(pScope, "L")
-    Quit $ListFind(tPhases, pScope) > 0
+			}
+		}
+		Quit 0
+	}
+	// Single string
+	Set scopeItem = $ZConvert(pScope, "L")
+	Quit $ListFind(tPhases, scopeItem) > 0
 }
 
 Method LoadDependencies(pPhaseList As %List, ByRef pParams) As %Status
@@ -1029,14 +1033,15 @@ Method GetResolvedReferences(Output pReferenceArray, pLockedDependencies As %Boo
 			Set tResource = ..Resources.GetNext(.tKey)
 			Quit:tKey=""
 			Set tPhases = tResource.Attributes.GetAt("Phase")
-			If ('..HasScope(pPhases,tResource.Scope)) || ('..HasScope(pPhases,tPhases)) {
+			If '..HasScope(pPhases,tResource.Scope) {
 				Continue
 			}
 			
 			kill tempArray
 			Set tSC = tResource.ResolveChildren(.tempArray)
-			Set Scope = $Get(tempArray("Scope"))
-			If (Scope = "") || ..HasScope(pPhases, Scope) {
+			Set resourceScope = tResource.Scope
+			Set attrScope = $Get(tempArray("Scope"))
+			If ..HasScope(pPhases, resourceScope) && ..HasScope(pPhases, attrScope) {
 				Merge pReferenceArray(..Name) = tempArray
 			}
 			If $$$ISERR(tSC) {

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -550,7 +550,19 @@ ClassMethod HasScope(pPhases As %List, pScope As %String) [ Private ]
 		Quit 1
 	}
 	Set tPhases = $zcvt(pPhases,"L")
-	Quit $ListFind(tPhases,pScope)
+	// If pScope contains a comma, treat it as a comma-separated list
+    If $Find(pScope, ",") {
+        For i = 1:1:$Length(pScope, ",") {
+            Set scopeItem = $ZConvert($Piece(pScope, ",", i), "L")
+            If $ListFind(tPhases, scopeItem) {
+				Return 1
+            }
+        }
+        Quit 0
+    }
+    // If not a list, treat it as a single item
+    Set pScope = $ZConvert(pScope, "L")
+    Quit $ListFind(tPhases, pScope) > 0
 }
 
 Method LoadDependencies(pPhaseList As %List, ByRef pParams) As %Status
@@ -1017,13 +1029,16 @@ Method GetResolvedReferences(Output pReferenceArray, pLockedDependencies As %Boo
 			Set tResource = ..Resources.GetNext(.tKey)
 			Quit:tKey=""
 			Set tPhases = tResource.Attributes.GetAt("Phase")
-			If ('..HasScope(pPhases,tResource.Scope)) || ('..HasScope(pPhases,$Piece(tPhases, ",", 1))) || ('..HasScope(pPhases,$Piece(tPhases, ",", 2))) {
+			If ('..HasScope(pPhases,tResource.Scope)) || ('..HasScope(pPhases,tPhases)) {
 				Continue
 			}
 			
 			kill tempArray
 			Set tSC = tResource.ResolveChildren(.tempArray)
-			Merge pReferenceArray(..Name) = tempArray
+			Set Scope = $Get(tempArray("Scope"))
+			If (Scope = "") || ..HasScope(pPhases, Scope) {
+				Merge pReferenceArray(..Name) = tempArray
+			}
 			If $$$ISERR(tSC) {
 				Quit
 			}


### PR DESCRIPTION
Fix for issue 786:

Resources with phase and scope are being exported even though they should not.

The following changes should be addressed:

Adding throw on error to %IPM.Lifecycle.Base ExportSingleModule() to avoid silently failing
In %IPM.Storage.Module GetResolvedReferences() adding check to tResource.Attributes.GetAt(“Phase”) to not include resource for export if there is a phase (in addition to scope checking)
In %IPM.ResourceProcessor.Test change Phase property to be a comma separated string instead of a List because it is not necessary to be a list