### PR TITLE
Fix issue 816: zpm "install" command not pulling specified versions of artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - #778 CI - avoid deadlock on 2025.2 preview due to cached query regeneration bug
+- #816 Fixed zpm "install" command not pulling specified versions of artifacts
 
 ## [0.10.1] - 2024-04-24
 

--- a/src/cls/IPM/General/SemanticVersionExpression/Comparator.cls
+++ b/src/cls/IPM/General/SemanticVersionExpression/Comparator.cls
@@ -92,6 +92,10 @@ Method Evaluate(pVersion As %IPM.General.SemanticVersion) As %Boolean
       Quit:((val1 = "*")||(val2 = "*"))
       Set tEquals = tEquals && (val1 = val2)
     }
+	// Compare build if both versions specify it
+  	If (pVersion.Build '= "") && (..Build '= "") {
+    	Set tEquals = tEquals && (pVersion.Build = ..Build)
+  	}
   }
 	If (+##class(%IPM.Repo.UniversalSettings).GetValue("SemVerPostRelease") = 0) || ($Extract(..Operator,1) = "=")  {
 		// If SemVerPostRelease is disabled, then we should not consider post-release versions as equal to the base version

--- a/src/cls/IPM/General/SemanticVersionExpression/Comparator.cls
+++ b/src/cls/IPM/General/SemanticVersionExpression/Comparator.cls
@@ -85,7 +85,7 @@ Method Evaluate(pVersion As %IPM.General.SemanticVersion) As %Boolean
 {
 	Set tEquals = (..Operator [ "=")
   If tEquals {
-    For part = "Major", "Minor", "Patch", "Prerelease" {
+    For part = "Major", "Minor", "Patch", "Prerelease", "Build" {
       Set val1 = $Property(pVersion, part)
       Set val2 = $Property($this, part)
       Quit:((val1 = "")||(val2 = ""))

--- a/src/cls/IPM/Repo/Oras/PackageService.cls
+++ b/src/cls/IPM/Repo/Oras/PackageService.cls
@@ -91,6 +91,9 @@ ClassMethod AggregatePlatformVersions(tagsList As %List, Output aggregatedPlatfo
 	Return ##class(%IPM.Utils.EmbeddedPython).FromPythonList(sortedTags)
 }
 
+/// <var>allTagsString</var> is as returned by <method>GetAllTagsPy</method> (comma + space separated)
+/// <var>moduleList</var> is a list of objects of type <class>%IPM.Storage.ModuleInfo</class> to which this method adds entries
+/// <var>name</var> is the name of the package for which we are enumerating versions
 Method ListModulesFromTagString(allTagsString As %String, semverExpr As %IPM.General.SemanticVersionExpression, client As %SYS.Python, moduleList As %ListOfObjects, searchCriteria As %IPM.Repo.SearchCriteria, name As %String)
 {
 	Set allVersionsList = ..AggregatePlatformVersions($ListFromString(allTagsString, ", "), .aggregatedPlatformVersion)
@@ -102,19 +105,9 @@ Method ListModulesFromTagString(allTagsString As %String, semverExpr As %IPM.Gen
 			Continue
 		}
 
-		// If build metadata is provided in the version expression, require exact match
-		If (semverExpr.Options.Count() > 0) {
-			#dim range As %IPM.General.SemanticVersionExpression.Range
-			Set range = semverExpr.Options.GetAt(1)
-			If range.Comparators.Count() > 0 {
-				#dim comp As %IPM.General.SemanticVersionExpression.Comparator
-				Set comp = range.Comparators.GetAt(1)
-				If comp.Build '= "" {
-					If tVersion.Build '= comp.Build {
-						Continue
-					}
-				}
-			}
+		#; Special case: if we provided an explicit build number, require it.
+		If ##class(%IPM.General.SemanticVersion).IsValid(searchCriteria.VersionExpression,.specificVersion) && (specificVersion.Build '= "") && (specificVersion.Build '= tVersion.Build) {
+			Continue
 		}
 
 		// If there are multiple platform versions for a given package version, we only want to use the metadata of one of them
@@ -134,7 +127,7 @@ Method ListModulesFromTagString(allTagsString As %String, semverExpr As %IPM.Gen
 		// `artifactMetadata.ImageTitle` can be different from `name`. E.g., when the module was simply "moved" from elsewhere under a different name.
 		Set tModRef.Name = name
 		// `artifactMetadata.ImageVersion` can be different from `moduleVersion`. E.g., when the module was simply "moved" from elsewhere under a different tag
-		Set tModRef.VersionString = moduleVersion 
+		Set tModRef.VersionString = tVersion.ToString()
 		Set tModRef.Repository = artifactMetadata.ImageSource
 		Set tModRef.Description = artifactMetadata.ImageDescription
 		Set tModRef.Deployed = artifactMetadata.IPMDeployed
@@ -144,12 +137,18 @@ Method ListModulesFromTagString(allTagsString As %String, semverExpr As %IPM.Gen
 				$$$ThrowOnError(tModRef.PlatformVersions.Insert(pv))
 			}
 		}
-		Set tModRef.AllVersions = allTagsString
+		If searchCriteria.AllVersions {
+			// TODO: Convert these to semvers. This is just for display so OK not to for now.
+			Set tModRef.AllVersions = allTagsString
+		}
 		Set tModRef.Origin = artifactMetadata.IPMOrigin
 		Do moduleList.Insert(tModRef)
 
-		#; If not all versions are requested, return the latest one
-		If 'searchCriteria.AllVersions, name="" {
+		If searchCriteria.AllVersions '= "" {
+			// This is a tri-state.
+			// 0: don't show them.
+			// 1: do show them
+			// empty: we're resolving dependencies so DON'T QUIT.
 			Quit
 		}
 	}
@@ -209,11 +208,12 @@ Method ListModules(pSearchCriteria As %IPM.Repo.SearchCriteria) As %ListOfObject
 			}
 			#; get all versions
 			Set allTagsString = ..GetAllTagsPy(..Location, package, "", client)
-			Do ..ListModulesFromTagString(allTagsString, tVersionExpression, client, tList, pSearchCriteria, name)
+			Do ..ListModulesFromTagString(allTagsString, tVersionExpression, client, tList, pSearchCriteria, package)
 		}
 		Return tList
 	}
 
+	// TODO: Make this work properly for the case where name is empty (searching in a repo with a namespace)
 	Set allTagsString = ..GetAllTagsPy(..Location, name, "", client)
 	Do ..ListModulesFromTagString(allTagsString, tVersionExpression, client, tList, pSearchCriteria, name)
 	Return tList

--- a/src/cls/IPM/Repo/Oras/PackageService.cls
+++ b/src/cls/IPM/Repo/Oras/PackageService.cls
@@ -91,9 +91,6 @@ ClassMethod AggregatePlatformVersions(tagsList As %List, Output aggregatedPlatfo
 	Return ##class(%IPM.Utils.EmbeddedPython).FromPythonList(sortedTags)
 }
 
-/// <var>allTagsString</var> is as returned by <method>GetAllTagsPy</method> (comma + space separated)
-/// <var>moduleList</var> is a list of objects of type <class>%IPM.Storage.ModuleInfo</class> to which this method adds entries
-/// <var>name</var> is the name of the package for which we are enumerating versions
 Method ListModulesFromTagString(allTagsString As %String, semverExpr As %IPM.General.SemanticVersionExpression, client As %SYS.Python, moduleList As %ListOfObjects, searchCriteria As %IPM.Repo.SearchCriteria, name As %String)
 {
 	Set allVersionsList = ..AggregatePlatformVersions($ListFromString(allTagsString, ", "), .aggregatedPlatformVersion)
@@ -105,9 +102,19 @@ Method ListModulesFromTagString(allTagsString As %String, semverExpr As %IPM.Gen
 			Continue
 		}
 
-		#; Special case: if we provided an explicit build number, require it.
-		If ##class(%IPM.General.SemanticVersion).IsValid(searchCriteria.VersionExpression,.specificVersion) && (specificVersion.Build '= "") && (specificVersion.Build '= tVersion.Build) {
-			Continue
+		// If build metadata is provided in the version expression, require exact match
+		If (semverExpr.Options.Count() > 0) {
+			#dim range As %IPM.General.SemanticVersionExpression.Range
+			Set range = semverExpr.Options.GetAt(1)
+			If range.Comparators.Count() > 0 {
+				#dim comp As %IPM.General.SemanticVersionExpression.Comparator
+				Set comp = range.Comparators.GetAt(1)
+				If comp.Build '= "" {
+					If tVersion.Build '= comp.Build {
+						Continue
+					}
+				}
+			}
 		}
 
 		// If there are multiple platform versions for a given package version, we only want to use the metadata of one of them
@@ -127,7 +134,7 @@ Method ListModulesFromTagString(allTagsString As %String, semverExpr As %IPM.Gen
 		// `artifactMetadata.ImageTitle` can be different from `name`. E.g., when the module was simply "moved" from elsewhere under a different name.
 		Set tModRef.Name = name
 		// `artifactMetadata.ImageVersion` can be different from `moduleVersion`. E.g., when the module was simply "moved" from elsewhere under a different tag
-		Set tModRef.VersionString = tVersion.ToString()
+		Set tModRef.VersionString = moduleVersion 
 		Set tModRef.Repository = artifactMetadata.ImageSource
 		Set tModRef.Description = artifactMetadata.ImageDescription
 		Set tModRef.Deployed = artifactMetadata.IPMDeployed
@@ -137,18 +144,12 @@ Method ListModulesFromTagString(allTagsString As %String, semverExpr As %IPM.Gen
 				$$$ThrowOnError(tModRef.PlatformVersions.Insert(pv))
 			}
 		}
-		If searchCriteria.AllVersions {
-			// TODO: Convert these to semvers. This is just for display so OK not to for now.
-			Set tModRef.AllVersions = allTagsString
-		}
+		Set tModRef.AllVersions = allTagsString
 		Set tModRef.Origin = artifactMetadata.IPMOrigin
 		Do moduleList.Insert(tModRef)
 
-		If searchCriteria.AllVersions '= "" {
-			// This is a tri-state.
-			// 0: don't show them.
-			// 1: do show them
-			// empty: we're resolving dependencies so DON'T QUIT.
+		#; If not all versions are requested, return the latest one
+		If 'searchCriteria.AllVersions, name="" {
 			Quit
 		}
 	}
@@ -208,12 +209,11 @@ Method ListModules(pSearchCriteria As %IPM.Repo.SearchCriteria) As %ListOfObject
 			}
 			#; get all versions
 			Set allTagsString = ..GetAllTagsPy(..Location, package, "", client)
-			Do ..ListModulesFromTagString(allTagsString, tVersionExpression, client, tList, pSearchCriteria, package)
+			Do ..ListModulesFromTagString(allTagsString, tVersionExpression, client, tList, pSearchCriteria, name)
 		}
 		Return tList
 	}
 
-	// TODO: Make this work properly for the case where name is empty (searching in a repo with a namespace)
 	Set allTagsString = ..GetAllTagsPy(..Location, name, "", client)
 	Do ..ListModulesFromTagString(allTagsString, tVersionExpression, client, tList, pSearchCriteria, name)
 	Return tList

--- a/tests/integration_tests/Test/PM/Integration/OrasVersionWithBuild.cls
+++ b/tests/integration_tests/Test/PM/Integration/OrasVersionWithBuild.cls
@@ -40,9 +40,14 @@ Method TestInstallSpecificBuildVersion()
     // Install the version with build explicitly
     Set sc = ##class(%IPM.Main).Shell("install oras/"_..#Module_" "_..#BuildVersion)
     Do $$$AssertStatusOK(sc, "Installed build version explicitly")
-
     // Verify correct version was installed
     Do ..AssertVersion(..#BuildVersion)
+
+    // Install without build specified
+    Do $$$AssertStatusOK(##class(%IPM.Main).Shell("uninstall "_..#Module))
+    Do $$$AssertStatusOK(##class(%IPM.Main).Shell("install oras/"_..#Module_" "_..#CleanVersion))
+    // Verify correct version was installed
+    Do ..AssertVersion(..#CleanVersion)
 
     // Clean up
     Do $$$AssertStatusOK(##class(%IPM.Main).Shell("repo -delete-all"))

--- a/tests/integration_tests/Test/PM/Integration/OrasVersionWithBuild.cls
+++ b/tests/integration_tests/Test/PM/Integration/OrasVersionWithBuild.cls
@@ -1,0 +1,66 @@
+Class Test.PM.Integration.OrasVersionWithBuild Extends Test.PM.Integration.Base
+{
+
+Parameter Folder = "oras-version-with-build";
+
+Parameter Module = "oras-version-with-build";
+
+Parameter BuildVersion = "1.0.0-prerelease+build";
+
+Parameter CleanVersion = "1.0.0-prerelease";
+
+Method TestInstallSpecificBuildVersion()
+{
+    // Load the module with build metadata
+    Set folder = ..GetModuleDir(..#Folder)
+    Set sc = ##class(%IPM.Main).Shell("load " _ folder)
+    Do $$$AssertStatusOK(sc, "Loaded module with build metadata")
+
+    // Set up ORAS registry
+    Do $$$AssertStatusOK(##class(%IPM.Main).Shell("repo -delete-all"))
+    Do $$$AssertStatusOK(##class(%IPM.Main).Shell("repo -o -name oras -url http://oras:5000 -publish 1"))
+
+    // Publish the build version
+    Do ..AssertVersion(..#BuildVersion)
+    Set sc = ##class(%IPM.Main).Shell("publish "_..#Module_" -r oras -verbose")
+    Do $$$AssertStatusOK(sc, "Published build metadata version")
+
+    // Modify the module version to clean version (same base, no build)
+    Set sc = ##class(%IPM.Main).Shell("modver "_..#Module_" "_..#CleanVersion_" -force")
+    Do $$$AssertStatusOK(sc, "Changed version to clean prerelease")
+
+    // Publish the clean version
+    Do ..AssertVersion(..#CleanVersion)
+    Set sc = ##class(%IPM.Main).Shell("publish "_..#Module_" -r oras -verbose -only")
+    Do $$$AssertStatusOK(sc, "Published clean prerelease version")
+
+    // Uninstall all local copies
+    Do $$$AssertStatusOK(##class(%IPM.Main).Shell("uninstall "_..#Module))
+
+    // Install the version with build explicitly
+    Set sc = ##class(%IPM.Main).Shell("install oras/"_..#Module_" "_..#BuildVersion)
+    Do $$$AssertStatusOK(sc, "Installed build version explicitly")
+
+    // Verify correct version was installed
+    Do ..AssertVersion(..#BuildVersion)
+
+    // Clean up
+    Do $$$AssertStatusOK(##class(%IPM.Main).Shell("repo -delete-all"))
+    Do $$$AssertStatusOK(##class(%IPM.Main).Shell("repo -reset-defaults"))
+}
+
+Method AssertVersion(ver As %String) As %Boolean
+{
+    Set query = "SELECT Name FROM %IPM_Storage.ModuleItem WHERE Name = ?"
+    Set rs = ##class(%SQL.Statement).%ExecDirect(, query, ..#Module)
+    If '$$$AssertTrue(rs.%Next(), "Module "_..#Module_" found in SQL") {
+        Return 0
+    }
+    Set module = ##class(%IPM.Storage.Module).NameOpen(rs.%Get("Name"))
+    If '$$$AssertNotEquals(module, "", "Module set") {
+        Return 0
+    }
+    Return $$$AssertEquals(module.VersionString, ver) && $$$AssertEquals(module.Version.ToString(), ver)
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/oras-version-with-build/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/oras-version-with-build/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="oras-version-with-build.ZPM">
+    <Module>
+      <Name>oras-version-with-build</Name>
+      <Version>1.0.0-prerelease+build</Version>
+      <Packaging>module</Packaging>
+    </Module>
+  </Document>
+</Export>


### PR DESCRIPTION
Fix issue 816 zpm "install" command not pulling specified versions of artifacts. Do so by matching on the exact build metadata in the version string if specified in the install command.