### PR TITLE
Intermediate PR for IPM commands

### DIFF
--- a/src/cls/IPM/Lifecycle/Module.cls
+++ b/src/cls/IPM/Lifecycle/Module.cls
@@ -186,4 +186,21 @@ Method %Package(ByRef pParams) As %Status
   quit tSC
 }
 
+Method %Update(ByRef pParams) As %Status
+{
+    set tSC = $$$OK
+    try {
+        set tVerbose = $get(pParams("Verbose"))
+        set tVersion = $get(pParams("Version"))
+        set tModule = ##class(%IPM.Storage.Module).NameOpen(..Module.DisplayName)
+        write:tVerbose !,"Seeding update steps",!
+        $$$ThrowOnError(tModule.SeedUpdateSteps())
+        write:tVerbose !,"Applying update steps",!
+        do ##class(%IPM.Utils.Update.Controller).ApplyUpdatesInOrder(tModule,,tVerbose)
+    } catch e {
+        set tSC = e.AsStatus()
+    }
+  quit tSC
+}
+
 }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -7,7 +7,7 @@ Class %IPM.Main Extends %IPM.CLI
 
 Parameter DOMAIN = "ZPM";
 
-Parameter STANDARDPHASES = {$listbuild("reload","compile","test","package","verify","publish","makedeployed")};
+Parameter STANDARDPHASES = {$listbuild("reload","compile","test","package","verify","publish","makedeployed","update")};
 
 /// Description of commands to use for this CLI
 XData Commands [ XMLNamespace = "http://www.intersystems.com/PackageManager/CLI" ]
@@ -55,6 +55,8 @@ This is accessible to other instances configured to look at the current namespac
 module repository.
 * publish: saves that artifact to the repository for which deployment is enabled.
 Currently, there may only be one of these per namespace.
+* update: run any update steps for the module to become updated to the latest available version by default.
+Can also specify desired version to upgrade to.
 </description>
 
 <!-- Examples -->
@@ -137,6 +139,26 @@ This command is an alias for `module-action module-name publish`
 <parameter name="module" required="true" description="Name of module on which to perform publish actions" />
 <modifier name="repo" aliases="r" dataAlias="PublishTo" description="Namespace-unique name for the module to publish to (if deployment is enabled)" />
 <modifier name="use-external-name" aliases="use-ext" dataAlias="UseExternalName" dataValue="1" description="Publish the package under the &lt;ExternalName&gt; of the package. If ExternalName is unspecified or illegal, an error will be thrown."/>
+</command>
+
+<command name="update" dataPrefix="D">
+<summary>Updates a module to a newer version.</summary>
+<description>
+	Updates a module to the latest available version by default. Can also specify a version with the -version modifier. Runs all of the update steps from the current version to the newer version.
+</description>
+
+<!-- Examples -->
+<example description="Updates the HS.JSON module from the current version to version 3.0.0.">
+	update HS.JSON -version 3.0.0
+</example>
+
+<!-- Parameters -->
+<parameter name="module" required="true" description="Name of module on which to perform update actions" />
+
+<!-- Modifiers -->
+<modifier name="version" aliases="ver" dataAlias="Version" description="Version to update module to" />
+<modifier name="verbose" aliases="v" dataAlias="Verbose" dataValue="1" description="Produces verbose output from the command." />
+<modifier name="force" aliases="f" dataAlias="Force" dataValue="1" description="If specified, the module will be updated even if there are warnings." />
 </command>
 
 <command name="makedeployed">
@@ -447,6 +469,7 @@ reinstall -env /path/to/env1.json;/path/to/env2.json example-package
 <modifier name="quiet" aliases="q" dataAlias="Verbose" dataValue="0" description="Produces minimal output from the command." />
 <modifier name="verbose" aliases="v" dataAlias="Verbose" dataValue="1" description="Produces verbose output from the command." />
 <modifier name="purge" dataAlias="Purge" dataValue="1" description="Purge data from tables during uninstall." />
+<modifier name="delete-data" dataAlias="DeleteData" dataValue="1" description="Deletes persistent data for the module." />
 
 </command>
 
@@ -2242,6 +2265,12 @@ ClassMethod Install(ByRef pCommandInfo) [ Internal ]
                 }
             }
             $$$ThrowOnError(##class(%IPM.Utils.Module).LoadQualifiedReference(tResult, .tParams, , tSynchronous))
+            if '$get(tParams("DeveloperMode")) {
+                set tModule = ##class(%IPM.Storage.Module).NameOpen(tModuleName)
+                if $isobject(tModule) {
+                    $$$ThrowOnError(tModule.SeedUpdateSteps())
+                }
+            }
         }
     } else {
         set tPrefix = ""

--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -1343,6 +1343,10 @@ ClassMethod LoadNewModule(
             tcommit
         }
         $$$ThrowOnError(tSC)
+        // On each load of a new module, we want to seed its update steps
+        if 'tDeveloperMode {
+            $$$ThrowOnError(tModule.SeedUpdateSteps())
+        }
         do tModule.WriteAfterInstallMessage()
     } catch e {
         set tSC = e.AsStatus()


### PR DESCRIPTION
This is a intermediate PR for IPM commands. With the addition of the new update command, testing can flow better amongst everyone working on the update framework.

Remaining TODOs:
1. "install" and "load": Add "Force" flag
2. "uninstall": Complete logic for "delete-data" flag
3. "update": Throw a warning to alert users of which update steps have been seeded (if any).
4. "update": Add more verbose logging
5. "update": Flags for log output device + Log file name + Log file location + Local module tarball location + JSON configuration file location + Force
6. "update": Ensure "update" command is not run on the primary instance if it hasn't run on the backup
7. Consider how to hold onto to tune table metadata (automatic exports/imports on update?)