### PR TITLE
Fix: Selectively undeploying classes within a package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - #829: Fixed export of resources with null Directory attribute
 - #832: Fixed places that export to possibly-nonexistent directories by adding /createdirs (needed in 2025.2+)
+- #823: Fixed selectively undeploying classes within a package
 
 ## [0.10.2] - 2025-06-04
 

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -642,10 +642,29 @@ Method %Reload(ByRef pParams) As %Status
 		
 		// Standard resource processing
 		Set tSC = $$$OK
+		Set deployedResources = []
+		Set nonDeployedResources = []
 		Set tKey = ""
 		For {
 			Set tResource = ..Module.Resources.GetNext(.tKey)
 			Quit:tKey=""
+			If tResource.Deploy {
+				do deployedResources.%Push(tResource)
+			}
+			Else {
+				do nonDeployedResources.%Push(tResource)
+			}
+		}
+		// Process deployed resources first
+		set iter = deployedResources.%GetIterator()
+		while iter.%GetNext(, .tResource) {
+			If $IsObject(tResource.Processor) {
+				Set tSC = $$$ADDSC(tSC,tResource.Processor.OnPhase("Reload",.pParams))
+			}
+		}
+		// Then process non deployed resources
+		set iter = nonDeployedResources.%GetIterator()
+		while iter.%GetNext(, .tResource) {
 			If $IsObject(tResource.Processor) {
 				Set tSC = $$$ADDSC(tSC,tResource.Processor.OnPhase("Reload",.pParams))
 			}

--- a/src/cls/IPM/ResourceProcessor/Default/Document.cls
+++ b/src/cls/IPM/ResourceProcessor/Default/Document.cls
@@ -170,10 +170,6 @@ Method OnPhase(pPhase As %String, ByRef pParams, Output pResourceHandled As %Boo
                   }	
                 }
               }
-              If ##class(%IPM.Utils.File).Exists(.tResourcePath) {
-                Set tSC = $$$OK
-                Quit
-              }
               If ..ResourceReference.Deploy {
                 If tVerbose {
                   Write !, "Loading deployed resource from Studio project: "_..ResourceReference.Name
@@ -188,6 +184,10 @@ Method OnPhase(pPhase As %String, ByRef pParams, Output pResourceHandled As %Boo
                   Set $$$DeployedProjectInstalled(tDeployedProjectPath) = ""
                 }
                 Return $$$OK
+              }
+              If ##class(%IPM.Utils.File).Exists(.tResourcePath) {
+                Set tSC = $$$OK
+                Quit
               }
               Set tSC = $$$ERROR($$$GeneralError, "Resource path '" _ tResourcePath _ "' not found")
             }


### PR DESCRIPTION
- Issue seems to happen in %IPM.ResourceProcessor.Default.Document::OnPhase() when pPhase="Reload"
- In this scenario, the if statement: "If ##class(%IPM.Utils.File).Exists(.tResourcePath)" evaluates to true for the package level resource.
        - This stops us from reaching the "If ..ResourceReference.Deploy" code block, where the deployed files are loaded in.
        - Since at least one class isn't deployed, the class directory exists so stops execution. Issue is there are other resources in the
          package that are deployed that we didn't handle

Fix:
- Swapped order of if-statements in OnPhase() to run steps if deployed whether or not the resource path exists to account for this case described above.
- 2 passes over the resource list in %Reload(). First pass: to split up resources between deployed and not deployed. Second pass: Process the resources--deployed first then not deployed.
        - Loading a non-deployed resource should override anything that was one with deployed resources