### PR TITLE
Fix: Selectively undeploying classes within a package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - #829: Fixed export of resources with null Directory attribute
 - #832: Fixed places that export to possibly-nonexistent directories by adding /createdirs (needed in 2025.2+)
-- #834: Fixed selectively undeploying classes within a package
+- #823: Fixed selectively undeploying classes within a package
 
 ## [0.10.2] - 2025-06-04
 
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #756: Support running commands using external names of packages.
 - #769: Allow `publish <module> -only` to publish a module without running `reload`
 - #533: External name changed to IPM (which carries greater meaning in 0.10.0)
+- #793: Add support for -synchronous flag to install command (added to load in #746)
 
 ### Changed
 - The minimum supported IRIS version for this release is 2022.1.
@@ -78,6 +79,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HSIEO-12012: Publishing modules with deployed code only run PrepareDeploy phase if module is in dev mode.
 - #782: Installer no longer includes unit tests
 - #781: Addressing an issue where file paths exceed 256 characters
+- #786: Resources with scope should not be exported
+- #788: Further reducing likelihood of file paths exceeding 256 characters
+- Issue installing with ORAS registries with specific builds listed; consistencies in repo -list-modules and -search with ORAS registries
+- #787: Publishing/unpublishing to remote registry broken
+- #649: Clear existing credentials when changing URL on remote HTTP registry
+- Reduced timeout when checking HTTP registry availability (fails faster rather than hanging for a long time and then failing)
 
 ## [0.9.2] - 2025-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - 2025-04-10
+## [0.10.3] - Unreleased
+
+### Fixed
+- #829: Fixed export of resources with null Directory attribute
+- #832: Fixed places that export to possibly-nonexistent directories by adding /createdirs (needed in 2025.2+)
+- #834: Fixed selectively undeploying classes within a package
+
+## [0.10.2] - 2025-06-04
+
+### Fixed
+- #809: Fixed installation of rpds.py in containers using durable %SYS
+- #811: Issues when upgrading from earlier IPM versions with cross-namespace differences
+- #796: Installation on environments without Flexible Python Runtime
+- #778: CI - avoid deadlock on 2025.2 preview due to cached query regeneration bug
+- #816: Fixed zpm "install" command not pulling specified versions of artifacts
+
+## [0.10.1] - 2025-04-24
+
+### Fixed
+- #797 Windows: IPM now uses the Python Runtime Library path from iris.cpf if defined
+
+## [0.10.0] - 2025-04-16
 
 *Important*: The minimum supported InterSystems IRIS version is now *2022.1*. For earlier IRIS versions, use IPM 0.9.x.
 

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -642,10 +642,29 @@ Method %Reload(ByRef pParams) As %Status
 		
 		// Standard resource processing
 		Set tSC = $$$OK
+		Set deployedResources = []
+		Set nonDeployedResources = []
 		Set tKey = ""
 		For {
 			Set tResource = ..Module.Resources.GetNext(.tKey)
 			Quit:tKey=""
+			If tResource.Deploy {
+				do deployedResources.%Push(tResource)
+			}
+			Else {
+				do nonDeployedResources.%Push(tResource)
+			}
+		}
+		// Process deployed resources first
+		set iter = deployedResources.%GetIterator()
+		while iter.%GetNext(, .tResource) {
+			If $IsObject(tResource.Processor) {
+				Set tSC = $$$ADDSC(tSC,tResource.Processor.OnPhase("Reload",.pParams))
+			}
+		}
+		// Then process non deployed resources
+		set iter = nonDeployedResources.%GetIterator()
+		while iter.%GetNext(, .tResource) {
 			If $IsObject(tResource.Processor) {
 				Set tSC = $$$ADDSC(tSC,tResource.Processor.OnPhase("Reload",.pParams))
 			}

--- a/src/cls/IPM/ResourceProcessor/Default/Document.cls
+++ b/src/cls/IPM/ResourceProcessor/Default/Document.cls
@@ -170,10 +170,6 @@ Method OnPhase(pPhase As %String, ByRef pParams, Output pResourceHandled As %Boo
                   }	
                 }
               }
-              If ##class(%IPM.Utils.File).Exists(.tResourcePath) {
-                Set tSC = $$$OK
-                Quit
-              }
               If ..ResourceReference.Deploy {
                 If tVerbose {
                   Write !, "Loading deployed resource from Studio project: "_..ResourceReference.Name
@@ -188,6 +184,10 @@ Method OnPhase(pPhase As %String, ByRef pParams, Output pResourceHandled As %Boo
                   Set $$$DeployedProjectInstalled(tDeployedProjectPath) = ""
                 }
                 Return $$$OK
+              }
+              If ##class(%IPM.Utils.File).Exists(.tResourcePath) {
+                Set tSC = $$$OK
+                Quit
               }
               Set tSC = $$$ERROR($$$GeneralError, "Resource path '" _ tResourcePath _ "' not found")
             }


### PR DESCRIPTION
- Issue seems to happen in %IPM.ResourceProcessor.Default.Document::OnPhase() when pPhase="Reload"
- In this scenario, the if statement: "If ##class(%IPM.Utils.File).Exists(.tResourcePath)" evaluates to true for the package level resource.
        - This stops us from reaching the "If ..ResourceReference.Deploy" code block, where the deployed files are loaded in.
        - Since at least one class isn't deployed, the class directory exists so stops execution. Issue is there are other resources in the 
          package that are deployed that we didn't handle

Fix:
- Swapped order of if-statements in OnPhase() to run steps if deployed whether or not the resource path exists to account for this case described above.
- 2 passes over the resource list in %Reload(). First pass: to split up resources between deployed and not deployed. Second pass: Process the resources--deployed first then not deployed.
        - Loading a non-deployed resource should override anything that was one with deployed resources