### PR TITLE
Fix: make CI pass on 2025.2

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -34,11 +34,6 @@ jobs:
                 then
                   continue
               fi
-              # Skip latest-preview due to #778
-              if [ "$tag" = "latest-preview" ];
-                then
-                  continue
-              fi
               images+='"'${n}:${tag}'",';
             done
           done;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - Unreleased
+
+### Fixed
+- #778 CI - avoid deadlock on 2025.2 preview due to cached query regeneration bug
+
 ## [0.10.1] - 2024-04-24
 
 ### Fixed

--- a/iris.script
+++ b/iris.script
@@ -2,6 +2,7 @@
   do $System.OBJ.Load("/home/irisowner/zpm/preload/cls/IPM/Installer.cls","ck")
   do ##class(IPM.Installer).setup("/home/irisowner/zpm/",3)
   zpm "repo -r -name registry -url https://pm.community.intersystems.com/"
+  do $System.SQL.PurgeAllNamespaces()
   halt
 
   // Currently broken for %IPM due to differing default behavior for packages starting with % - vscode-per-namespace-settings passes through as-is, IPM expects to strip %.

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="Cache" version="25">
 <Document name="ZPM.ZPM"><Module>
   <Name>ZPM</Name>
-  <Version>0.10.1-SNAPSHOT</Version>
+  <Version>0.10.2-SNAPSHOT</Version>
   <ExternalName>IPM</ExternalName>
   <Description>InterSystems Package Manager (IPM) provides development tools and infrastructure for defining, building, distributing, and installing modules and applications.</Description>
   <Keywords>Package Manager</Keywords>


### PR DESCRIPTION
Fixes #778 

Solution (in theory) is just to purge cached queries so we aren't stuck with stale queries in the container when it boots.