### PR TITLE
Initial commit. Separating out list generation into a helper method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Format all files and add consistent formatting settings, format on save etc.
+- #848: Lifecycle methods should process resources in order of granularity
 
 ## [0.10.2] - 2025-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Format all files and add consistent formatting settings, format on save etc.
-- #848: Lifecycle methods should process resources in order of granularity
+- #848: Resource processing should be done in order of granularity
 
 ## [0.10.2] - 2025-06-04
 

--- a/src/cls/IPM/DependencyAnalyzer.cls
+++ b/src/cls/IPM/DependencyAnalyzer.cls
@@ -237,10 +237,11 @@ ClassMethod FindReferenceHelper(
 
     // If we are running for a module, get references for all module resources
     if pIsModule {
+        set orderedResourceList = tModule.GetOrderedResourceList()
         set tResourceKey = ""
         for {
             #dim tResource As %IPM.Storage.ResourceReference
-            set tResource = tModule.Resources.GetNext(.tResourceKey)
+            set tResource = orderedResourceList.GetNext(.tResourceKey)
             if (tResourceKey = "") {
                 quit
             }

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -186,55 +186,6 @@ ClassMethod GetCompletePhasesForOne(pOnePhase As %String) As %List
     )
 }
 
-/// This method iterates over resources of a module and returns a list of objects in the correct order that resources should be processed
-/// Process resources based on their package depth (higher level first so more granular resource will override)
-/// e.g. <Resource Name="Depth1.PKG"/> should be processed before <Resource Name="Depth1.Depth2.CLS"/>
-Method GetOrderedResourceList() As %ListOfObjects
-{
-    set nonDocumentResourceList = ##class(%ListOfObjects).%New()
-    set tKey = ""
-    for {
-        set tResource = ..Module.Resources.GetNext(.tKey)
-        quit:tKey=""
-        if $isobject(tResource.Processor) && tResource.Processor.%Extends("%IPM.ResourceProcessor.Default.Document") {
-            // Strip extension from resource name as that caused improper sorting (i.e. MyPackage.MyClass.CLS gets sorted before MyPackage.PKG)
-            set tResourceName = $piece(tResource.Name,".",1,*-1)
-            if ($get(documentResourceList(tResourceName)) = "") {
-                set documentResourceList(tResourceName) = ##class(%ListOfObjects).%New()
-            }
-            do documentResourceList(tResourceName).Insert(tResource)
-        }
-        else {
-            do nonDocumentResourceList.Insert(tResource)
-        }
-    }
-    set orderedResourceList = ##class(%ListOfObjects).%New()
-
-    // Combine all objects into one larger list
-    // First document resources
-    set tKey = ""
-    for {
-        set tKey = $order(documentResourceList(tKey))
-        quit:tKey=""
-        set tResourceList = documentResourceList(tKey)
-        set tKey2 = ""
-        for {
-            set tResource = tResourceList.GetNext(.tKey2)
-            quit:tKey2=""
-            do orderedResourceList.Insert(tResource)
-        }
-    }
-    // Then non-document resources
-    set tKey = ""
-    for {
-        set tResource = nonDocumentResourceList.GetNext(.tKey)
-        quit:tKey=""
-        do orderedResourceList.Insert(tResource)
-    }
-
-    return orderedResourceList
-}
-
 /// Match single inputted phase to the correctly CamelCased lifecycle phase <br/>
 ClassMethod MatchSinglePhase(pOnePhase As %String) As %String
 {
@@ -268,7 +219,7 @@ Method OnBeforeArtifact(
     set tSC = $$$OK
     try {
         // Notify resource processors
-        set orderedResourceList = ..GetOrderedResourceList()
+        set orderedResourceList = ..Module.GetOrderedResourceList()
         set tKey = ""
         for {
             #dim tResource As %IPM.Storage.ResourceReference
@@ -372,7 +323,7 @@ Method %Clean(ByRef pParams) As %Status
         }
 
         if (tLevel > 0) {
-            set orderedResourceList = ..GetOrderedResourceList()
+            set orderedResourceList = ..Module.GetOrderedResourceList()
             set tKey = ""
             for {
                 #dim tResource As %IPM.Storage.ResourceReference
@@ -594,7 +545,7 @@ Method %Initialize(ByRef pParams) As %Status
 {
     set status = $$$OK
     try {
-        set orderedResourceList = ..GetOrderedResourceList()
+        set orderedResourceList = ..Module.GetOrderedResourceList()
         set key = ""
         for {
             set resource = orderedResourceList.GetNext(.key)
@@ -725,7 +676,7 @@ Method %Reload(ByRef pParams) As %Status
         }
 
         // Resource processing
-        set orderedResourceList = ..GetOrderedResourceList()
+        set orderedResourceList = ..Module.GetOrderedResourceList()
         set tSC = $$$OK
         set tKey = ""
         for {
@@ -954,7 +905,7 @@ Method %Compile(ByRef pParams) As %Status
         $$$ThrowOnError(tSC)
 
         // Compile items within the module that are compilable using OnPhase
-        set orderedResourceList = ..GetOrderedResourceList()
+        set orderedResourceList = ..Module.GetOrderedResourceList()
         set tKey = ""
         for {
             #dim tResource As %IPM.Storage.ResourceReference
@@ -1131,7 +1082,7 @@ Method %Test(ByRef pParams) As %Status
         set tSC = ..Module.LoadDependencies(..PhaseList,.pParams)
         $$$ThrowOnError(tSC)
 
-        set orderedResourceList = ..GetOrderedResourceList()
+        set orderedResourceList = ..Module.GetOrderedResourceList()
         set tKey = ""
         for {
             set tResource = orderedResourceList.GetNext(.tKey)
@@ -1371,10 +1322,10 @@ Method %Verify(ByRef pParams) As %Status
         set tSC = ..Module.LoadDependencies(..PhaseList,.pParams)
         $$$ThrowOnError(tSC)
 
-        set orderedResourceList = ..GetOrderedResourceList()
+        set orderedResourceList = ..Module.GetOrderedResourceList()
         set tKey = ""
         for {
-        #dim tResource As %IPM.Storage.ResourceReference
+            #dim tResource As %IPM.Storage.ResourceReference
             set tResource = orderedResourceList.GetNext(.tKey)
             quit:tKey=""
 

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -186,6 +186,55 @@ ClassMethod GetCompletePhasesForOne(pOnePhase As %String) As %List
     )
 }
 
+/// This method iterates over resources of a module and returns a list of objects in the correct order that resources should be processed
+/// Process resources based on their package depth (higher level first so more granular resource will override)
+/// e.g. <Resource Name="Depth1.PKG"/> should be processed before <Resource Name="Depth1.Depth2.CLS"/>
+ClassMethod GetOrderedResourceList(ByRef module) As %ListOfObjects
+{
+    set nonDocumentResourceList = ##class(%ListOfObjects).%New()
+    set tKey = ""
+    for {
+        set tResource = module.Resources.GetNext(.tKey)
+        quit:tKey=""
+        if $isobject(tResource.Processor) && tResource.Processor.%Extends("%IPM.ResourceProcessor.Default.Document") {
+            // Strip extension from resource name as that caused improper sorting (i.e. MyPackage.MyClass.CLS gets sorted before MyPackage.PKG)
+            set tResourceName = $piece(tResource.Name,".",1,*-1)
+            if ($get(documentResourceList(tResourceName)) = "") {
+                set documentResourceList(tResourceName) = ##class(%ListOfObjects).%New()
+            }
+            do documentResourceList(tResourceName).Insert(tResource)
+        }
+        else {
+            do nonDocumentResourceList.Insert(tResource)
+        }
+    }
+    set orderedResourceList = ##class(%ListOfObjects).%New()
+
+    // Combine all objects into one larger list
+    // First document resources
+    set tKey = ""
+    for {
+        set tKey = $order(documentResourceList(tKey))
+        quit:tKey=""
+        set tResourceList = documentResourceList(tKey)
+        set tKey2 = ""
+        for {
+            set tResource = tResourceList.GetNext(.tKey2)
+            quit:tKey2=""
+            do orderedResourceList.Insert(tResource)
+        }
+    }
+    // Then non-document resources
+    set tKey = ""
+    for {
+        set tResource = nonDocumentResourceList.GetNext(.tKey)
+        quit:tKey=""
+        do orderedResourceList.Insert(tResource)
+    }
+
+    return orderedResourceList
+}
+
 /// Match single inputted phase to the correctly CamelCased lifecycle phase <br/>
 ClassMethod MatchSinglePhase(pOnePhase As %String) As %String
 {
@@ -672,53 +721,19 @@ Method %Reload(ByRef pParams) As %Status
             set ^Sources("MODULE",..Module.Name) = tAbsolutePrefix_tRoot
         }
 
-        // Process resources based on their package depth (higher level first so more granular resource will override)
-        // e.g. <Resource Name="Depth1.PKG"/> will be processed before <Resource Name="Depth1.Depth2.CLS"/>
-        set nonDocumentResourceList = ##class(%ListOfObjects).%New()
-        set tKey = ""
-        for {
-            set tResource = ..Module.Resources.GetNext(.tKey)
-            quit:tKey=""
-            if $isobject(tResource.Processor) {
-                if tResource.Processor.%Extends("%IPM.ResourceProcessor.Default.Document") {
-                    // Strip extension from resource name as that caused improper sorting (i.e. MyPackage.MyClass.CLS gets sorted before MyPackage.PKG)
-                    set tResourceName = $piece(tResource.Name,".",1,*-1)
-                    if ($get(documentResourceList(tResourceName)) = "") {
-                        set documentResourceList(tResourceName) = ##class(%ListOfObjects).%New()
-                    }
-                    do documentResourceList(tResourceName).Insert(tResource)
-                }
-                else {
-                    do nonDocumentResourceList.Insert(tResource)
-                }
-            }
-        }
-        // Process document resources by depth order
+        // Resource processing
+        set orderedResourceList = ..GetOrderedResourceList(..Module)
         set tSC = $$$OK
         set tKey = ""
         for {
-            set tKey = $order(documentResourceList(tKey))
+            set tResource = orderedResourceList.GetNext(.tKey)
             quit:tKey=""
-            set tResourceList = documentResourceList(tKey)
-            set tKey2 = ""
-            for {
-                set tResource = tResourceList.GetNext(.tKey2)
-                quit:tKey2=""
+            if $isobject(tResource.Processor) {
                 set tSC = $$$ADDSC(tSC,tResource.Processor.OnPhase("Reload",.pParams))
-                if $$$ISERR(tSC) {
-                    quit
-                }
             }
         }
-        // Process non-document resources sequentially
-        set tKey = ""
-        for {
-            set tResource = nonDocumentResourceList.GetNext(.tKey)
-            quit:tKey=""
-            set tSC = $$$ADDSC(tSC,tResource.Processor.OnPhase("Reload",.pParams))
-            if $$$ISERR(tSC) {
-                quit
-            }
+        if $$$ISERR(tSC) {
+            quit
         }
 
         // call %OnModifyResources to let the source control class do any other mapping it needs to

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -189,12 +189,12 @@ ClassMethod GetCompletePhasesForOne(pOnePhase As %String) As %List
 /// This method iterates over resources of a module and returns a list of objects in the correct order that resources should be processed
 /// Process resources based on their package depth (higher level first so more granular resource will override)
 /// e.g. <Resource Name="Depth1.PKG"/> should be processed before <Resource Name="Depth1.Depth2.CLS"/>
-ClassMethod GetOrderedResourceList(ByRef module) As %ListOfObjects
+Method GetOrderedResourceList() As %ListOfObjects
 {
     set nonDocumentResourceList = ##class(%ListOfObjects).%New()
     set tKey = ""
     for {
-        set tResource = module.Resources.GetNext(.tKey)
+        set tResource = ..Module.Resources.GetNext(.tKey)
         quit:tKey=""
         if $isobject(tResource.Processor) && tResource.Processor.%Extends("%IPM.ResourceProcessor.Default.Document") {
             // Strip extension from resource name as that caused improper sorting (i.e. MyPackage.MyClass.CLS gets sorted before MyPackage.PKG)
@@ -268,10 +268,11 @@ Method OnBeforeArtifact(
     set tSC = $$$OK
     try {
         // Notify resource processors
+        set orderedResourceList = ..GetOrderedResourceList()
         set tKey = ""
         for {
             #dim tResource As %IPM.Storage.ResourceReference
-            set tResource = ..Module.Resources.GetNext(.tKey)
+            set tResource = orderedResourceList.GetNext(.tKey)
             quit:(tKey="")
 
             if $isobject(tResource.Processor) {
@@ -371,10 +372,11 @@ Method %Clean(ByRef pParams) As %Status
         }
 
         if (tLevel > 0) {
+            set orderedResourceList = ..GetOrderedResourceList()
             set tKey = ""
             for {
                 #dim tResource As %IPM.Storage.ResourceReference
-                set tResource = ..Module.Resources.GetNext(.tKey)
+                set tResource = orderedResourceList.GetNext(.tKey)
                 quit:tKey=""
 
                 if $isobject(tResource.Processor) {
@@ -592,9 +594,10 @@ Method %Initialize(ByRef pParams) As %Status
 {
     set status = $$$OK
     try {
+        set orderedResourceList = ..GetOrderedResourceList()
         set key = ""
         for {
-            set resource = ..Module.Resources.GetNext(.key)
+            set resource = orderedResourceList.GetNext(.key)
             quit:key=""
             if $isobject(resource.Processor) {
                 set status = $$$ADDSC(status,resource.Processor.OnPhase("Initialize",.pParams))
@@ -722,7 +725,7 @@ Method %Reload(ByRef pParams) As %Status
         }
 
         // Resource processing
-        set orderedResourceList = ..GetOrderedResourceList(..Module)
+        set orderedResourceList = ..GetOrderedResourceList()
         set tSC = $$$OK
         set tKey = ""
         for {
@@ -951,10 +954,11 @@ Method %Compile(ByRef pParams) As %Status
         $$$ThrowOnError(tSC)
 
         // Compile items within the module that are compilable using OnPhase
+        set orderedResourceList = ..GetOrderedResourceList()
         set tKey = ""
         for {
             #dim tResource As %IPM.Storage.ResourceReference
-            set tResource = ..Module.Resources.GetNext(.tKey)
+            set tResource = orderedResourceList.GetNext(.tKey)
             quit:tKey=""
 
             set tHandled = 0
@@ -970,7 +974,7 @@ Method %Compile(ByRef pParams) As %Status
         // Build maps of other compilable things
         set tKey = ""
         for {
-            set tResource = ..Module.Resources.GetNext(.tKey)
+            set tResource = orderedResourceList.GetNext(.tKey)
             quit:tKey=""
 
             if '$data(tHandledMap(tResource.Name)) && $isobject(tResource.Processor) {
@@ -1127,8 +1131,11 @@ Method %Test(ByRef pParams) As %Status
         set tSC = ..Module.LoadDependencies(..PhaseList,.pParams)
         $$$ThrowOnError(tSC)
 
-        for i=1:1:..Module.Resources.Count() {
-            set tResource = ..Module.Resources.GetAt(i)
+        set orderedResourceList = ..GetOrderedResourceList()
+        set tKey = ""
+        for {
+            set tResource = orderedResourceList.GetNext(.tKey)
+            quit:tKey=""
             if $isobject(tResource.Processor) {
                 set tSC = $$$ADDSC(tSC,tResource.Processor.OnPhase("Test",.pParams))
             }
@@ -1364,9 +1371,12 @@ Method %Verify(ByRef pParams) As %Status
         set tSC = ..Module.LoadDependencies(..PhaseList,.pParams)
         $$$ThrowOnError(tSC)
 
+        set orderedResourceList = ..GetOrderedResourceList()
+        set tKey = ""
+        for {
         #dim tResource As %IPM.Storage.ResourceReference
-        for i=1:1:..Module.Resources.Count() {
-            set tResource = ..Module.Resources.GetAt(i)
+            set tResource = orderedResourceList.GetNext(.tKey)
+            quit:tKey=""
 
             set tHandled = 0
             if $isobject(tResource.Processor) {

--- a/src/cls/IPM/Lifecycle/Module.cls
+++ b/src/cls/IPM/Lifecycle/Module.cls
@@ -81,7 +81,7 @@ Method %PrepareDeploy(ByRef pParams) As %Status
         $$$ThrowOnError(..Module.%Reload())
 
         set tSource = tPackageDeployNamespace _ "-CODE"
-        set orderedResourceList = ..GetOrderedResourceList()
+        set orderedResourceList = ..Module.GetOrderedResourceList()
         set tKey = ""
         for {
             set tResource = orderedResourceList.GetNext(.tKey)

--- a/src/cls/IPM/Lifecycle/Module.cls
+++ b/src/cls/IPM/Lifecycle/Module.cls
@@ -81,9 +81,10 @@ Method %PrepareDeploy(ByRef pParams) As %Status
         $$$ThrowOnError(..Module.%Reload())
 
         set tSource = tPackageDeployNamespace _ "-CODE"
+        set orderedResourceList = ..GetOrderedResourceList()
         set tKey = ""
         for {
-            set tResource = ..Module.Resources.GetNext(.tKey)
+            set tResource = orderedResourceList.GetNext(.tKey)
             quit:(tKey="")
 
             set tName = $piece(tResource.Name, ".", 1, *-1)

--- a/src/cls/IPM/Lifecycle/StudioProject.cls
+++ b/src/cls/IPM/Lifecycle/StudioProject.cls
@@ -167,10 +167,11 @@ Method PackageOneModule(
     set tWorkingDirectory = tTempFileManager.GetTempFolderName()
 
     // Notify resource processors for harvest of static files from module root
+    set orderedResourceList = pModule.GetOrderedResourceList()
     set tKey = ""
     for {
         #dim tResource As %IPM.Storage.ResourceReference
-        set tResource = pModule.Resources.GetNext(.tKey)
+        set tResource = orderedResourceList.GetNext(.tKey)
         quit:(tKey="")
 
         if $isobject(tResource.Processor) {

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -85,6 +85,55 @@ Property AfterInstallMessage As %String(MAXLEN = "", XMLPROJECTION = "Element");
 
 Property Deployed As %Boolean(XMLPROJECTION = "Element");
 
+/// This method iterates over resources of a module and returns a list of objects in the correct order that resources should be processed
+/// Process resources based on their package depth (higher level first so more granular resource will override)
+/// e.g. <Resource Name="Depth1.PKG"/> should be processed before <Resource Name="Depth1.Depth2.CLS"/>
+Method GetOrderedResourceList() As %ListOfObjects
+{
+    set nonDocumentResourceList = ##class(%ListOfObjects).%New()
+    set tKey = ""
+    for {
+        set tResource = ..Resources.GetNext(.tKey)
+        quit:tKey=""
+        if $isobject(tResource.Processor) && tResource.Processor.%Extends("%IPM.ResourceProcessor.Default.Document") {
+            // Strip extension from resource name as that caused improper sorting (i.e. MyPackage.MyClass.CLS gets sorted before MyPackage.PKG)
+            set tResourceName = $piece(tResource.Name,".",1,*-1)
+            if ($get(documentResourceList(tResourceName)) = "") {
+                set documentResourceList(tResourceName) = ##class(%ListOfObjects).%New()
+            }
+            do documentResourceList(tResourceName).Insert(tResource)
+        }
+        else {
+            do nonDocumentResourceList.Insert(tResource)
+        }
+    }
+    set orderedResourceList = ##class(%ListOfObjects).%New()
+
+    // Combine all objects into one larger list
+    // First document resources
+    set tKey = ""
+    for {
+        set tKey = $order(documentResourceList(tKey))
+        quit:tKey=""
+        set tResourceList = documentResourceList(tKey)
+        set tKey2 = ""
+        for {
+            set tResource = tResourceList.GetNext(.tKey2)
+            quit:tKey2=""
+            do orderedResourceList.Insert(tResource)
+        }
+    }
+    // Then non-document resources
+    set tKey = ""
+    for {
+        set tResource = nonDocumentResourceList.GetNext(.tKey)
+        quit:tKey=""
+        do orderedResourceList.Insert(tResource)
+    }
+
+    return orderedResourceList
+}
+
 Method HaveToDeploy() As %Boolean
 {
     set deploy = 0

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -86,7 +86,7 @@ Property AfterInstallMessage As %String(MAXLEN = "", XMLPROJECTION = "Element");
 Property Deployed As %Boolean(XMLPROJECTION = "Element");
 
 /// This method iterates over resources of a module and returns a list of objects in the correct order that resources should be processed
-/// Process resources based on their package depth (higher level first so more granular resource will override)
+/// Process document resources based on their package depth first, followed by the order things are defined in the module.xml for the rest
 /// e.g. <Resource Name="Depth1.PKG"/> should be processed before <Resource Name="Depth1.Depth2.CLS"/>
 Method GetOrderedResourceList() As %ListOfObjects
 {

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -237,8 +237,9 @@ Method GetCustomPhases(Output pPhases)
             set pPhases($$$lcase(tInvoke.CustomPhase)) = tInvoke.CustomPhase
         }
     }
+    set orderedResourceList = ..GetOrderedResourceList()
     for {
-        set tResource = ..Resources.GetNext(.key)
+        set tResource = orderedResourceList.GetNext(.key)
         if key = "" {
             quit
         }
@@ -403,10 +404,11 @@ ClassMethod ExecutePhases(
                 $$$ThrowOnError(tSC)
                 $$$ThrowOnError(tLifecycle.OnBeforeResourceProcessing(tOnePhase, .pParams))
                 // Notify resource processors
+                set orderedResourceList = tModule.GetOrderedResourceList()
                 set tKey = ""
                 for {
                     #dim tResource As %IPM.Storage.ResourceReference
-                    set tResource = tModule.Resources.GetNext(.tKey)
+                    set tResource = orderedResourceList.GetNext(.tKey)
                     if (tKey = "") {
                         quit
                     }
@@ -430,7 +432,7 @@ ClassMethod ExecutePhases(
                 if tIsCustomPhase {
                     set tKey = ""
                     for {
-                        set tResource = tModule.Resources.GetNext(.tKey)
+                        set tResource = orderedResourceList.GetNext(.tKey)
                         if tKey = "" {
                             quit
                         }
@@ -461,9 +463,10 @@ ClassMethod ExecutePhases(
                 quit:$$$ISERR(tSC)
 
                 // Notify resource processors
+                set orderedResourceList = tModule.GetOrderedResourceList()
                 set tKey=""
                 for {
-                    set tResource = tModule.Resources.GetNext(.tKey)
+                    set tResource = orderedResourceList.GetNext(.tKey)
                     if (tKey = "") {
                         quit
                     }
@@ -1107,10 +1110,11 @@ Method GetResolvedReferences(
 
         set pReferenceArray(..Name, ..Name_".ZPM") = ""
 
+        set orderedResourceList = ..GetOrderedResourceList()
         set tKey = ""
         for {
             #dim tResource As %IPM.Storage.ResourceReference
-            set tResource = ..Resources.GetNext(.tKey)
+            set tResource = orderedResourceList.GetNext(.tKey)
             quit:tKey=""
             if '..HasScope(pPhases,tResource.Scope) {
                 continue
@@ -1291,9 +1295,10 @@ Method %OnValidateObject() As %Status [ Private, ServerOnly = 1 ]
         $$$ThrowOnError(tSC)
 
         set tSC = $$$OK
+        set orderedResourceList = ..GetOrderedResourceList()
         set tKey = ""
         for {
-            set tResource = ..Resources.GetNext(.tKey)
+            set tResource = orderedResourceList.GetNext(.tKey)
             quit:(tKey="")
 
             // If it hasn't been saved yet (to account for module renames)...
@@ -1373,9 +1378,10 @@ Method %OnAddToSaveSet(
         $$$ThrowOnError(tSC)
 
         set tSC = $$$OK
+        set orderedResourceList = ..GetOrderedResourceList()
         set tKey = ""
         for {
-            set tResource = ..Resources.GetNext(.tKey)
+            set tResource = orderedResourceList.GetNext(.tKey)
             quit:(tKey="")
 
             // If it hasn't been saved yet (to account for module renames)...
@@ -1488,10 +1494,11 @@ Method GetStudioProject(
             do pProject.AddItem(..Name_".ZPM")
         }
 
+        set orderedResourceList = ..GetOrderedResourceList()
         set tResourceKey = ""
         for {
             #dim tResource As %IPM.Storage.ResourceReference
-            set tResource = ..Resources.GetNext(.tResourceKey)
+            set tResource = orderedResourceList.GetNext(.tResourceKey)
             if (tResourceKey = "") {
                 quit
             }


### PR DESCRIPTION
Addresses #848 

Idea is to create a helper method which compiles all resources into one list in their proper processing order. Lifecycle methods can then use this `orderedResourceList.GetNext(.tKey)` instead of `..Module.Resources.GetNext(.tKey)`