### PR TITLE
chore(ci): skip latest-preview for now

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -29,9 +29,13 @@ jobs:
             tags=$(curl -su ":" https://containers.intersystems.com/v2/intersystems/${n}/tags/list | jq -r '.tags[]' | awk '!/(-linux)|([1-4]-preview)|(-em)|(-cd)/' | awk '!/\.[1-4]\./' | sort | uniq)
             for tag in $tags
             do
-              # Skip irishealth-community due to bad interaction with ZPM document type
-              # Also skip 2023.2 because the license has expired
+              # Skip 2023.3 and 2023.2 because the license has expired
               if [ "$tag" = "2023.3" -o "$tag" = "2023.2" ];
+                then
+                  continue
+              fi
+              # Skip latest-preview due to #778
+              if [ "$tag" = "latest-preview" ];
                 then
                   continue
               fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.1] - 2024-04-24
 
 ### Fixed
-- #797 DetectPipCaller now correctly uses Python Runtime Library path from IRIS cpf if defined
+- #797 Windows: IPM now uses the Python Runtime Library path from iris.cpf if defined
 
 ## [0.10.0] - 2025-04-16
 


### PR DESCRIPTION
Likely related to but does not fix #778 

Will need to re-release 0.10.1 after merging to have CI create artifacts + really publish