### PR TITLE
Update framework Tests (Part Two)

### DIFF
--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -1214,6 +1214,7 @@ ClassMethod LoadNewModule(
         if '$data(pParams("qstruct")) {
             set qstruct = "ck"_$select(tVerbose:"d",1:"-d")
         }
+        set commandLineModuleName = $get(pParams("ModuleName"))
 
         // Check for valid license key prior to top-level module load
         // This may throw an exception.
@@ -1236,28 +1237,6 @@ ClassMethod LoadNewModule(
 
         set pDirectory = ##class(%File).NormalizeDirectory("",pDirectory)
 
-        set newModuleObj = ..GetModuleObjectFromPath(pDirectory,.foundNewModuleObj)
-        if foundNewModuleObj {
-            // Check that on an update command with -path flag, the module in the path matches the module specified for update.
-            set commandLineModuleName = $get(pParams("ModuleName"))
-            if (commandLineModuleName '= "") && (newModuleObj.Name '= commandLineModuleName) {
-                set msg = $$$FormatText("The specified path does not contain a module matching the specified module to update. Module in path = %1. Specified module = %2.",newModuleObj.Name,commandLineModuleName)
-                $$$ThrowStatus($$$ERROR($$$GeneralError, msg))
-            }
-            // Note that for update/install commands, the operation version validity has already been checked in %IPM.Main.Install().
-            if isLoad {
-                // Check that the module currently installed is not being downgraded.
-                // Check that the load command is not being used to update a module, unless the -force flag is passed.
-                do ..CheckOperationVersionValidity(newModuleObj, .pParams)
-            }
-        }
-
-        if ($get(pParams("NoJournal"),0) '= 0) {
-            // Disable journalling with process-level switch.
-            set tJournalMgr = ##class(%IPM.Utils.JournalManager).%New(0)
-        } elseif tUseTransactions {
-            tstart
-        }
         // This loads the new version of the module into storage. Overrides the module context of the currently installed module, if it exists.
         set tSC = $system.OBJ.Load(pDirectory_"module.xml",$select(tVerbose:"d",1:"-d"),,.tLoadedList)
         $$$ThrowOnError(tSC)
@@ -1276,6 +1255,34 @@ ClassMethod LoadNewModule(
 
         set tDisplayName = $piece(tFirstLoaded, ".", 1, *-1)
         set tModuleName = $$$lcase(tDisplayName)
+
+        #dim tInstallContext As %IPM.General.InstallContext
+        set tInstallContext = ##class(%IPM.General.InstallContext).%Get(.tSC)
+        $$$ThrowOnError(tSC)
+
+        if 'tInstallContext.ModuleIsDependency(tModuleName) {
+          set newModuleObj = ..GetModuleObjectFromPath(pDirectory,.foundNewModuleObj)
+          if foundNewModuleObj {
+            // Check that on an update command with -path flag, the module in the path matches the module specified for update.
+            if (commandLineModuleName '= "") && (newModuleObj.Name '= commandLineModuleName) {
+                set msg = $$$FormatText("The specified path does not contain a module matching the specified module to update. Module in path = %1. Specified module = %2.",newModuleObj.Name,commandLineModuleName)
+                $$$ThrowStatus($$$ERROR($$$GeneralError, msg))
+            }
+            // Note that for update/install commands, the operation version validity has already been checked in %IPM.Main.Install().
+            if isLoad {
+                // Check that the module currently installed is not being downgraded.
+                // Check that the load command is not being used to update a module, unless the -force flag is passed.
+                do ..CheckOperationVersionValidity(newModuleObj, .pParams)
+            }
+        }
+        }
+
+        if ($get(pParams("NoJournal"),0) '= 0) {
+            // Disable journalling with process-level switch.
+            set tJournalMgr = ##class(%IPM.Utils.JournalManager).%New(0)
+        } elseif tUseTransactions {
+            tstart
+        }
 
         if (pRepository '= "") {
             // Force developer mode to be 0 if repository is read only.
@@ -1328,9 +1335,6 @@ ClassMethod LoadNewModule(
 
         $$$ThrowOnError(##class(%IPM.Storage.Module).CheckSystemRequirements(tModuleName))
 
-        #dim tInstallContext As %IPM.General.InstallContext
-        set tInstallContext = ##class(%IPM.General.InstallContext).%Get(.tSC)
-        $$$ThrowOnError(tSC)
         if 'tInstallContext.ModuleIsDependency(tModuleName) {
             if 'pSynchronous {
                 // Regular async multi-threaded loading of dependencies

--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -1263,7 +1263,7 @@ ClassMethod LoadNewModule(
         if 'tInstallContext.ModuleIsDependency(tModuleName) {
           set newModuleObj = ..GetModuleObjectFromPath(pDirectory,.foundNewModuleObj)
           if foundNewModuleObj {
-            // Check that on an update command with -path flag, the module in the path matches the module specified for update.
+            // Check that on an update command with -path flag, the module in the path matches the base module specified for update.
             if (commandLineModuleName '= "") && (newModuleObj.Name '= commandLineModuleName) {
                 set msg = $$$FormatText("The specified path does not contain a module matching the specified module to update. Module in path = %1. Specified module = %2.",newModuleObj.Name,commandLineModuleName)
                 $$$ThrowStatus($$$ERROR($$$GeneralError, msg))

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -120,36 +120,6 @@ Method TestUpdateNonMatchingTarballFails()
   do ..CleanUpDirectory(exportDir)
 }
 
-Method TestSimultaneousUpdateFails()
-{
-  do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
-
-  if ('$system.Event.Defined("FirstUpdate")){
-    set isNamedResourceCreated = $system.Event.Create("FirstUpdate")
-    if 'isNamedResourceCreated {
-      $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource FirstUpdate not created"))
-    }
-  }
-
-  if ('$system.Event.Defined("SecondUpdate")){
-    set isNamedResourceCreated = $system.Event.Create("SecondUpdate")
-    if 'isNamedResourceCreated {
-      $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource SecondUpdate not created"))
-    }
-  }
-
-  job ..UpdateJobWrapper(..#ModuleNoDependencies, ..#ModuleTwoVersion, "FirstUpdate")
-  job ..UpdateJobWrapper(..#ModuleNoDependencies, ..#ModuleThreeVersion, "SecondUpdate")
-
-  set $listbuild(firstCode, firstResponse) = $system.Event.WaitMsg("FirstUpdate")
-  set $listbuild(secondCode, secondResponse) = $system.Event.WaitMsg("SecondUpdate")
-
-  do $$$AssertStatusOK(firstResponse, "Update of module="_..#ModuleNoDependencies_" to version="_..#ModuleTwoVersion_" succeeded.")
-  do $$$AssertStatusNotOK(secondResponse, "Attempting to update module="_..#ModuleNoDependencies_" while another update of that module in the same namespace is in-progress failed.")
-
-  do ..CleanUpModule(..#ModuleNoDependencies)
-}
-
 Method TestUpdateAfterInterruptedUpdate()
 {
   do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
@@ -554,17 +524,6 @@ Method AssertModulePackagedCorrectly(
 
   // Uninstall module
   do ..CleanUpModule(moduleName)
-}
-
-ClassMethod UpdateJobWrapper(
-	moduleName,
-	toVersion,
-	resourceName)
-{
-  set sc = ##class(%IPM.Main).Shell("update "_moduleName_" "_toVersion_" -v")
-
-  // Send update status to the named resource
-  do $system.Event.Signal(resourceName, sc)
 }
 
 ClassMethod InterruptedUpdateJobWrapper(

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -13,7 +13,7 @@ Parameter ModuleNoUpdateSteps As STRING = "update-no-steps";
 
 Parameter ModuleStepAddedOlderVersion As STRING = "update-step-added-to-older-version-class";
 
-Parameter ModuleStepAddedNewVersion As STRING = "update-step-added-curr-version-class";
+Parameter ModuleStepAddedCurrVersion As STRING = "update-step-added-curr-version-class";
 
 Parameter ModuleOneVersion As STRING = "1.2.1";
 
@@ -55,203 +55,141 @@ Method TestModuleUpdateStepAddedOlderVersion()
 
 Method TestAllNoErrorModulesNoMirror()
 {
-  #; if $system.Mirror.IsMember() {
-  #;   return
-  #; }
-  #; // Simple module without dependencies
-  #; set updateStepsToSeed = [["UpdatePackage.V1", "MethodA", 1]]
-  #; set updateStepsToRun = [["UpdatePackage.V1", "MethodB", 0], ["UpdatePackage.V1", "MethodC", 1], ["UpdatePackage.V2", "MethodA", 1], ["UpdatePackage.V2", "MethodC", 1], ["UpdatePackage.V2", "MethodB", 0]]
-  #; do ..NormalUpdateTestSuite(..#ModuleNoDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  if $system.Mirror.IsMember() {
+    return
+  }
+  // Simple module without dependencies
+  set updateStepsToSeed = [["UpdatePackage.V1", "MethodA", 1]]
+  set updateStepsToRun = [["UpdatePackage.V1", "MethodB", 0], ["UpdatePackage.V1", "MethodC", 1], ["UpdatePackage.V2", "MethodA", 1], ["UpdatePackage.V2", "MethodC", 1], ["UpdatePackage.V2", "MethodB", 0]]
+  do ..NormalUpdateTestSuite(..#ModuleNoDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
 
-  #; // Module with dependencies
-  #; set updateStepsToSeed = updateStepsToSeed.addAll([["UpdateDeps.UpdatePackage.V1", "MethodA", 1]])
-  #; set updateStepsToRun = updateStepsToRun.addAll([["UpdateDeps.UpdatePackage.V1", "MethodB", 0], ["UpdateDeps.UpdatePackage.V1", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodA", 1], ["UpdateDeps.UpdatePackage.V2", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodB", 0]])
-  #; do ..NormalUpdateTestSuite(..#ModuleWithDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  // Module with dependencies
+  set updateStepsToSeed = updateStepsToSeed.addAll([["UpdateDeps.UpdatePackage.V1", "MethodA", 1]])
+  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDeps.UpdatePackage.V1", "MethodB", 0], ["UpdateDeps.UpdatePackage.V1", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodA", 1], ["UpdateDeps.UpdatePackage.V2", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodB", 0]])
+  do ..NormalUpdateTestSuite(..#ModuleWithDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
 
-  #; // Module with dependencies added in new version
-  #; set updateStepsToSeed = [["UpdateDepsAdded.UpdatePackage.V1", "MethodA", 1]]
-  #; set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsAdded.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsAdded.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodB", 0]])
-  #; do ..SingleNormalUpdateTest(..#ModuleWithDependenciesAdded, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
-  #; do ..CleanUpModule(..#ModuleWithDependenciesAdded)
+  // Module with dependencies added in new version
+  set updateStepsToSeed = [["UpdateDepsAdded.UpdatePackage.V1", "MethodA", 1]]
+  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsAdded.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsAdded.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodB", 0]])
+  do ..SingleNormalUpdateTest(..#ModuleWithDependenciesAdded, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
+  do ..CleanUpModule(..#ModuleWithDependenciesAdded)
 
-  #; // Module with dependencies added in new version
-  #; set updateStepsToSeed = [["UpdateDepsRemoved.UpdatePackage.V1", "MethodA", 1], ["UpdatePackage.V1", "MethodA", 1]]
-  #; set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsRemoved.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsRemoved.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodB", 0]])
-  #; do ..SingleNormalUpdateTest(..#ModuleWithDependenciesRemoved, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
-  #; do ..CleanUpModule(..#ModuleWithDependenciesAdded)
+  // Module with dependencies added in new version
+  set updateStepsToSeed = [["UpdateDepsRemoved.UpdatePackage.V1", "MethodA", 1], ["UpdatePackage.V1", "MethodA", 1]]
+  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsRemoved.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsRemoved.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodB", 0]])
+  do ..SingleNormalUpdateTest(..#ModuleWithDependenciesRemoved, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
+  do ..CleanUpModule(..#ModuleWithDependenciesAdded)
 
   // Module with no update steps
   do ..SingleNormalUpdateTest(..#ModuleNoUpdateSteps, [], [], ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
   do ..CleanUpModule(..#ModuleNoUpdateSteps)
 }
 
-// Method TestAllErrorModulesNoMirror()
-
-// {
-
-//   do ..SingleFailedUpdateTest(..#ModuleStepAddedOlderVersion, ..#ModuleTwoVersion, ..#ModuleThreeVersion)
-
-//   do ..CleanUpModule(moduleName)
-
-// }
-
-// Method TestUpdateOfUninstalledModule()
-
-// {
-
-//   // Make sure the module is not installed
-
-//   if (##class(%IPM.Storage.Module).NameExists(..#ModuleNoDependencies)) {
-
-//     set sc = ##class(%IPM.Main).Shell("uninstall "_..#ModuleNoDependencies)
-
-//     $$$ThrowOnError(sc)
-
-//   }
-
-//   // Update non-existent module
-
-//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleOneVersion)
-
-//   do $$$AssertStatusNotOK(sc)
-
-// }
-
-// Method TestUpdateToOlderVersion()
-
-// {
-
-//   // Load module
-
-//   do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleTwoVersion)
-
-//   // Update module
-
-//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleOneVersion)
-
-//   do $$$AssertStatusNotOK(sc, "Attempt at updating module to older version failed.")
-
-//   do $$$AssertTrue((sc [ "version"), "Error message is descriptive and correctly mentions 'version'")
-
-//   do ..CleanUpModule(..#ModuleNoDependencies)
-
-// }
-
-// Method TestUpdateToInvalidVersion()
-
-// {
-
-//   // Load module
-
-//   do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
-
-//   // Update module
-
-//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" 1.0.0")
-
-//   do $$$AssertStatusNotOK(sc, "Attempt at updating module to non-existent version failed.")
-
-//   do ..CleanUpModule(..#ModuleNoDependencies)
-
-// }
-
-// Method TestUpdateToNewVersionTwice()
-
-// {
-
-//   // Load module
-
-//   do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
-
-//   // Update module to a 2.x version
-
-//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
-
-//   do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleTwoVersion_" without error")
-
-//   // Update module to a 3.x version
-
-//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleThreeVersion)
-
-//   do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleThreeVersion_" without error")
-
-//   do ..CleanUpModule(..#ModuleNoDependencies)
-
-// }
-
-// Method TestUpdateToSameVersionTwiceNoMirror()
-
-// {
-
-//   if $system.Mirror.IsMember() {
-
-//     return
-
-//   }
-
-//   // Load module
-
-//   do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
-
-//   // Update module to a 2.x version
-
-//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
-
-//   do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleTwoVersion_"without error")
-
-//   // Get timestamps of the V2 methods
-
-//   set stepTwoA = ..GetUpdateStep("UpdatePackage.V2", "MethodA", 1)
-
-//   set stepTwoB = ..GetUpdateStep("UpdatePackage.V2", "MethodB", 0)
-
-//   set stepTwoC = ..GetUpdateStep("UpdatePackage.V2", "MethodC", 1)
-
-//   set twoAStart = stepTwoA.TimeStampStart
-
-//   set twoAEnd = stepTwoA.TimeStampEnd
-
-//   set twoBStart = stepTwoB.TimeStampStart
-
-//   set twoBEnd = stepTwoB.TimeStampEnd
-
-//   set twoCStart = stepTwoC.TimeStampStart
-
-//   set twoCEnd = stepTwoC.TimeStampEnd
-
-//   // Update module to SAME version
-
-//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
-
-//   do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleTwoVersion_"without error")
-
-//   // Reload UpdateStep persistence to get the (hopefully not updated) version
-
-//   set stepTwoA = ..GetUpdateStep("UpdatePackage.V2", "MethodA", 1)
-
-//   set stepTwoB = ..GetUpdateStep("UpdatePackage.V2", "MethodB", 0)
-
-//   set stepTwoC = ..GetUpdateStep("UpdatePackage.V2", "MethodC", 1)
-
-//   // Check that second update does not rerun update steps
-
-//   // (timestamps on each update step should not have changed)
-
-//   do $$$AssertEquals(twoAStart, stepTwoA.TimeStampStart)
-
-//   do $$$AssertEquals(twoAEnd, stepTwoA.TimeStampEnd)
-
-//   do $$$AssertEquals(twoBStart, stepTwoB.TimeStampStart)
-
-//   do $$$AssertEquals(twoBEnd, stepTwoB.TimeStampEnd)
-
-//   do $$$AssertEquals(twoCStart, stepTwoC.TimeStampStart)
-
-//   do $$$AssertEquals(twoCEnd, stepTwoC.TimeStampEnd)
-
-//   do ..CleanUpModule(..#ModuleNoDependencies)
-
-// }
+Method TestAllErrorModulesNoMirror()
+{
+  #; do ..SingleFailedUpdateTest(..#ModuleStepAddedOlderVersion, ..#ModuleTwoVersion, ..#ModuleThreeVersion)
+  #; do ..CleanUpModule(moduleName)
+}
+
+Method TestUpdateOfUninstalledModule()
+{
+  // Make sure the module is not installed
+  if (##class(%IPM.Storage.Module).NameExists(..#ModuleNoDependencies)) {
+    set sc = ##class(%IPM.Main).Shell("uninstall "_..#ModuleNoDependencies)
+    $$$ThrowOnError(sc)
+  }
+
+  // Update non-existent module
+  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleOneVersion)
+  do $$$AssertStatusNotOK(sc)
+}
+
+Method TestUpdateToOlderVersion()
+{
+  // Install module
+  do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleTwoVersion)
+
+  // Update module
+  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleOneVersion)
+  do $$$AssertStatusNotOK(sc, "Attempt at updating module to older version failed.")
+  do $$$AssertTrue((sc [ "version"), "Error message is descriptive and correctly mentions 'version'")
+
+  do ..CleanUpModule(..#ModuleNoDependencies)
+}
+
+Method TestUpdateToInvalidVersion()
+{
+  // Install module
+  do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
+
+  // Update module
+  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" 1.0.0")
+  do $$$AssertStatusNotOK(sc, "Attempt at updating module to non-existent version failed.")
+
+  do ..CleanUpModule(..#ModuleNoDependencies)
+}
+
+Method TestUpdateToNewVersionTwice()
+{
+  // Install module
+  do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
+
+  // Update module to a 2.x version
+  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
+  do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleTwoVersion_" without error")
+
+  // Update module to a 3.x version
+  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleThreeVersion)
+  do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleThreeVersion_" without error")
+
+  do ..CleanUpModule(..#ModuleNoDependencies)
+}
+
+Method TestUpdateToSameVersionTwiceNoMirror()
+{
+
+  if $system.Mirror.IsMember() {
+    return
+  }
+
+  // Load module
+  do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
+
+  // Update module to a 2.x version
+  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
+  do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleTwoVersion_"without error")
+
+  // Get timestamps of the V2 methods
+  set stepTwoA = ..GetUpdateStep("UpdatePackage.V2", "MethodA", 1)
+  set stepTwoB = ..GetUpdateStep("UpdatePackage.V2", "MethodB", 0)
+  set stepTwoC = ..GetUpdateStep("UpdatePackage.V2", "MethodC", 1)
+  set twoAStart = stepTwoA.TimeStampStart
+  set twoAEnd = stepTwoA.TimeStampEnd
+  set twoBStart = stepTwoB.TimeStampStart
+  set twoBEnd = stepTwoB.TimeStampEnd
+  set twoCStart = stepTwoC.TimeStampStart
+  set twoCEnd = stepTwoC.TimeStampEnd
+
+  // Update module to SAME version
+  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
+  do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleTwoVersion_"without error")
+
+  // Reload UpdateStep persistence to get the (hopefully not updated) version
+  set stepTwoA = ..GetUpdateStep("UpdatePackage.V2", "MethodA", 1)
+  set stepTwoB = ..GetUpdateStep("UpdatePackage.V2", "MethodB", 0)
+  set stepTwoC = ..GetUpdateStep("UpdatePackage.V2", "MethodC", 1)
+
+  // Check that second update does not rerun update steps
+  // (timestamps on each update step should not have changed)
+  do $$$AssertEquals(twoAStart, stepTwoA.TimeStampStart)
+  do $$$AssertEquals(twoAEnd, stepTwoA.TimeStampEnd)
+  do $$$AssertEquals(twoBStart, stepTwoB.TimeStampStart)
+  do $$$AssertEquals(twoBEnd, stepTwoB.TimeStampEnd)
+  do $$$AssertEquals(twoCStart, stepTwoC.TimeStampStart)
+  do $$$AssertEquals(twoCEnd, stepTwoC.TimeStampEnd)
+
+  do ..CleanUpModule(..#ModuleNoDependencies)
+}
 
 /// ///////////////////////////////////////////// HELPER METHODS ////////////////////////////////////////////////
 /// Runs through four variations of update for a given module that are each expected to complete successfully:
@@ -347,8 +285,8 @@ Method SingleNormalUpdateNewStepTest(
 
 /// NOTE: For testing simplicity, we will always assume that in the update test, both the module and its dependencies are being updated
 /// from and to the same version numbers.
-/// Completes an update of given moduleName from fromVersion to toVersion, verifying that the given updateStepsToSeed are seeded
-/// and that the given updateStepsToRun are run
+/// Verifies that updating the given moduleName from fromVersion to toVersion FAILS, checking that the given updateStepsToSeed are seeded
+/// but that the "update" command throws an error.
 /// @argument moduleName          Name of module to install and update
 /// @argument updateStepsToSeed   Array of [className, methodName, isPrimaryOnlyStep] update steps that are defined in the module PRE-update
 /// @argument updateStepsToRun    Array of [className, methodName, isPrimaryOnlyStep] update steps that exist in the new version of the module POST-update

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -163,10 +163,13 @@ Method TestUpdateToSameVersionTwiceNoMirror()
   set stepTwoA = ..GetUpdateStep("UpdatePackage.V2", "MethodA", 1)
   set stepTwoB = ..GetUpdateStep("UpdatePackage.V2", "MethodB", 0)
   set stepTwoC = ..GetUpdateStep("UpdatePackage.V2", "MethodC", 1)
+
   set twoAStart = stepTwoA.TimeStampStart
   set twoAEnd = stepTwoA.TimeStampEnd
+
   set twoBStart = stepTwoB.TimeStampStart
   set twoBEnd = stepTwoB.TimeStampEnd
+
   set twoCStart = stepTwoC.TimeStampStart
   set twoCEnd = stepTwoC.TimeStampEnd
 
@@ -183,8 +186,10 @@ Method TestUpdateToSameVersionTwiceNoMirror()
   // (timestamps on each update step should not have changed)
   do $$$AssertEquals(twoAStart, stepTwoA.TimeStampStart)
   do $$$AssertEquals(twoAEnd, stepTwoA.TimeStampEnd)
+
   do $$$AssertEquals(twoBStart, stepTwoB.TimeStampStart)
   do $$$AssertEquals(twoBEnd, stepTwoB.TimeStampEnd)
+
   do $$$AssertEquals(twoCStart, stepTwoC.TimeStampStart)
   do $$$AssertEquals(twoCEnd, stepTwoC.TimeStampEnd)
 

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -5,6 +5,8 @@ Parameter ModuleNoDependencies As STRING = "update-simple";
 
 Parameter ModuleWithDependencies As STRING = "update-deps";
 
+Parameter ModuleWithDependenciesAdded As STRING = "update-deps-added";
+
 Parameter ModuleOneVersion As STRING = "1.2.1";
 
 Parameter ModuleTwoVersion As STRING = "2.1.1";
@@ -13,19 +15,11 @@ Parameter ModuleThreeVersion As STRING = "3.5.0";
 
 Parameter UpdateTestRepo As STRING = "update-test-modules";
 
-Method OnBeforeOneTest() As %Status
-{
-  // Setup repo pointing to all modules used for tests in this class
-  set sc = ##class(%IPM.Main).Shell("repo -n "_..#UpdateTestRepo_"-fs -path /home/irisowner/zpm/tests/integration_tests/Test/PM/Integration/_data/update-test/")
-  do $$$AssertStatusOK(sc,"Created "_..#UpdateTestRepo_" repo successfully.")
-  return sc
-}
-
-Method OnAfterOneTest() As %Status
+Method OnBeforeAllTests() As %Status
 {
   // Clean up repo used for tests
-  set sc = ##class(%IPM.Main).Shell("repo -delete -name "_..#UpdateTestRepo)
-  do $$$AssertStatusOK(sc,"Deleted "_..#UpdateTestRepo_" repo successfully.")
+  set sc = ##class(%IPM.Main).Shell("repo -delete-all")
+  set sc = ##class(%IPM.Main).Shell("repo -n "_..#UpdateTestRepo_" -fs -path /home/irisowner/zpm/tests/integration_tests/Test/PM/Integration/_data/update-test/")
   return sc
 }
 
@@ -37,12 +31,17 @@ Method TestAllNoErrorModulesNoMirror()
   // Simple module without dependencies
   set updateStepsToSeed = [["UpdatePackage.V1", "MethodA", 1]]
   set updateStepsToRun = [["UpdatePackage.V1", "MethodB", 0], ["UpdatePackage.V1", "MethodC", 1], ["UpdatePackage.V2", "MethodA", 1], ["UpdatePackage.V2", "MethodC", 1], ["UpdatePackage.V2", "MethodB", 0]]
-  do ..DoNormalUpdateNoMirror(..ModuleNoDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  do ..NormalUpdateTestSuite(..#ModuleNoDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
 
   // Module with dependencies
   set updateStepsToSeed = updateStepsToSeed.addAll([["UpdateDeps.UpdatePackage.V1", "MethodA", 1]])
   set updateStepsToRun = updateStepsToRun.addAll([["UpdateDeps.UpdatePackage.V1", "MethodB", 0], ["UpdateDeps.UpdatePackage.V1", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodA", 1], ["UpdateDeps.UpdatePackage.V2", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodB", 0]])
-  do ..DoNormalUpdateNoMirror(..ModuleWithDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  do ..NormalUpdateTestSuite(..#ModuleWithDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+
+  // Module with dependencies added in new version
+  set updateStepsToSeed = [["UpdateDepsAdded.UpdatePackage.V1", "MethodA", 1]]
+  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsAdded.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsAdded.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodB", 0]])
+  do ..NormalUpdateTestSuite(..#ModuleWithDependenciesAdded, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
 }
 
 Method TestUpdateToOlderVersion()

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -60,7 +60,7 @@ Method TestAllNoErrorModulesNoMirror()
 
   // Module with dependencies added in new version
   set updateStepsToSeed = [["UpdateDepsAdded.UpdatePackage.V1", "MethodA", 1]]
-  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsAdded.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsAdded.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodB", 0]])
+  set updateStepsToRun = [["UpdateDepsAdded.UpdatePackage.V1", "MethodB", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodB", 0]]
   do ..SingleNormalUpdateTest(..#ModuleWithDependenciesAdded, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
   do ..CleanUpModule(..#ModuleWithDependenciesAdded)
 

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -9,7 +9,15 @@ Parameter ModuleWithDependenciesAdded As STRING = "update-deps-added";
 
 Parameter ModuleWithDependenciesRemoved As STRING = "update-deps-removed";
 
+Parameter ModuleNoUpdateSteps As STRING = "update-no-steps";
+
+Parameter ModuleStepAddedOlderVersion As STRING = "update-step-added-to-older-version-class";
+
+Parameter ModuleStepAddedNewVersion As STRING = "update-step-added-curr-version-class";
+
 Parameter ModuleOneVersion As STRING = "1.2.1";
+
+Parameter ModuleOneVersionMinorBump As STRING = "1.3.1";
 
 Parameter ModuleTwoVersion As STRING = "2.1.1";
 
@@ -25,121 +33,225 @@ Method OnBeforeAllTests() As %Status
   return sc
 }
 
+Method TestModuleUpdateStepAddedOlderVersion()
+{
+  // Test updating module when update step is added to an older V# class
+  set updateStepsToSeed = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodB", 0]]
+  set seededUpdateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1]]
+  set seededUpdateStepsToNotRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodB", 0]]
+  set updateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodD", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodC", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V3", "MethodA", 1]]
+
+  do ..SingleNormalUpdateNewStepTest(..#ModuleStepAddedOlderVersion, updateStepsToSeed, seededUpdateStepsToRun, seededUpdateStepsToNotRun, updateStepsToRun, ..#ModuleTwoVersion, ..#ModuleThreeVersion)
+  do ..CleanUpModule(..#ModuleStepAddedOlderVersion)
+
+  // Test updating module when new update step is added to current V# class which precedes existing update steps in order
+  set updateStepsToSeed = [["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodC", 1]]
+  set seededUpdateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1]]
+  set updateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodD", 0]]
+
+  do ..SingleNormalUpdateNewStepTest(..#ModuleStepAddedCurrVersion, updateStepsToSeed, seededUpdateStepsToRun, [], updateStepsToRun, ..#ModuleOneVersion, ..#ModuleOneVersionMinorBump)
+  do ..CleanUpModule(..#ModuleStepAddedCurrVersion)
+}
+
 Method TestAllNoErrorModulesNoMirror()
 {
-  if $system.Mirror.IsMember() {
-    return
-  }
-  // Simple module without dependencies
-  set updateStepsToSeed = [["UpdatePackage.V1", "MethodA", 1]]
-  set updateStepsToRun = [["UpdatePackage.V1", "MethodB", 0], ["UpdatePackage.V1", "MethodC", 1], ["UpdatePackage.V2", "MethodA", 1], ["UpdatePackage.V2", "MethodC", 1], ["UpdatePackage.V2", "MethodB", 0]]
-  do ..NormalUpdateTestSuite(..#ModuleNoDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  #; if $system.Mirror.IsMember() {
+  #;   return
+  #; }
+  #; // Simple module without dependencies
+  #; set updateStepsToSeed = [["UpdatePackage.V1", "MethodA", 1]]
+  #; set updateStepsToRun = [["UpdatePackage.V1", "MethodB", 0], ["UpdatePackage.V1", "MethodC", 1], ["UpdatePackage.V2", "MethodA", 1], ["UpdatePackage.V2", "MethodC", 1], ["UpdatePackage.V2", "MethodB", 0]]
+  #; do ..NormalUpdateTestSuite(..#ModuleNoDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
 
-  // Module with dependencies
-  set updateStepsToSeed = updateStepsToSeed.addAll([["UpdateDeps.UpdatePackage.V1", "MethodA", 1]])
-  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDeps.UpdatePackage.V1", "MethodB", 0], ["UpdateDeps.UpdatePackage.V1", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodA", 1], ["UpdateDeps.UpdatePackage.V2", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodB", 0]])
-  do ..NormalUpdateTestSuite(..#ModuleWithDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  #; // Module with dependencies
+  #; set updateStepsToSeed = updateStepsToSeed.addAll([["UpdateDeps.UpdatePackage.V1", "MethodA", 1]])
+  #; set updateStepsToRun = updateStepsToRun.addAll([["UpdateDeps.UpdatePackage.V1", "MethodB", 0], ["UpdateDeps.UpdatePackage.V1", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodA", 1], ["UpdateDeps.UpdatePackage.V2", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodB", 0]])
+  #; do ..NormalUpdateTestSuite(..#ModuleWithDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
 
-  // Module with dependencies added in new version
-  set updateStepsToSeed = [["UpdateDepsAdded.UpdatePackage.V1", "MethodA", 1]]
-  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsAdded.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsAdded.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodB", 0]])
-  do ..NormalUpdateTestSuite(..#ModuleWithDependenciesAdded, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  #; // Module with dependencies added in new version
+  #; set updateStepsToSeed = [["UpdateDepsAdded.UpdatePackage.V1", "MethodA", 1]]
+  #; set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsAdded.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsAdded.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodB", 0]])
+  #; do ..SingleNormalUpdateTest(..#ModuleWithDependenciesAdded, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
+  #; do ..CleanUpModule(..#ModuleWithDependenciesAdded)
 
-  // Module with dependencies added in new version
-  set updateStepsToSeed = [["UpdateDepsRemoved.UpdatePackage.V1", "MethodA", 1], ["UpdatePackage.V1", "MethodA", 1]]
-  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsRemoved.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsRemoved.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodB", 0]])
-  do ..NormalUpdateTestSuite(..#ModuleWithDependenciesRemoved, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  #; // Module with dependencies added in new version
+  #; set updateStepsToSeed = [["UpdateDepsRemoved.UpdatePackage.V1", "MethodA", 1], ["UpdatePackage.V1", "MethodA", 1]]
+  #; set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsRemoved.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsRemoved.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodB", 0]])
+  #; do ..SingleNormalUpdateTest(..#ModuleWithDependenciesRemoved, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
+  #; do ..CleanUpModule(..#ModuleWithDependenciesAdded)
+
+  // Module with no update steps
+  do ..SingleNormalUpdateTest(..#ModuleNoUpdateSteps, [], [], ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
+  do ..CleanUpModule(..#ModuleNoUpdateSteps)
 }
 
-Method TestUpdateToOlderVersion()
-{
-  // Load module
-  do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleTwoVersion)
+// Method TestAllErrorModulesNoMirror()
 
-  // Update module
-  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleOneVersion)
-  do $$$AssertStatusNotOK(sc, "Attempt at updating module to older version failed.")
-  do $$$AssertTrue((sc [ "version"), "Error message is descriptive and correctly mentions 'version'")
+// {
 
-  do ..CleanUpModule(..#ModuleNoDependencies)
-}
+//   do ..SingleFailedUpdateTest(..#ModuleStepAddedOlderVersion, ..#ModuleTwoVersion, ..#ModuleThreeVersion)
 
-Method TestUpdateToInvalidVersion()
-{
-  // Load module
-  do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
+//   do ..CleanUpModule(moduleName)
 
-  // Update module
-  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" 1.0.0")
-  do $$$AssertStatusNotOK(sc, "Attempt at updating module to non-existent version failed.")
+// }
 
-  do ..CleanUpModule(..#ModuleNoDependencies)
-}
+// Method TestUpdateOfUninstalledModule()
 
-Method TestUpdateToNewVersionTwice()
-{
-  // Load module
-  do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
+// {
 
-  // Update module to a 2.x version
-  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
-  do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleTwoVersion_" without error")
+//   // Make sure the module is not installed
 
-  // Update module to a 3.x version
-  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleThreeVersion)
-  do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleThreeVersion_" without error")
+//   if (##class(%IPM.Storage.Module).NameExists(..#ModuleNoDependencies)) {
 
-  do ..CleanUpModule(..#ModuleNoDependencies)
-}
+//     set sc = ##class(%IPM.Main).Shell("uninstall "_..#ModuleNoDependencies)
 
-Method TestUpdateToSameVersionTwiceNoMirror()
-{
-  if $system.Mirror.IsMember() {
-    return
-  }
-  // Load module
-  do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
+//     $$$ThrowOnError(sc)
 
-  // Update module to a 2.x version
-  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
-  do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleTwoVersion_"without error")
+//   }
 
-  // Get timestamps of the V2 methods
-  set stepTwoA = ..GetUpdateStep("UpdatePackage.V2", "MethodA", 1)
-  set stepTwoB = ..GetUpdateStep("UpdatePackage.V2", "MethodB", 0)
-  set stepTwoC = ..GetUpdateStep("UpdatePackage.V2", "MethodC", 1)
+//   // Update non-existent module
 
-  set twoAStart = stepTwoA.TimeStampStart
-  set twoAEnd = stepTwoA.TimeStampEnd
+//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleOneVersion)
 
-  set twoBStart = stepTwoB.TimeStampStart
-  set twoBEnd = stepTwoB.TimeStampEnd
+//   do $$$AssertStatusNotOK(sc)
 
-  set twoCStart = stepTwoC.TimeStampStart
-  set twoCEnd = stepTwoC.TimeStampEnd
+// }
 
-  // Update module to SAME version
-  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
-  do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleTwoVersion_"without error")
+// Method TestUpdateToOlderVersion()
 
-  // Reload UpdateStep persistence to get the (hopefully not updated) version
-  set stepTwoA = ..GetUpdateStep("UpdatePackage.V2", "MethodA", 1)
-  set stepTwoB = ..GetUpdateStep("UpdatePackage.V2", "MethodB", 0)
-  set stepTwoC = ..GetUpdateStep("UpdatePackage.V2", "MethodC", 1)
+// {
 
-  // Check that second update does not rerun update steps
-  // (timestamps on each update step should not have changed)
-  do $$$AssertEquals(twoAStart, stepTwoA.TimeStampStart)
-  do $$$AssertEquals(twoAEnd, stepTwoA.TimeStampEnd)
+//   // Load module
 
-  do $$$AssertEquals(twoBStart, stepTwoB.TimeStampStart)
-  do $$$AssertEquals(twoBEnd, stepTwoB.TimeStampEnd)
+//   do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleTwoVersion)
 
-  do $$$AssertEquals(twoCStart, stepTwoC.TimeStampStart)
-  do $$$AssertEquals(twoCEnd, stepTwoC.TimeStampEnd)
+//   // Update module
 
-  do ..CleanUpModule(..#ModuleNoDependencies)
-}
+//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleOneVersion)
+
+//   do $$$AssertStatusNotOK(sc, "Attempt at updating module to older version failed.")
+
+//   do $$$AssertTrue((sc [ "version"), "Error message is descriptive and correctly mentions 'version'")
+
+//   do ..CleanUpModule(..#ModuleNoDependencies)
+
+// }
+
+// Method TestUpdateToInvalidVersion()
+
+// {
+
+//   // Load module
+
+//   do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
+
+//   // Update module
+
+//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" 1.0.0")
+
+//   do $$$AssertStatusNotOK(sc, "Attempt at updating module to non-existent version failed.")
+
+//   do ..CleanUpModule(..#ModuleNoDependencies)
+
+// }
+
+// Method TestUpdateToNewVersionTwice()
+
+// {
+
+//   // Load module
+
+//   do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
+
+//   // Update module to a 2.x version
+
+//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
+
+//   do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleTwoVersion_" without error")
+
+//   // Update module to a 3.x version
+
+//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleThreeVersion)
+
+//   do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleThreeVersion_" without error")
+
+//   do ..CleanUpModule(..#ModuleNoDependencies)
+
+// }
+
+// Method TestUpdateToSameVersionTwiceNoMirror()
+
+// {
+
+//   if $system.Mirror.IsMember() {
+
+//     return
+
+//   }
+
+//   // Load module
+
+//   do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
+
+//   // Update module to a 2.x version
+
+//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
+
+//   do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleTwoVersion_"without error")
+
+//   // Get timestamps of the V2 methods
+
+//   set stepTwoA = ..GetUpdateStep("UpdatePackage.V2", "MethodA", 1)
+
+//   set stepTwoB = ..GetUpdateStep("UpdatePackage.V2", "MethodB", 0)
+
+//   set stepTwoC = ..GetUpdateStep("UpdatePackage.V2", "MethodC", 1)
+
+//   set twoAStart = stepTwoA.TimeStampStart
+
+//   set twoAEnd = stepTwoA.TimeStampEnd
+
+//   set twoBStart = stepTwoB.TimeStampStart
+
+//   set twoBEnd = stepTwoB.TimeStampEnd
+
+//   set twoCStart = stepTwoC.TimeStampStart
+
+//   set twoCEnd = stepTwoC.TimeStampEnd
+
+//   // Update module to SAME version
+
+//   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
+
+//   do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleTwoVersion_"without error")
+
+//   // Reload UpdateStep persistence to get the (hopefully not updated) version
+
+//   set stepTwoA = ..GetUpdateStep("UpdatePackage.V2", "MethodA", 1)
+
+//   set stepTwoB = ..GetUpdateStep("UpdatePackage.V2", "MethodB", 0)
+
+//   set stepTwoC = ..GetUpdateStep("UpdatePackage.V2", "MethodC", 1)
+
+//   // Check that second update does not rerun update steps
+
+//   // (timestamps on each update step should not have changed)
+
+//   do $$$AssertEquals(twoAStart, stepTwoA.TimeStampStart)
+
+//   do $$$AssertEquals(twoAEnd, stepTwoA.TimeStampEnd)
+
+//   do $$$AssertEquals(twoBStart, stepTwoB.TimeStampStart)
+
+//   do $$$AssertEquals(twoBEnd, stepTwoB.TimeStampEnd)
+
+//   do $$$AssertEquals(twoCStart, stepTwoC.TimeStampStart)
+
+//   do $$$AssertEquals(twoCEnd, stepTwoC.TimeStampEnd)
+
+//   do ..CleanUpModule(..#ModuleNoDependencies)
+
+// }
 
 /// ///////////////////////////////////////////// HELPER METHODS ////////////////////////////////////////////////
 /// Runs through four variations of update for a given module that are each expected to complete successfully:
@@ -159,19 +271,115 @@ Method NormalUpdateTestSuite(
   do ..CleanUpModule(moduleName)
 
   // Dev mode, install
-  do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 1)
-  do ..CleanUpModule(moduleName)
+  #; do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 1)
+  #; do ..CleanUpModule(moduleName)
 
   // Dev mode, load
-  set exportDir = $system.Util.ManagerDirectory()_"/"_moduleName
-  do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 1, exportDir)
-  do ..CleanUpModule(moduleName)
-  do ..CleanUpDirectory(exportDir)
+  set exportDir = $system.Util.ManagerDirectory()_moduleName
+  #; do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 1, exportDir)
+  #; do ..CleanUpModule(moduleName)
+  #; do ..CleanUpDirectory(exportDir)
 
   // No dev mode, load
   do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 0, exportDir)
   do ..CleanUpModule(moduleName)
   do ..CleanUpDirectory(exportDir)
+}
+
+Method SingleNormalUpdateNewStepTest(
+	moduleName As %String,
+	updateStepsToSeed As %DynamicArray,
+	seededUpdateStepsToRun As %DynamicArray,
+	seededUpdateStepsToNotRun As %DynamicArray,
+	updateStepsToRun As %DynamicArray,
+	fromVersion As %String,
+	toVersion As %String)
+{
+  // Install module
+  do ..AssertModuleInstalledCorrectly(moduleName, fromVersion)
+
+  // Verify that update steps were correctly seeded and capture the TimeStampStart property for comparison
+  set timeStampArr = []
+  set iter = updateStepsToSeed.%GetIterator()
+  while iter.%GetNext(.key, .value) {
+    set className = value.%Get(0)
+    set methodName = value.%Get(1)
+    set isPrimaryOnly = value.%Get(2)
+
+    set updateStep = ..GetUpdateStep(className, methodName, isPrimaryOnly)
+    do $$$AssertTrue($isobject(updateStep), "Update step with class="_className_" and method="_methodName_" exists.")
+    set timeStampArr(className, methodName, isPrimaryOnly) = updateStep.TimeStampStart
+  }
+
+  // Update module
+  set sc = ##class(%IPM.Main).Shell("update -v "_moduleName_" "_toVersion)
+  do $$$AssertStatusOK(sc, "Updated module "_moduleName_" without error")
+
+  // Check that the seeded update methods within the same version class as the new update step was prepended to WERE run
+  set iter = seededUpdateStepsToRun.%GetIterator()
+  while iter.%GetNext(.key, .value) {
+    set className = value.%Get(0)
+    set methodName = value.%Get(1)
+    set isPrimaryOnly = value.%Get(2)
+
+    set updateStep = ..GetUpdateStep(className, methodName, isPrimaryOnly)
+    do $$$AssertNotEquals(timeStampArr(className, methodName, isPrimaryOnly), updateStep.TimeStampStart, "Seeded update step with class="_className_" and method="_methodName_" WAS run on update after step order changed.")
+  }
+
+  // Check that the rest of the seeded update methods WERE NOT run
+  set iter = seededUpdateStepsToNotRun.%GetIterator()
+  while iter.%GetNext(.key, .value) {
+    set className = value.%Get(0)
+    set methodName = value.%Get(1)
+    set isPrimaryOnly = value.%Get(2)
+
+    set updateStep = ..GetUpdateStep(className, methodName, isPrimaryOnly)
+    do $$$AssertEquals(timeStampArr(className, methodName, isPrimaryOnly), updateStep.TimeStampStart, "Seeded update step with class="_className_" and method="_methodName_" WAS NOT run on update after step order changed.")
+  }
+
+  // Check whether correct UpdateStep rows exist in the correct table after update command is run
+  do ..AssertUpdateStepsExist(updateStepsToRun)
+
+  // Check module version has been updated
+  set module = ##class(%IPM.Storage.Module).NameOpen(moduleName)
+  do $$$AssertEquals(module.VersionString, toVersion)
+}
+
+/// NOTE: For testing simplicity, we will always assume that in the update test, both the module and its dependencies are being updated
+/// from and to the same version numbers.
+/// Completes an update of given moduleName from fromVersion to toVersion, verifying that the given updateStepsToSeed are seeded
+/// and that the given updateStepsToRun are run
+/// @argument moduleName          Name of module to install and update
+/// @argument updateStepsToSeed   Array of [className, methodName, isPrimaryOnlyStep] update steps that are defined in the module PRE-update
+/// @argument updateStepsToRun    Array of [className, methodName, isPrimaryOnlyStep] update steps that exist in the new version of the module POST-update
+/// @argument fromVersion         Version of module to install
+/// @argument toVersion           Version of module to which to update
+Method SingleFailedUpdateTest(
+	moduleName As %String,
+	updateStepsToSeed As %DynamicArray,
+	updateStepsToRun As %DynamicArray,
+	fromVersion As %String,
+	toVersion As %String)
+{
+  // Install module
+  do ..AssertModuleInstalledCorrectly(moduleName, fromVersion)
+
+  // Verify that update steps were correctly seeded and capture the TimeStampStart property for comparison
+  set timeStampArr = []
+  set iter = updateStepsToSeed.%GetIterator()
+  while iter.%GetNext(.key, .value) {
+    set className = value.%Get(0)
+    set methodName = value.%Get(1)
+    set isPrimaryOnly = value.%Get(2)
+
+    set updateStep = ..GetUpdateStep(className, methodName, isPrimaryOnly)
+    do $$$AssertTrue($isobject(updateStep), "Update step with class="_className_" and method="_methodName_" exists.")
+    set timeStampArr(className, methodName, isPrimaryOnly) = updateStep.TimeStampStart
+  }
+
+  // Update module (with appropriate flags)
+  set sc = ##class(%IPM.Main).Shell("update -v "_moduleName_" "_toVersion)
+  do $$$AssertStatusNotOK(sc, "Attempting to update module "_moduleName_" FAILED.")
 }
 
 /// NOTE: For testing simplicity, we will always assume that in the update test, both the module and its dependencies are being updated
@@ -184,6 +392,7 @@ Method NormalUpdateTestSuite(
 /// @argument fromVersion         Version of module to install
 /// @argument toVersion           Version of module to which to update
 /// @argument developerMode       1 if update should be run with -dev flag, 0 otherwise
+/// @argument pathToModule        Path to the module tarball to load
 Method SingleNormalUpdateTest(
 	moduleName As %String,
 	updateStepsToSeed As %DynamicArray,
@@ -194,7 +403,7 @@ Method SingleNormalUpdateTest(
 	pathToModule As %String = "")
 {
   // Package module to update to (if we want to test updating from a tarball)
-  if pathToModule {
+  if (pathToModule '= "") {
     do ..AssertModulePackagedCorrectly(moduleName, toVersion, pathToModule)
   }
 
@@ -208,15 +417,16 @@ Method SingleNormalUpdateTest(
     set className = value.%Get(0)
     set methodName = value.%Get(1)
     set isPrimaryOnly = value.%Get(2)
+    write !, "[SEEDED] Module: "_moduleName_", Class: "_className_" Method: "_methodName_" isPrimaryOnly: "_isPrimaryOnly
 
     set updateStep = ..GetUpdateStep(className, methodName, isPrimaryOnly)
-    do $$$AssertTrue(%IsObject(updateStep), "Update step with class="_className_" and method="_methodName_" exists.")
+    do $$$AssertTrue($isobject(updateStep), "Update step with class="_className_" and method="_methodName_" exists.")
     set timeStampArr(className, methodName, isPrimaryOnly) = updateStep.TimeStampStart
   }
 
   // Update module (with appropriate flags)
   set devFlag = $select(developerMode: "-dev ", 1: "")
-  set pathFlag = $select(pathToModule: "-path="_pathToModule_" ", 1: "")
+  set pathFlag = $select((pathToModule '= ""): "-path "_pathToModule_" ", 1: "")
   set sc = ##class(%IPM.Main).Shell("update -v "_devFlag_pathFlag_moduleName_" "_toVersion)
   do $$$AssertStatusOK(sc, "Updated module "_moduleName_" without error")
 
@@ -228,7 +438,7 @@ Method SingleNormalUpdateTest(
     set isPrimaryOnly = value.%Get(2)
 
     set updateStep = ..GetUpdateStep(className, methodName, isPrimaryOnly)
-    do $$$AssertTrue(%IsObject(updateStep), "Update step with class="_className_" and method="_methodName_" exists.")
+    do $$$AssertTrue($isobject(updateStep), "Update step with class="_className_" and method="_methodName_" exists.")
     do $$$AssertEquals(timeStampArr(className, methodName, isPrimaryOnly), updateStep.TimeStampStart, "Seeded update step with class="_className_" and method="_methodName_" was correctly not rerun on update.")
   }
 
@@ -268,7 +478,7 @@ Method AssertUpdateStepsExist(updateStepsList As %DynamicArray)
     set isPrimaryOnly = value.%Get(2)
 
     set updateStep = ..GetUpdateStep(className, methodName, isPrimaryOnly)
-    do $$$AssertTrue(%IsObject(updateStep), "Update step with class="_className_" and method="_methodName_" exists.")
+    do $$$AssertTrue($isobject(updateStep), "Update step with class="_className_" and method="_methodName_" exists.")
   }
 }
 
@@ -277,7 +487,7 @@ Method AssertModuleInstalledCorrectly(
 	moduleVersion As %String)
 {
   set sc = ##class(%IPM.Main).Shell("install -v "_moduleName_" "_moduleVersion)
-  do $$$AssertStatusOK(sc, "Loaded module successfully")
+  do $$$AssertStatusOK(sc,"Installed "_moduleName_" version = "_moduleVersion_" successfully.")
 }
 
 Method AssertModulePackagedCorrectly(
@@ -287,11 +497,11 @@ Method AssertModulePackagedCorrectly(
 {
   // Initial install of module (necessary to be able to package)
   set sc = ##class(%IPM.Main).Shell("install "_moduleName_" "_version)
-  do $$$AssertStatusOK(sc,"Installed "_moduleName_" version = "_version_" successfully.")
+  do $$$AssertStatusOK(sc,"Installed "_moduleName_" version = "_version_" successfully for packaging.")
 
   // Package module
-  set sc = ##class(%IPM.Main).Shell(_moduleName_" package -only -v -DPath="_packageDir)
-  do $$$AssertStatusOK(sc, "Successfully packaged module to "_packageDir)
+  set sc = ##class(%IPM.Main).Shell(moduleName_" package -only -v -DPath="_packageDir)
+  do $$$AssertStatusOK(sc, "Successfully packaged module "_moduleName_" to "_packageDir)
 
   // Uninstall module
   do ..CleanUpModule(moduleName)
@@ -315,12 +525,17 @@ ClassMethod CleanUpModule(moduleName As %String)
 {
   set sc = ##class(%IPM.Main).Shell("uninstall -r "_moduleName)
   $$$ThrowOnError(sc)
+
+  return
 }
 
 ClassMethod CleanUpDirectory(dir As %String)
 {
-  set sc = ##class(%File).RemoveDirectoryTree(dir, .return)
-  $$$ThrowOnError(sc)
+  set isRemoved = ##class(%File).RemoveDirectoryTree(dir)
+  if 'isRemoved {
+    $$$ThrowOnError($$$ERROR($$$GeneralError,$$$FormatText("Unable to remove directory tree for dir = '%1", dir)))
+  }
+  return
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -7,6 +7,8 @@ Parameter ModuleWithDependencies As STRING = "update-deps";
 
 Parameter ModuleWithDependenciesAdded As STRING = "update-deps-added";
 
+Parameter ModuleWithDependenciesRemoved As STRING = "update-deps-removed";
+
 Parameter ModuleOneVersion As STRING = "1.2.1";
 
 Parameter ModuleTwoVersion As STRING = "2.1.1";
@@ -42,6 +44,11 @@ Method TestAllNoErrorModulesNoMirror()
   set updateStepsToSeed = [["UpdateDepsAdded.UpdatePackage.V1", "MethodA", 1]]
   set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsAdded.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsAdded.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsAdded.UpdatePackage.V2", "MethodB", 0]])
   do ..NormalUpdateTestSuite(..#ModuleWithDependenciesAdded, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+
+  // Module with dependencies added in new version
+  set updateStepsToSeed = [["UpdateDepsRemoved.UpdatePackage.V1", "MethodA", 1], ["UpdatePackage.V1", "MethodA", 1]]
+  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsRemoved.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsRemoved.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodB", 0]])
+  do ..NormalUpdateTestSuite(..#ModuleWithDependenciesRemoved, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
 }
 
 Method TestUpdateToOlderVersion()

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -15,6 +15,8 @@ Parameter ModuleStepAddedOlderVersion As STRING = "update-step-added-to-older-ve
 
 Parameter ModuleStepAddedCurrVersion As STRING = "update-step-added-curr-version-class";
 
+Parameter ModuleStepErrors As STRING = "update-step-errors";
+
 Parameter ModuleOneVersion As STRING = "1.2.1";
 
 Parameter ModuleOneVersionMinorBump As STRING = "1.3.1";
@@ -31,26 +33,6 @@ Method OnBeforeAllTests() As %Status
   set sc = ##class(%IPM.Main).Shell("repo -delete-all")
   set sc = ##class(%IPM.Main).Shell("repo -n "_..#UpdateTestRepo_" -fs -path /home/irisowner/zpm/tests/integration_tests/Test/PM/Integration/_data/update-test/")
   return sc
-}
-
-Method TestModuleUpdateStepAddedOlderVersion()
-{
-  // Test updating module when update step is added to an older V# class
-  set updateStepsToSeed = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodB", 0]]
-  set seededUpdateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1]]
-  set seededUpdateStepsToNotRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodB", 0]]
-  set updateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodD", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodC", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V3", "MethodA", 1]]
-
-  do ..SingleNormalUpdateNewStepTest(..#ModuleStepAddedOlderVersion, updateStepsToSeed, seededUpdateStepsToRun, seededUpdateStepsToNotRun, updateStepsToRun, ..#ModuleTwoVersion, ..#ModuleThreeVersion)
-  do ..CleanUpModule(..#ModuleStepAddedOlderVersion)
-
-  // Test updating module when new update step is added to current V# class which precedes existing update steps in order
-  set updateStepsToSeed = [["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodC", 1]]
-  set seededUpdateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1]]
-  set updateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodD", 0]]
-
-  do ..SingleNormalUpdateNewStepTest(..#ModuleStepAddedCurrVersion, updateStepsToSeed, seededUpdateStepsToRun, [], updateStepsToRun, ..#ModuleOneVersion, ..#ModuleOneVersionMinorBump)
-  do ..CleanUpModule(..#ModuleStepAddedCurrVersion)
 }
 
 Method TestAllNoErrorModulesNoMirror()
@@ -87,8 +69,28 @@ Method TestAllNoErrorModulesNoMirror()
 
 Method TestAllErrorModulesNoMirror()
 {
-  #; do ..SingleFailedUpdateTest(..#ModuleStepAddedOlderVersion, ..#ModuleTwoVersion, ..#ModuleThreeVersion)
-  #; do ..CleanUpModule(moduleName)
+  do ..SingleFailedUpdateTest(..#ModuleStepErrors, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  do ..CleanUpModule(..#ModuleStepErrors)
+}
+
+Method TestModuleUpdateStepAddedOlderVersion()
+{
+  // Test updating module when update step is added to an older V# class
+  set updateStepsToSeed = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodB", 0]]
+  set seededUpdateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1]]
+  set seededUpdateStepsToNotRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodB", 0]]
+  set updateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodD", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodC", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V3", "MethodA", 1]]
+
+  do ..SingleNormalUpdateNewStepTest(..#ModuleStepAddedOlderVersion, updateStepsToSeed, seededUpdateStepsToRun, seededUpdateStepsToNotRun, updateStepsToRun, ..#ModuleTwoVersion, ..#ModuleThreeVersion)
+  do ..CleanUpModule(..#ModuleStepAddedOlderVersion)
+
+  // Test updating module when new update step is added to current V# class which precedes existing update steps in order
+  set updateStepsToSeed = [["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodC", 1]]
+  set seededUpdateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1]]
+  set updateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodD", 0]]
+
+  do ..SingleNormalUpdateNewStepTest(..#ModuleStepAddedCurrVersion, updateStepsToSeed, seededUpdateStepsToRun, [], updateStepsToRun, ..#ModuleOneVersion, ..#ModuleOneVersionMinorBump)
+  do ..CleanUpModule(..#ModuleStepAddedCurrVersion)
 }
 
 Method TestUpdateOfUninstalledModule()

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -113,11 +113,72 @@ Method TestUpdateNonMatchingTarballFails()
 
   do ..AssertModuleInstalledCorrectly(moduleToUpdate, fromVersion)
 
-  set sc = ##class(%IPM.Main).Shell("update -v -path "_exportDir_" "_moduleToUpdate)
+  set sc = ##class(%IPM.Main).Shell("update "_moduleToUpdate_" -path "_exportDir_" -v")
   do $$$AssertStatusNotOK(sc, "Attempting to update module "_moduleToUpdate_" FAILED because the module in the path provided does not match the module to update.")
 
   do ..CleanUpModule(moduleToUpdate)
   do ..CleanUpDirectory(exportDir)
+}
+
+Method TestSimultaneousUpdateFails()
+{
+  do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
+
+  set isNamedResourceDeleted = $system.Event.Delete("FirstUpdate")
+  if 'isNamedResourceDeleted {
+    $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource FirstUpdate not deleted"))
+  }
+  set isNamedResourceDeleted = $system.Event.Delete("SecondUpdate")
+  if 'isNamedResourceDeleted {
+    $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource SecondUpdate not deleted"))
+  }
+
+  set isNamedResourceCreated = $system.Event.Create("FirstUpdate")
+  if 'isNamedResourceCreated {
+    $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource FirstUpdate not created"))
+  }
+  set isNamedResourceCreated = $system.Event.Create("SecondUpdate")
+  if 'isNamedResourceCreated {
+    $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource SecondUpdate not created"))
+  }
+
+  job ..UpdateJobWrapper(..#ModuleNoDependencies, ..#ModuleTwoVersion, "First Update")
+  job ..UpdateJobWrapper(..#ModuleNoDependencies, ..#ModuleThreeVersion, "Second Update")
+
+  set $listbuild(firstCode, firstResponse) = $system.Event.WaitMsg("First Update")
+  set $listbuild(secondCode, secondResponse) = $system.Event.WaitMsg("Second Update")
+
+  do $$$AssertStatusOK(firstResponse, "Update of module="_..#ModuleNoDependencies_" to version="_..#ModuleTwoVersion_" succeeded.")
+  do $$$AssertStatusNotOK(secondResponse, "Attempting to update module="_..#ModuleNoDependencies_" while another update of that module in the same namespace is in-progress failed.")
+
+  do ..CleanUpModule(..#ModuleNoDependencies)
+}
+
+Method TestUpdateAfterInterruptedUpdate()
+{
+  do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
+
+  set isNamedResourceCreated = $system.Event.Create("Interrupted Update")
+  if 'isNamedResourceCreated {
+    $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource FirstUpdate not created"))
+  }
+
+  job ..InterruptedUpdateJobWrapper(..#ModuleNoDependencies, ..#ModuleTwoVersion, "Interrupted Update")
+
+  // Gets child job ID
+  set $listbuild(codeOne, processId) = $system.Event.WaitMsg("Interrupted Update")
+  do $system.Process.Terminate(processId)
+
+  // Gets update status
+  set $listbuild(codeTwo, sc) = $system.Event.WaitMsg("Interrupted Update")
+  do $$$AssertStatusNotOK(sc, "Updating module "_..#ModuleNoDependencies_" from "_..#ModuleOneVersion_" to "_..#ModuleTwoVersion_" was interrupted and failed.")
+
+  // Perform another update
+  set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
+  do $$$AssertStatusOK(sc, "Update of module "_..#ModuleNoDependencies_" version "_..#ModuleTwoVersion_" after interrupted update succeeded.")
+
+  // Assert it completed
+  do ..CleanUpModule(..#ModuleNoDependencies)
 }
 
 Method TestModuleUpdateStepAdded()
@@ -150,7 +211,7 @@ Method TestUpdateOfUninstalledModule()
 
   // Update non-existent module
   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleOneVersion)
-  do $$$AssertStatusNotOK(sc)
+  do $$$AssertStatusNotOK(sc, "Update of uninstalled module "_..#ModuleNoDependencies_" version "_..#ModuleOneVersion_" failed.")
 }
 
 Method TestUpdateToOlderVersion()
@@ -498,6 +559,31 @@ Method AssertModulePackagedCorrectly(
   do ..CleanUpModule(moduleName)
 }
 
+ClassMethod UpdateJobWrapper(
+	moduleName,
+	toVersion,
+	resourceName)
+{
+  set sc = ##class(%IPM.Main).Shell("update "_moduleName_" "_toVersion_" -v")
+
+  // Send update status to the named resource
+  do $system.Event.Signal(resourceName, sc)
+}
+
+ClassMethod InterruptedUpdateJobWrapper(
+	moduleName,
+	toVersion,
+	resourceName)
+{
+  // Send job ID to the named resource
+  do $system.Event.Signal(resourceName, $system.SYS.ProcessID())
+
+  set sc = ##class(%IPM.Main).Shell("update "_moduleName_" "_toVersion_" -v")
+
+  // Send update status to the named resource
+  do $system.Event.Signal(resourceName, sc)
+}
+
 ClassMethod GetUpdateStep(
 	className As %String,
 	methodName As %String,
@@ -507,6 +593,10 @@ ClassMethod GetUpdateStep(
     set step = ##class(%IPM.Storage.UpdateStep.PrimaryOnly).GetUpdateStep(className, methodName)
   } else {
     set step = ##class(%IPM.Storage.UpdateStep.AnyMember).GetUpdateStep(className, methodName)
+  }
+
+  if step.%Id() = "" {
+    return ""
   }
 
   return step

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -3,6 +3,8 @@ Class Test.PM.Integration.Update Extends Test.PM.Integration.Base
 
 Parameter ModuleNoDependencies As STRING = "update-simple";
 
+Parameter ModuleWithDependencies As STRING = "update-deps";
+
 Parameter ModuleOneVersion As STRING = "1.2.1";
 
 Parameter ModuleTwoVersion As STRING = "2.1.1";
@@ -27,23 +29,20 @@ Method OnAfterOneTest() As %Status
   return sc
 }
 
-Method TestModuleNormalUpdateNoMirror()
+Method TestAllNoErrorModulesNoMirror()
 {
+  if $system.Mirror.IsMember() {
+    return
+  }
+  // Simple module without dependencies
   set updateStepsToSeed = [["UpdatePackage.V1", "MethodA", 1]]
   set updateStepsToRun = [["UpdatePackage.V1", "MethodB", 0], ["UpdatePackage.V1", "MethodC", 1], ["UpdatePackage.V2", "MethodA", 1], ["UpdatePackage.V2", "MethodC", 1], ["UpdatePackage.V2", "MethodB", 0]]
+  do ..DoNormalUpdateNoMirror(..ModuleNoDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
 
-  // No dev mode, install
-  do ..ModuleNormalUpdateNoMirrorHelper(..#ModuleNoDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
-
-  // Dev mode, install
-  do ..ModuleNormalUpdateNoMirrorHelper(..#ModuleNoDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 1)
-
-  // No dev mode, load
-  set exportDir = $system.Util.ManagerDirectory()
-  do ..ModuleNormalUpdateNoMirrorHelper(..#ModuleNoDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 1, exportDir)
-
-  set modulesToUninstall = [].%Push(..#ModuleNoDependencies)
-  do ..CleanUp(modulesToUninstall)
+  // Module with dependencies
+  set updateStepsToSeed = updateStepsToSeed.addAll([["UpdateDeps.UpdatePackage.V1", "MethodA", 1]])
+  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDeps.UpdatePackage.V1", "MethodB", 0], ["UpdateDeps.UpdatePackage.V1", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodA", 1], ["UpdateDeps.UpdatePackage.V2", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodB", 0]])
+  do ..DoNormalUpdateNoMirror(..ModuleWithDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
 }
 
 Method TestUpdateToOlderVersion()
@@ -56,8 +55,7 @@ Method TestUpdateToOlderVersion()
   do $$$AssertStatusNotOK(sc, "Attempt at updating module to older version failed.")
   do $$$AssertTrue((sc [ "version"), "Error message is descriptive and correctly mentions 'version'")
 
-  set modulesToUninstall = [].%Push(..#ModuleNoDependencies)
-  do ..CleanUp(modulesToUninstall)
+  do ..CleanUpModule(..#ModuleNoDependencies)
 }
 
 Method TestUpdateToInvalidVersion()
@@ -69,8 +67,7 @@ Method TestUpdateToInvalidVersion()
   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" 1.0.0")
   do $$$AssertStatusNotOK(sc, "Attempt at updating module to non-existent version failed.")
 
-  set modulesToUninstall = [].%Push(..#ModuleNoDependencies)
-  do ..CleanUp(modulesToUninstall)
+  do ..CleanUpModule(..#ModuleNoDependencies)
 }
 
 Method TestUpdateToNewVersionTwice()
@@ -86,8 +83,7 @@ Method TestUpdateToNewVersionTwice()
   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleThreeVersion)
   do $$$AssertStatusOK(sc, "Updated module to "_..#ModuleThreeVersion_" without error")
 
-  set modulesToUninstall = [].%Push(..#ModuleNoDependencies)
-  do ..CleanUp(modulesToUninstall)
+  do ..CleanUpModule(..#ModuleNoDependencies)
 }
 
 Method TestUpdateToSameVersionTwiceNoMirror()
@@ -136,11 +132,42 @@ Method TestUpdateToSameVersionTwiceNoMirror()
   do $$$AssertEquals(twoCStart, stepTwoC.TimeStampStart)
   do $$$AssertEquals(twoCEnd, stepTwoC.TimeStampEnd)
 
-  set modulesToUninstall = [].%Push(..#ModuleNoDependencies)
-  do ..CleanUp(modulesToUninstall)
+  do ..CleanUpModule(..#ModuleNoDependencies)
 }
 
 /// ///////////////////////////////////////////// HELPER METHODS ////////////////////////////////////////////////
+/// Runs through four variations of update for a given module that are each expected to complete successfully:
+/// - Install, dev mode
+/// - Install, no dev mode
+/// - Load, no dev mode
+/// - Load, dev mode
+Method NormalUpdateTestSuite(
+	moduleName As %String,
+	updateStepsToSeed As %DynamicArray,
+	updateStepsToRun As %DynamicArray,
+	fromVersion As %String,
+	toVersion As %String)
+{
+  // No dev mode, install
+  do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 0)
+  do ..CleanUpModule(moduleName)
+
+  // Dev mode, install
+  do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 1)
+  do ..CleanUpModule(moduleName)
+
+  // Dev mode, load
+  set exportDir = $system.Util.ManagerDirectory()_"/"_moduleName
+  do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 1, exportDir)
+  do ..CleanUpModule(moduleName)
+  do ..CleanUpDirectory(exportDir)
+
+  // No dev mode, load
+  do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 0, exportDir)
+  do ..CleanUpModule(moduleName)
+  do ..CleanUpDirectory(exportDir)
+}
+
 /// NOTE: For testing simplicity, we will always assume that in the update test, both the module and its dependencies are being updated
 /// from and to the same version numbers.
 /// Completes an update of given moduleName from fromVersion to toVersion, verifying that the given updateStepsToSeed are seeded
@@ -151,7 +178,7 @@ Method TestUpdateToSameVersionTwiceNoMirror()
 /// @argument fromVersion         Version of module to install
 /// @argument toVersion           Version of module to which to update
 /// @argument developerMode       1 if update should be run with -dev flag, 0 otherwise
-Method ModuleNormalUpdateNoMirrorHelper(
+Method SingleNormalUpdateTest(
 	moduleName As %String,
 	updateStepsToSeed As %DynamicArray,
 	updateStepsToRun As %DynamicArray,
@@ -160,10 +187,6 @@ Method ModuleNormalUpdateNoMirrorHelper(
 	developerMode As %Boolean = 0,
 	pathToModule As %String = "")
 {
-  if $system.Mirror.IsMember() {
-    return
-  }
-
   // Package module to update to (if we want to test updating from a tarball)
   if pathToModule {
     do ..AssertModulePackagedCorrectly(moduleName, toVersion, pathToModule)
@@ -228,24 +251,6 @@ Method ModuleNormalUpdateNoMirrorHelper(
   }
 }
 
-Method AssertModulePackagedCorrectly(
-	moduleName As %String,
-	version As %String,
-	packageDir As %String)
-{
-  // Initial install of module (necessary to be able to package)
-  set sc = ##class(%IPM.Main).Shell("install "_moduleName_" "_version)
-  do $$$AssertStatusOK(sc,"Installed "_moduleName_" version = "_version_" successfully.")
-
-  // Package module
-  set sc = ##class(%IPM.Main).Shell(_moduleName_" package -only -v -DPath="_packageDir)
-  do $$$AssertStatusOK(sc, "Successfully packaged module to "_packageDir)
-
-  // Uninstall module
-  set sc = ##class(%IPM.Main).Shell("uninstall "_moduleName_" "_version)
-  do $$$AssertStatusOK(sc,"Uninstalled "_moduleName_" version = "_version_" successfully after packaging.")
-}
-
 /// Asserts that each update method in the given array has a corresponding UpdateStep object of the correct subclass
 /// @params updateStepsList  Array of arrays, where each element is [className, methodName, isPrimaryOnly]
 Method AssertUpdateStepsExist(updateStepsList As %DynamicArray)
@@ -269,6 +274,23 @@ Method AssertModuleInstalledCorrectly(
   do $$$AssertStatusOK(sc, "Loaded module successfully")
 }
 
+Method AssertModulePackagedCorrectly(
+	moduleName As %String,
+	version As %String,
+	packageDir As %String)
+{
+  // Initial install of module (necessary to be able to package)
+  set sc = ##class(%IPM.Main).Shell("install "_moduleName_" "_version)
+  do $$$AssertStatusOK(sc,"Installed "_moduleName_" version = "_version_" successfully.")
+
+  // Package module
+  set sc = ##class(%IPM.Main).Shell(_moduleName_" package -only -v -DPath="_packageDir)
+  do $$$AssertStatusOK(sc, "Successfully packaged module to "_packageDir)
+
+  // Uninstall module
+  do ..CleanUpModule(moduleName)
+}
+
 ClassMethod GetUpdateStep(
 	className As %String,
 	methodName As %String,
@@ -283,15 +305,16 @@ ClassMethod GetUpdateStep(
   return step
 }
 
-ClassMethod CleanUp(moduleArr As %DynamicArray)
+ClassMethod CleanUpModule(moduleName As %String)
 {
-  set iter = moduleArr.%GetIterator()
-  while iter.%GetNext(.key, .value) {
-    set moduleName = value.%Get(0)
+  set sc = ##class(%IPM.Main).Shell("uninstall -r "_moduleName)
+  $$$ThrowOnError(sc)
+}
 
-    set sc = ##class(%IPM.Main).Shell("uninstall -r "_moduleName)
-    $$$ThrowOnError(sc)
-  }
+ClassMethod CleanUpDirectory(dir As %String)
+{
+  set sc = ##class(%File).RemoveDirectoryTree(dir, .return)
+  $$$ThrowOnError(sc)
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -154,20 +154,21 @@ Method TestUpdateAfterInterruptedUpdate()
 {
   do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
 
-  set isNamedResourceCreated = $system.Event.Create("InterruptedUpdate")
-  if 'isNamedResourceCreated {
-    $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource FirstUpdate not created"))
+  if ('$system.Event.Defined("InterruptedUpdate")){
+    set isNamedResourceCreated = $system.Event.Create("InterruptedUpdate")
+    if 'isNamedResourceCreated {
+      $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource InterruptedUpdate not created"))
+    }
   }
 
   job ..InterruptedUpdateJobWrapper(..#ModuleNoDependencies, ..#ModuleTwoVersion, "InterruptedUpdate")
 
   // Gets child job ID
-  set $listbuild(codeOne, processId) = $system.Event.WaitMsg("InterruptedUpdate")
-  do $system.Process.Terminate(processId)
+  set $listbuild(codeOne, updateProcessId) = $system.Event.WaitMsg("InterruptedUpdate")
+  set sc = $system.Process.Terminate(updateProcessId)
 
   // Gets update status
-  set $listbuild(codeTwo, sc) = $system.Event.WaitMsg("InterruptedUpdate")
-  do $$$AssertStatusNotOK(sc, "Updating module "_..#ModuleNoDependencies_" from "_..#ModuleOneVersion_" to "_..#ModuleTwoVersion_" was interrupted and failed.")
+  do $$$AssertTrue(sc = 1, "Updating module "_..#ModuleNoDependencies_" from "_..#ModuleOneVersion_" to "_..#ModuleTwoVersion_" was interrupted.")
 
   // Perform another update
   set sc = ##class(%IPM.Main).Shell("update -v "_..#ModuleNoDependencies_" "_..#ModuleTwoVersion)
@@ -575,9 +576,6 @@ ClassMethod InterruptedUpdateJobWrapper(
   do $system.Event.Signal(resourceName, $system.SYS.ProcessID())
 
   set sc = ##class(%IPM.Main).Shell("update "_moduleName_" "_toVersion_" -v")
-
-  // Send update status to the named resource
-  do $system.Event.Signal(resourceName, sc)
 }
 
 ClassMethod GetUpdateStep(

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -124,29 +124,25 @@ Method TestSimultaneousUpdateFails()
 {
   do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
 
-  set isNamedResourceDeleted = $system.Event.Delete("FirstUpdate")
-  if 'isNamedResourceDeleted {
-    $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource FirstUpdate not deleted"))
-  }
-  set isNamedResourceDeleted = $system.Event.Delete("SecondUpdate")
-  if 'isNamedResourceDeleted {
-    $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource SecondUpdate not deleted"))
+  if ('$system.Event.Defined("FirstUpdate")){
+    set isNamedResourceCreated = $system.Event.Create("FirstUpdate")
+    if 'isNamedResourceCreated {
+      $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource FirstUpdate not created"))
+    }
   }
 
-  set isNamedResourceCreated = $system.Event.Create("FirstUpdate")
-  if 'isNamedResourceCreated {
-    $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource FirstUpdate not created"))
-  }
-  set isNamedResourceCreated = $system.Event.Create("SecondUpdate")
-  if 'isNamedResourceCreated {
-    $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource SecondUpdate not created"))
+  if ('$system.Event.Defined("SecondUpdate")){
+    set isNamedResourceCreated = $system.Event.Create("SecondUpdate")
+    if 'isNamedResourceCreated {
+      $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource SecondUpdate not created"))
+    }
   }
 
-  job ..UpdateJobWrapper(..#ModuleNoDependencies, ..#ModuleTwoVersion, "First Update")
-  job ..UpdateJobWrapper(..#ModuleNoDependencies, ..#ModuleThreeVersion, "Second Update")
+  job ..UpdateJobWrapper(..#ModuleNoDependencies, ..#ModuleTwoVersion, "FirstUpdate")
+  job ..UpdateJobWrapper(..#ModuleNoDependencies, ..#ModuleThreeVersion, "SecondUpdate")
 
-  set $listbuild(firstCode, firstResponse) = $system.Event.WaitMsg("First Update")
-  set $listbuild(secondCode, secondResponse) = $system.Event.WaitMsg("Second Update")
+  set $listbuild(firstCode, firstResponse) = $system.Event.WaitMsg("FirstUpdate")
+  set $listbuild(secondCode, secondResponse) = $system.Event.WaitMsg("SecondUpdate")
 
   do $$$AssertStatusOK(firstResponse, "Update of module="_..#ModuleNoDependencies_" to version="_..#ModuleTwoVersion_" succeeded.")
   do $$$AssertStatusNotOK(secondResponse, "Attempting to update module="_..#ModuleNoDependencies_" while another update of that module in the same namespace is in-progress failed.")
@@ -158,19 +154,19 @@ Method TestUpdateAfterInterruptedUpdate()
 {
   do ..AssertModuleInstalledCorrectly(..#ModuleNoDependencies, ..#ModuleOneVersion)
 
-  set isNamedResourceCreated = $system.Event.Create("Interrupted Update")
+  set isNamedResourceCreated = $system.Event.Create("InterruptedUpdate")
   if 'isNamedResourceCreated {
     $$$ThrowOnError($$$ERROR($$$GeneralError, "Resource FirstUpdate not created"))
   }
 
-  job ..InterruptedUpdateJobWrapper(..#ModuleNoDependencies, ..#ModuleTwoVersion, "Interrupted Update")
+  job ..InterruptedUpdateJobWrapper(..#ModuleNoDependencies, ..#ModuleTwoVersion, "InterruptedUpdate")
 
   // Gets child job ID
-  set $listbuild(codeOne, processId) = $system.Event.WaitMsg("Interrupted Update")
+  set $listbuild(codeOne, processId) = $system.Event.WaitMsg("InterruptedUpdate")
   do $system.Process.Terminate(processId)
 
   // Gets update status
-  set $listbuild(codeTwo, sc) = $system.Event.WaitMsg("Interrupted Update")
+  set $listbuild(codeTwo, sc) = $system.Event.WaitMsg("InterruptedUpdate")
   do $$$AssertStatusNotOK(sc, "Updating module "_..#ModuleNoDependencies_" from "_..#ModuleOneVersion_" to "_..#ModuleTwoVersion_" was interrupted and failed.")
 
   // Perform another update

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -321,14 +321,14 @@ Method NormalUpdateTestSuite(
   do ..CleanUpModule(moduleName)
 
   // Dev mode, install
-  #; do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 1)
-  #; do ..CleanUpModule(moduleName)
+  do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 1)
+  do ..CleanUpModule(moduleName)
 
   // Dev mode, load
   set exportDir = $system.Util.ManagerDirectory()_moduleName
-  #; do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 1, exportDir)
-  #; do ..CleanUpModule(moduleName)
-  #; do ..CleanUpDirectory(exportDir)
+  do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 1, exportDir)
+  do ..CleanUpModule(moduleName)
+  do ..CleanUpDirectory(exportDir)
 
   // No dev mode, load
   do ..SingleNormalUpdateTest(moduleName, updateStepsToSeed, updateStepsToRun, fromVersion, toVersion, 0, exportDir)

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -23,6 +23,8 @@ Parameter ModuleDepErrors As STRING = "update-dep-errors";
 
 Parameter ModuleInvokeErrors As STRING = "update-invoke-errors";
 
+Parameter ModuleDepInvokeErrors As STRING = "update-dep-invoke-errors";
+
 Parameter ModuleOneVersion As STRING = "1.2.1";
 
 Parameter ModuleOneVersionMinorBump As STRING = "1.3.1";
@@ -92,6 +94,27 @@ Method TestAllErrorModulesNoMirror()
   set updateStepsToSeed = [["UpdateInvokeErrors.UpdatePackage.V1", "MethodA", 0]]
   do ..SingleFailedUpdateTest(..#ModuleInvokeErrors, updateStepsToSeed, ..#ModuleOneVersion, ..#ModuleTwoVersion)
   do ..CleanUpModule(..#ModuleInvokeErrors)
+
+  set updateStepsToSeed = [["UpdateDepInvokeErrors.UpdatePackage.V1", "MethodA", 0], ["UpdateInvokeErrors.UpdatePackage.V1", "MethodA", 0]]
+  do ..SingleFailedUpdateTest(..#ModuleDepInvokeErrors, updateStepsToSeed, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  do ..CleanUpModule(..#ModuleDepInvokeErrors)
+}
+
+Method TestUpdateNonMatchingTarballFails()
+{
+  set moduleToPackage = ..#ModuleWithDependencies
+  set moduleToUpdate = ..#ModuleNoDependencies
+  set fromVersion = ..#ModuleOneVersion
+  set toVersion = ..#ModuleTwoVersion
+
+  // Package moduleToPackage (which is not the same module as moduleToUpdate)
+  set exportDir = $system.Util.ManagerDirectory()_moduleToPackage
+  do ..AssertModulePackagedCorrectly(moduleToPackage, toVersion, exportDir)
+
+  do ..AssertModuleInstalledCorrectly(moduleToUpdate, fromVersion)
+
+  set sc = ##class(%IPM.Main).Shell("update -v -path "_exportDir_" "_moduleToUpdate_" "_toVersion)
+  do $$$AssertStatusNotOK(sc, "Attempting to update module "_moduleToUpdate_" FAILED because the module in the path provided does not match the module to update.")
 }
 
 Method TestModuleUpdateStepAdded()

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -167,7 +167,7 @@ Method TestUpdateAfterInterruptedUpdate()
   set $listbuild(codeOne, updateProcessId) = $system.Event.WaitMsg("InterruptedUpdate")
   set sc = $system.Process.Terminate(updateProcessId)
 
-  // Gets update status
+  // Gets process termination status
   do $$$AssertTrue(sc = 1, "Updating module "_..#ModuleNoDependencies_" from "_..#ModuleOneVersion_" to "_..#ModuleTwoVersion_" was interrupted.")
 
   // Perform another update

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -17,6 +17,12 @@ Parameter ModuleStepAddedCurrVersion As STRING = "update-step-added-curr-version
 
 Parameter ModuleStepErrors As STRING = "update-step-errors";
 
+Parameter ModuleSeededStepErrors As STRING = "update-seeded-step-errors";
+
+Parameter ModuleDepErrors As STRING = "update-dep-errors";
+
+Parameter ModuleInvokeErrors As STRING = "update-invoke-errors";
+
 Parameter ModuleOneVersion As STRING = "1.2.1";
 
 Parameter ModuleOneVersionMinorBump As STRING = "1.3.1";
@@ -41,13 +47,13 @@ Method TestAllNoErrorModulesNoMirror()
     return
   }
   // Simple module without dependencies
-  set updateStepsToSeed = [["UpdatePackage.V1", "MethodA", 1]]
-  set updateStepsToRun = [["UpdatePackage.V1", "MethodB", 0], ["UpdatePackage.V1", "MethodC", 1], ["UpdatePackage.V2", "MethodA", 1], ["UpdatePackage.V2", "MethodC", 1], ["UpdatePackage.V2", "MethodB", 0]]
+  set updateStepsToSeed = [["UpdatePackage.V1", "MethodA", 0]]
+  set updateStepsToRun = [["UpdatePackage.V1", "MethodB", 1], ["UpdatePackage.V1", "MethodC", 1], ["UpdatePackage.V2", "MethodA", 1], ["UpdatePackage.V2", "MethodC", 1], ["UpdatePackage.V2", "MethodB", 0]]
   do ..NormalUpdateTestSuite(..#ModuleNoDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
 
   // Module with dependencies
-  set updateStepsToSeed = updateStepsToSeed.addAll([["UpdateDeps.UpdatePackage.V1", "MethodA", 1]])
-  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDeps.UpdatePackage.V1", "MethodB", 0], ["UpdateDeps.UpdatePackage.V1", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodA", 1], ["UpdateDeps.UpdatePackage.V2", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodB", 0]])
+  set updateStepsToSeed = updateStepsToSeed.addAll([["UpdateDeps.UpdatePackage.V1", "MethodA", 0]])
+  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDeps.UpdatePackage.V1", "MethodB", 1], ["UpdateDeps.UpdatePackage.V1", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodA", 1], ["UpdateDeps.UpdatePackage.V2", "MethodC", 1], ["UpdateDeps.UpdatePackage.V2", "MethodB", 0]])
   do ..NormalUpdateTestSuite(..#ModuleWithDependencies, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion)
 
   // Module with dependencies added in new version
@@ -56,24 +62,39 @@ Method TestAllNoErrorModulesNoMirror()
   do ..SingleNormalUpdateTest(..#ModuleWithDependenciesAdded, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
   do ..CleanUpModule(..#ModuleWithDependenciesAdded)
 
-  // Module with dependencies added in new version
-  set updateStepsToSeed = [["UpdateDepsRemoved.UpdatePackage.V1", "MethodA", 1], ["UpdatePackage.V1", "MethodA", 1]]
-  set updateStepsToRun = updateStepsToRun.addAll([["UpdateDepsRemoved.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsRemoved.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodB", 0]])
+  // Module with dependencies removed in new version
+  set updateStepsToSeed = [["UpdateDepsRemoved.UpdatePackage.V1", "MethodA", 1], ["UpdatePackage.V1", "MethodA", 0]]
+  set updateStepsToRun = [["UpdateDepsRemoved.UpdatePackage.V1", "MethodB", 0], ["UpdateDepsRemoved.UpdatePackage.V1", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodA", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodC", 1], ["UpdateDepsRemoved.UpdatePackage.V2", "MethodB", 0]]
   do ..SingleNormalUpdateTest(..#ModuleWithDependenciesRemoved, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
-  do ..CleanUpModule(..#ModuleWithDependenciesAdded)
+  do ..CleanUpModule(..#ModuleWithDependenciesRemoved)
 
   // Module with no update steps
   do ..SingleNormalUpdateTest(..#ModuleNoUpdateSteps, [], [], ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
   do ..CleanUpModule(..#ModuleNoUpdateSteps)
+
+  // Module with an error in a seeded update step
+  set updateStepsToSeed = [["UpdateSeededStepErrors.UpdatePackage.V1", "MethodA", 0]]
+  set updateStepsToRun = [["UpdateSeededStepErrors.UpdatePackage.V2", "MethodA", 1]]
+  do ..SingleNormalUpdateTest(..#ModuleSeededStepErrors, updateStepsToSeed, updateStepsToRun, ..#ModuleOneVersion, ..#ModuleTwoVersion, 0)
+  do ..CleanUpModule(..#ModuleSeededStepErrors)
 }
 
 Method TestAllErrorModulesNoMirror()
 {
-  do ..SingleFailedUpdateTest(..#ModuleStepErrors, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  set updateStepsToSeed = [["UpdateStepErrors.UpdatePackage.V1", "MethodA", 1], ["UpdateStepErrors.UpdatePackage.V1", "MethodB", 0], ["UpdateStepErrors.UpdatePackage.V1", "MethodC", 1]]
+  do ..SingleFailedUpdateTest(..#ModuleStepErrors, updateStepsToSeed, ..#ModuleOneVersion, ..#ModuleTwoVersion)
   do ..CleanUpModule(..#ModuleStepErrors)
+
+  set updateStepsToSeed = updateStepsToSeed.addAll([["UpdateDepErrors.UpdatePackage.V1", "MethodA", 0]])
+  do ..SingleFailedUpdateTest(..#ModuleDepErrors, updateStepsToSeed, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  do ..CleanUpModule(..#ModuleDepErrors)
+
+  set updateStepsToSeed = [["UpdateInvokeErrors.UpdatePackage.V1", "MethodA", 0]]
+  do ..SingleFailedUpdateTest(..#ModuleInvokeErrors, updateStepsToSeed, ..#ModuleOneVersion, ..#ModuleTwoVersion)
+  do ..CleanUpModule(..#ModuleInvokeErrors)
 }
 
-Method TestModuleUpdateStepAddedOlderVersion()
+Method TestModuleUpdateStepAdded()
 {
   // Test updating module when update step is added to an older V# class
   set updateStepsToSeed = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V2", "MethodB", 0]]
@@ -86,8 +107,8 @@ Method TestModuleUpdateStepAddedOlderVersion()
 
   // Test updating module when new update step is added to current V# class which precedes existing update steps in order
   set updateStepsToSeed = [["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodC", 1]]
-  set seededUpdateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodC", 1]]
-  set updateStepsToRun = [["UpdateStepAddedOlderVersion.UpdatePackage.V1", "MethodD", 0]]
+  set seededUpdateStepsToRun = [["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodA", 1], ["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodB", 0], ["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodC", 1]]
+  set updateStepsToRun = [["UpdateStepAddedCurrVersionClass.UpdatePackage.V1", "MethodD", 0]]
 
   do ..SingleNormalUpdateNewStepTest(..#ModuleStepAddedCurrVersion, updateStepsToSeed, seededUpdateStepsToRun, [], updateStepsToRun, ..#ModuleOneVersion, ..#ModuleOneVersionMinorBump)
   do ..CleanUpModule(..#ModuleStepAddedCurrVersion)
@@ -260,7 +281,7 @@ Method SingleNormalUpdateNewStepTest(
   set sc = ##class(%IPM.Main).Shell("update -v "_moduleName_" "_toVersion)
   do $$$AssertStatusOK(sc, "Updated module "_moduleName_" without error")
 
-  // Check that the seeded update methods within the same version class as the new update step was prepended to WERE run
+  // Check that the seeded update methods within the same version class as the new update step was prepended to were run
   set iter = seededUpdateStepsToRun.%GetIterator()
   while iter.%GetNext(.key, .value) {
     set className = value.%Get(0)
@@ -287,7 +308,7 @@ Method SingleNormalUpdateNewStepTest(
 
   // Check module version has been updated
   set module = ##class(%IPM.Storage.Module).NameOpen(moduleName)
-  do $$$AssertEquals(module.VersionString, toVersion)
+  do $$$AssertEquals(module.VersionString, toVersion, "Module "_moduleName_" version was successfully updated so that the desired version="_toVersion_" equals current version="_module.VersionString)
 }
 
 /// NOTE: For testing simplicity, we will always assume that in the update test, both the module and its dependencies are being updated
@@ -302,7 +323,6 @@ Method SingleNormalUpdateNewStepTest(
 Method SingleFailedUpdateTest(
 	moduleName As %String,
 	updateStepsToSeed As %DynamicArray,
-	updateStepsToRun As %DynamicArray,
 	fromVersion As %String,
 	toVersion As %String)
 {
@@ -395,9 +415,9 @@ Method SingleNormalUpdateTest(
 
   // Check module version has been updated
   set module = ##class(%IPM.Storage.Module).NameOpen(moduleName)
-  do $$$AssertEquals(module.VersionString, toVersion)
+  do $$$AssertEquals(module.VersionString, toVersion, "Module "_moduleName_" version was successfully updated so that the desired version="_toVersion_" equals current version="_module.VersionString)
 
-  // Check that dependency versions have been updated
+  // Check that dependency version string in the module.xml of the base module matches the version installed
   // dependencyGraph format: dependencyGraph(<module name>) = $ListBuild(<depth>, <server>, <version>)
   set sc = module.BuildDependencyGraph(.dependencyGraph)
   $$$ThrowOnError(sc)
@@ -406,9 +426,10 @@ Method SingleNormalUpdateTest(
     set moduleName = $order(dependencyGraph(moduleName),1,moduleInfo)
     quit:moduleName=""
 
-    set moduleVersion = $list(moduleInfo, 2)
+    set moduleExpectedVersion = $list(moduleInfo, 3) // Taken from the module.xml <Version> tag
+    set moduleActualVersion = ##class(%IPM.Storage.Module).NameOpen(moduleName).VersionString // The version of the installed module
 
-    do $$$AssertEquals(moduleVersion, toVersion)
+    do $$$AssertEquals(moduleExpectedVersion, moduleActualVersion, "Module dependency "_moduleName_" expected version="_moduleExpectedVersion_" equals actual version="_moduleActualVersion)
   }
 }
 

--- a/tests/integration_tests/Test/PM/Integration/Update.cls
+++ b/tests/integration_tests/Test/PM/Integration/Update.cls
@@ -113,8 +113,11 @@ Method TestUpdateNonMatchingTarballFails()
 
   do ..AssertModuleInstalledCorrectly(moduleToUpdate, fromVersion)
 
-  set sc = ##class(%IPM.Main).Shell("update -v -path "_exportDir_" "_moduleToUpdate_" "_toVersion)
+  set sc = ##class(%IPM.Main).Shell("update -v -path "_exportDir_" "_moduleToUpdate)
   do $$$AssertStatusNotOK(sc, "Attempting to update module "_moduleToUpdate_" FAILED because the module in the path provided does not match the module to update.")
+
+  do ..CleanUpModule(moduleToUpdate)
+  do ..CleanUpDirectory(exportDir)
 }
 
 Method TestModuleUpdateStepAdded()
@@ -405,7 +408,6 @@ Method SingleNormalUpdateTest(
     set className = value.%Get(0)
     set methodName = value.%Get(1)
     set isPrimaryOnly = value.%Get(2)
-    write !, "[SEEDED] Module: "_moduleName_", Class: "_className_" Method: "_methodName_" isPrimaryOnly: "_isPrimaryOnly
 
     set updateStep = ..GetUpdateStep(className, methodName, isPrimaryOnly)
     do $$$AssertTrue($isobject(updateStep), "Update step with class="_className_" and method="_methodName_" exists.")

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-dep-errors/cls/UpdateDepErrors/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-dep-errors/cls/UpdateDepErrors/UpdatePackage/V1.cls
@@ -1,4 +1,4 @@
-Class UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+Class UpdateDepErrors.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
 {
 
 ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
@@ -13,7 +13,7 @@ ClassMethod GetOrderedMethods() As %Library.DynamicArray
 
 ClassMethod MethodA()
 {
-    write !, "This is UpdatePackage.V1::MethodA()"
+    write !, "This is  UpdateDepErrors.UpdatePackage.V1::MethodA()"
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-dep-errors/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-dep-errors/module.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-dep-errors.ZPM">
+    <Module>
+      <Name>update-dep-errors</Name>
+      <Version>1.2.1</Version>
+      <Resource Name="UpdateDepErrors.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateDepErrors.UpdatePackage</UpdatePackage>
+      <Dependencies>
+        <ModuleReference>
+          <Name>update-step-errors</Name>
+          <Version>^1.0.0</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-dep-invoke-errors/cls/UpdateDepInvokeErrors/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-dep-invoke-errors/cls/UpdateDepInvokeErrors/UpdatePackage/V1.cls
@@ -1,0 +1,19 @@
+Class UpdateDepInvokeErrors.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return []
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodA"]
+}
+
+ClassMethod MethodA()
+{
+  write !, "This is  UpdateDepInvokeErrors.UpdatePackage.V1::MethodA()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-dep-invoke-errors/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-dep-invoke-errors/module.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-dep-invoke-errors.ZPM">
+    <Module>
+      <Name>update-dep-invoke-errors</Name>
+      <Version>1.2.1</Version>
+      <Resource Name="UpdateDepInvokeErrors.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateDepInvokeErrors.UpdatePackage</UpdatePackage>
+      <Dependencies>
+        <ModuleReference>
+          <Name>update-invoke-errors</Name>
+          <Version>^1.0.0</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps-added/cls/UpdateDepsAdded/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps-added/cls/UpdateDepsAdded/UpdatePackage/V1.cls
@@ -1,0 +1,29 @@
+Class UpdateDepsAdded.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateDepsAdded.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateDepsAdded.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateDepsAdded.UpdatePackage.V1::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps-added/cls/UpdateDepsAdded/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps-added/cls/UpdateDepsAdded/UpdatePackage/V1.cls
@@ -3,27 +3,17 @@ Class UpdateDepsAdded.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
 
 ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
 {
-    return ["MethodA", "MethodC"]
+    return ["MethodA"]
 }
 
 ClassMethod GetOrderedMethods() As %Library.DynamicArray
 {
-    return ["MethodB"]
+    return []
 }
 
 ClassMethod MethodA()
 {
     write !, "This is UpdateDepsAdded.UpdatePackage.V1::MethodA()"
-}
-
-ClassMethod MethodB()
-{
-    write !, "This is UpdateDepsAdded.UpdatePackage.V1::MethodB()"
-}
-
-ClassMethod MethodC()
-{
-    write !, "This is UpdateDepsAdded.UpdatePackage.V1::MethodC()"
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps-added/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps-added/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-deps-added.ZPM">
+    <Module>
+      <Name>update-deps-added</Name>
+      <Version>1.2.1</Version>
+      <Resource Name="UpdateDepsAdded.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateDepsAdded.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps-removed/cls/UpdateDepsRemoved/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps-removed/cls/UpdateDepsRemoved/UpdatePackage/V1.cls
@@ -1,0 +1,29 @@
+Class UpdateDepsRemoved.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateDepsRemoved.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateDepsRemoved.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateDepsRemoved.UpdatePackage.V1::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps-removed/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps-removed/module.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-deps-removed.ZPM">
+    <Module>
+      <Name>update-deps-removed</Name>
+      <Version>1.2.1</Version>
+      <Resource Name="UpdateDepsRemoved.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateDepsRemoved.UpdatePackage</UpdatePackage>
+      <Dependencies>
+        <ModuleReference>
+          <Name>update-simple</Name>
+          <Version>^1.0.0</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps/cls/UpdateDeps/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps/cls/UpdateDeps/UpdatePackage/V1.cls
@@ -1,0 +1,29 @@
+Class UpdateDeps.UpdateDeps.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateDeps.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateDeps.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateDeps.UpdatePackage.V1::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps/cls/UpdateDeps/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps/cls/UpdateDeps/UpdatePackage/V1.cls
@@ -3,27 +3,17 @@ Class UpdateDeps.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
 
 ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
 {
-    return ["MethodA", "MethodC"]
+    return []
 }
 
 ClassMethod GetOrderedMethods() As %Library.DynamicArray
 {
-    return ["MethodB"]
+    return ["MethodA"]
 }
 
 ClassMethod MethodA()
 {
     write !, "This is UpdateDeps.UpdatePackage.V1::MethodA()"
-}
-
-ClassMethod MethodB()
-{
-    write !, "This is UpdateDeps.UpdatePackage.V1::MethodB()"
-}
-
-ClassMethod MethodC()
-{
-    write !, "This is UpdateDeps.UpdatePackage.V1::MethodC()"
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps/cls/UpdateDeps/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps/cls/UpdateDeps/UpdatePackage/V1.cls
@@ -1,4 +1,4 @@
-Class UpdateDeps.UpdateDeps.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+Class UpdateDeps.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
 {
 
 ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-deps/module.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-deps.ZPM">
+    <Module>
+      <Name>update-deps</Name>
+      <Version>1.2.1</Version>
+      <Resource Name="UpdateDeps.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateDeps.UpdatePackage</UpdatePackage>
+      <Dependencies>
+        <ModuleReference>
+          <Name>update-simple</Name>
+          <Version>^1.0.0</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-invoke-errors/cls/ClassPackage/InvokedClass.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-invoke-errors/cls/ClassPackage/InvokedClass.cls
@@ -1,0 +1,10 @@
+Class ClassPackage.InvokedClass
+{
+
+ClassMethod InvokedMethod()
+{
+    write !, "This is ClassPackage.InvokedClass::InvokedMethod()"
+    $$$ThrowOnError($$$ERROR($$$GeneralError, "ClassPackage.InvokedClass::InvokedMethod() threw an error."))
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-invoke-errors/cls/UpdateInvokeErrors/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-invoke-errors/cls/UpdateInvokeErrors/UpdatePackage/V1.cls
@@ -1,4 +1,4 @@
-Class UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+Class UpdateInvokeErrors.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
 {
 
 ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
@@ -13,7 +13,7 @@ ClassMethod GetOrderedMethods() As %Library.DynamicArray
 
 ClassMethod MethodA()
 {
-    write !, "This is UpdatePackage.V1::MethodA()"
+  write !, "This is  UpdateInvokeErrors.UpdatePackage.V1::MethodA()"
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-invoke-errors/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-invoke-errors/module.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-invoke-errors.ZPM">
+    <Module>
+      <Name>update-invoke-errors</Name>
+      <Version>1.2.1</Version>
+      <Resource Name="UpdateInvokeErrors.UpdatePackage.PKG" />
+      <Resource Name="ClassPackage.PKG"/>
+      <UpdatePackage>UpdateInvokeErrors.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-no-steps/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-no-steps/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-no-steps.ZPM">
+    <Module>
+      <Name>update-no-steps</Name>
+      <Version>1.2.1</Version>
+      <Resource Name="UpdateNoStepsPackage.PKG" />
+      <UpdatePackage>UpdateNoStepsPackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-seeded-step-errors/cls/UpdateSeededStepErrors/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-seeded-step-errors/cls/UpdateSeededStepErrors/UpdatePackage/V1.cls
@@ -1,0 +1,20 @@
+Class UpdateSeededStepErrors.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return []
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodA"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateSeededStepErrors.UpdatePackage.V1::MethodA()"
+    $$$ThrowOnError($$$ERROR($$$GeneralError, "UpdateSeededStepErrors.UpdatePackage.V1::MethodA() threw an error."))
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-seeded-step-errors/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-seeded-step-errors/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-seeded-step-errors.ZPM">
+    <Module>
+      <Name>update-seeded-step-errors</Name>
+      <Version>1.2.1</Version>
+      <Resource Name="UpdateSeededStepErrors.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateSeededStepErrors.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-added-curr-version-minor-bump/cls/UpdateStepAddedCurrVersionClass/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-added-curr-version-minor-bump/cls/UpdateStepAddedCurrVersionClass/UpdatePackage/V1.cls
@@ -1,0 +1,34 @@
+Class UpdateStepAddedCurrVersionClass.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodD", "MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateStepAddedCurrVersionClass.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateStepAddedCurrVersionClass.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateStepAddedCurrVersionClass.UpdatePackage.V1::MethodC()"
+}
+
+ClassMethod MethodD()
+{
+    write !, "This is UpdateStepAddedCurrVersionClass.UpdatePackage.V1::MethodD()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-added-curr-version-minor-bump/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-added-curr-version-minor-bump/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-step-added-curr-version-class.ZPM">
+    <Module>
+      <Name>update-step-added-curr-version-class</Name>
+      <Version>1.3.1</Version>
+      <Resource Name="UpdateStepAddedCurrVersionClass.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateStepAddedCurrVersionClass.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-added-curr-version/cls/UpdateStepAddedCurrVersionClass/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-added-curr-version/cls/UpdateStepAddedCurrVersionClass/UpdatePackage/V1.cls
@@ -1,0 +1,29 @@
+Class UpdateStepAddedCurrVersionClass.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateStepAddedCurrVersionClass.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateStepAddedCurrVersionClass.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateStepAddedCurrVersionClass.UpdatePackage.V1::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-added-curr-version/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-added-curr-version/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-step-added-curr-version-class.ZPM">
+    <Module>
+      <Name>update-step-added-curr-version-class</Name>
+      <Version>1.2.1</Version>
+      <Resource Name="UpdateStepAddedCurrVersionClass.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateStepAddedCurrVersionClass.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-errors/cls/UpdateStepErrors/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-errors/cls/UpdateStepErrors/UpdatePackage/V1.cls
@@ -1,0 +1,29 @@
+Class UpdateStepErrors.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateStepErrors.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateStepErrors.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateStepErrors.UpdatePackage.V1::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-errors/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-errors/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-step-errors.ZPM">
+    <Module>
+      <Name>update-step-errors</Name>
+      <Version>1.2.1</Version>
+      <Resource Name="UpdateStepErrors.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateStepErrors.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-order-changed-minor-bump/cls/UpdateStepOrderChanged/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-order-changed-minor-bump/cls/UpdateStepOrderChanged/UpdatePackage/V1.cls
@@ -1,0 +1,29 @@
+Class UpdateStepOrderChanged.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodC", "MethodA"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateStepOrderChanged.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateStepOrderChanged.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateStepOrderChanged.UpdatePackage.V1::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-order-changed-minor-bump/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-order-changed-minor-bump/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-step-order-changed.ZPM">
+    <Module>
+      <Name>update-step-order-changed</Name>
+      <Version>1.3.1</Version>
+      <Resource Name="UpdateStepOrderChanged.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateStepOrderChanged.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-order-changed/cls/UpdateStepOrderChanged/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-order-changed/cls/UpdateStepOrderChanged/UpdatePackage/V1.cls
@@ -1,0 +1,29 @@
+Class UpdateStepOrderChanged.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateStepOrderChanged.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateStepOrderChanged.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateStepOrderChanged.UpdatePackage.V1::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-order-changed/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-1.x/update-step-order-changed/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-step-order-changed.ZPM">
+    <Module>
+      <Name>update-step-order-changed</Name>
+      <Version>1.2.1</Version>
+      <Resource Name="UpdateStepOrderChanged.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateStepOrderChanged.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-dep-errors/cls/UpdateDepErrors/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-dep-errors/cls/UpdateDepErrors/UpdatePackage/V1.cls
@@ -1,4 +1,4 @@
-Class UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+Class UpdateDepErrors.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
 {
 
 ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
@@ -13,7 +13,7 @@ ClassMethod GetOrderedMethods() As %Library.DynamicArray
 
 ClassMethod MethodA()
 {
-    write !, "This is UpdatePackage.V1::MethodA()"
+    write !, "This is  UpdateDepErrors.UpdatePackage.V1::MethodA()"
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-dep-errors/cls/UpdateDepErrors/UpdatePackage/V2.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-dep-errors/cls/UpdateDepErrors/UpdatePackage/V2.cls
@@ -1,4 +1,4 @@
-Class UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+Class UpdateDepErrors.UpdatePackage.V2 Extends %IPM.General.Update.VersionBase
 {
 
 ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
@@ -13,7 +13,7 @@ ClassMethod GetOrderedMethods() As %Library.DynamicArray
 
 ClassMethod MethodA()
 {
-    write !, "This is UpdatePackage.V1::MethodA()"
+    write !, "This is UpdateDepErrors.UpdatePackage.V2::MethodA()"
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-dep-errors/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-dep-errors/module.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-dep-errors.ZPM">
+    <Module>
+      <Name>update-dep-errors</Name>
+      <Version>2.1.1</Version>
+      <Resource Name="UpdateDepErrors.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateDepErrors.UpdatePackage</UpdatePackage>
+      <Dependencies>
+        <ModuleReference>
+          <Name>update-step-errors</Name>
+          <Version>^2.0.0</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-dep-invoke-errors/cls/UpdateDepInvokeErrors/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-dep-invoke-errors/cls/UpdateDepInvokeErrors/UpdatePackage/V1.cls
@@ -1,0 +1,19 @@
+Class UpdateDepInvokeErrors.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return []
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodA"]
+}
+
+ClassMethod MethodA()
+{
+  write !, "This is  UpdateDepInvokeErrors.UpdatePackage.V1::MethodA()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-dep-invoke-errors/cls/UpdateDepInvokeErrors/UpdatePackage/V2.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-dep-invoke-errors/cls/UpdateDepInvokeErrors/UpdatePackage/V2.cls
@@ -1,0 +1,19 @@
+Class UpdateDepInvokeErrors.UpdatePackage.V2 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return []
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodA"]
+}
+
+ClassMethod MethodA()
+{
+  write !, "This is  UpdateDepInvokeErrors.UpdatePackage.V2::MethodA()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-dep-invoke-errors/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-dep-invoke-errors/module.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-dep-invoke-errors.ZPM">
+    <Module>
+      <Name>update-dep-invoke-errors</Name>
+      <Version>2.1.1</Version>
+      <Resource Name="UpdateDepInvokeErrors.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateDepInvokeErrors.UpdatePackage</UpdatePackage>
+      <Dependencies>
+        <ModuleReference>
+          <Name>update-invoke-errors</Name>
+          <Version>^2.0.0</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-added/cls/UpdateDepsAdded/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-added/cls/UpdateDepsAdded/UpdatePackage/V1.cls
@@ -1,0 +1,29 @@
+Class UpdateDepsAdded.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateDepsAdded.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateDepsAdded.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateDepsAdded.UpdatePackage.V1::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-added/cls/UpdateDepsAdded/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-added/cls/UpdateDepsAdded/UpdatePackage/V1.cls
@@ -3,12 +3,12 @@ Class UpdateDepsAdded.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
 
 ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
 {
-    return ["MethodA", "MethodC"]
+    return ["MethodA", "MethodB"]
 }
 
 ClassMethod GetOrderedMethods() As %Library.DynamicArray
 {
-    return ["MethodB"]
+    return []
 }
 
 ClassMethod MethodA()
@@ -19,11 +19,6 @@ ClassMethod MethodA()
 ClassMethod MethodB()
 {
     write !, "This is UpdateDepsAdded.UpdatePackage.V1::MethodB()"
-}
-
-ClassMethod MethodC()
-{
-    write !, "This is UpdateDepsAdded.UpdatePackage.V1::MethodC()"
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-added/cls/UpdateDepsAdded/UpdatePackage/V2.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-added/cls/UpdateDepsAdded/UpdatePackage/V2.cls
@@ -1,0 +1,29 @@
+Class UpdateDepsAdded.UpdatePackage.V2 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateDepsAdded.UpdatePackage.V2::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateDepsAdded.UpdatePackage.V2::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateDepsAdded.UpdatePackage.V2::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-added/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-added/module.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-deps-added.ZPM">
+    <Module>
+      <Name>update-deps-added</Name>
+      <Version>2.1.1</Version>
+      <Resource Name="UpdateDepsAdded.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateDepsAdded.UpdatePackage</UpdatePackage>
+      <Dependencies>
+        <ModuleReference>
+          <Name>update-simple</Name>
+          <Version>^1.0.0</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-removed/cls/UpdateDepsRemoved/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-removed/cls/UpdateDepsRemoved/UpdatePackage/V1.cls
@@ -1,0 +1,29 @@
+Class UpdateDepsRemoved.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateDepsRemoved.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateDepsRemoved.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateDepsRemoved.UpdatePackage.V1::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-removed/cls/UpdateDepsRemoved/UpdatePackage/V2.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-removed/cls/UpdateDepsRemoved/UpdatePackage/V2.cls
@@ -1,0 +1,29 @@
+Class UpdateDepsRemoved.UpdatePackage.V2 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateDepsRemoved.UpdatePackage.V2::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateDepsRemoved.UpdatePackage.V2::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateDepsRemoved.UpdatePackage.V2::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-removed/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps-removed/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-deps-removed.ZPM">
+    <Module>
+      <Name>update-deps-removed</Name>
+      <Version>2.1.1</Version>
+      <Resource Name="UpdateDepsRemoved.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateDepsRemoved.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps/cls/UpdateDeps/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps/cls/UpdateDeps/UpdatePackage/V1.cls
@@ -3,12 +3,12 @@ Class UpdateDeps.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
 
 ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
 {
-    return ["MethodA", "MethodC"]
+    return ["MethodB", "MethodC"]
 }
 
 ClassMethod GetOrderedMethods() As %Library.DynamicArray
 {
-    return ["MethodB"]
+    return ["MethodA"]
 }
 
 ClassMethod MethodA()

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps/cls/UpdateDeps/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps/cls/UpdateDeps/UpdatePackage/V1.cls
@@ -1,0 +1,29 @@
+Class UpdateDeps.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateDeps.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateDeps.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateDeps.UpdatePackage.V1::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps/cls/UpdateDeps/UpdatePackage/V2.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps/cls/UpdateDeps/UpdatePackage/V2.cls
@@ -1,0 +1,29 @@
+Class UpdateDeps.UpdatePackage.V2 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateDeps.UpdatePackage.V2::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateDeps.UpdatePackage.V2::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateDeps.UpdatePackage.V2::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-deps/module.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-deps.ZPM">
+    <Module>
+      <Name>update-deps</Name>
+      <Version>2.1.1</Version>
+      <Resource Name="UpdateDeps.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateDeps.UpdatePackage</UpdatePackage>
+      <Dependencies>
+        <ModuleReference>
+          <Name>update-simple</Name>
+          <Version>^2.0.0</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-invoke-errors/cls/ClassPackage/InvokedClass.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-invoke-errors/cls/ClassPackage/InvokedClass.cls
@@ -1,0 +1,10 @@
+Class ClassPackage.InvokedClass
+{
+
+ClassMethod InvokedMethod()
+{
+    write !, "This is ClassPackage.InvokedClass::InvokedMethod()"
+    $$$ThrowOnError($$$ERROR($$$GeneralError, "ClassPackage.InvokedClass::InvokedMethod() threw an error."))
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-invoke-errors/cls/UpdateInvokeErrors/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-invoke-errors/cls/UpdateInvokeErrors/UpdatePackage/V1.cls
@@ -1,4 +1,4 @@
-Class UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+Class UpdateInvokeErrors.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
 {
 
 ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
@@ -13,7 +13,7 @@ ClassMethod GetOrderedMethods() As %Library.DynamicArray
 
 ClassMethod MethodA()
 {
-    write !, "This is UpdatePackage.V1::MethodA()"
+  write !, "This is  UpdateInvokeErrors.UpdatePackage.V1::MethodA()"
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-invoke-errors/cls/UpdateInvokeErrors/UpdatePackage/V2.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-invoke-errors/cls/UpdateInvokeErrors/UpdatePackage/V2.cls
@@ -1,4 +1,4 @@
-Class UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+Class UpdateInvokeErrors.UpdatePackage.V2 Extends %IPM.General.Update.VersionBase
 {
 
 ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
@@ -13,7 +13,7 @@ ClassMethod GetOrderedMethods() As %Library.DynamicArray
 
 ClassMethod MethodA()
 {
-    write !, "This is UpdatePackage.V1::MethodA()"
+  write !, "This is  UpdateInvokeErrors.UpdatePackage.V2::MethodA()"
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-invoke-errors/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-invoke-errors/module.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-invoke-errors.ZPM">
+    <Module>
+      <Name>update-invoke-errors</Name>
+      <Version>2.1.1</Version>
+      <Resource Name="UpdateInvokeErrors.UpdatePackage.PKG" />
+      <Resource Name="ClassPackage.PKG"/>
+      <UpdatePackage>UpdateInvokeErrors.UpdatePackage</UpdatePackage>
+      <Invoke Class="ClassPackage.InvokedClass" Method="InvokedMethod" Phase="Activate"></Invoke>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-no-steps/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-no-steps/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-no-steps.ZPM">
+    <Module>
+      <Name>update-no-steps</Name>
+      <Version>2.1.1</Version>
+      <Resource Name="UpdateNoStepsPackage.PKG" />
+      <UpdatePackage>UpdateNoStepsPackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-seeded-step-errors/cls/UpdateSeededStepErrors/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-seeded-step-errors/cls/UpdateSeededStepErrors/UpdatePackage/V1.cls
@@ -1,0 +1,20 @@
+Class UpdateSeededStepErrors.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return []
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodA"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateSeededStepErrors.UpdatePackage.V1::MethodA()"
+    $$$ThrowOnError($$$ERROR($$$GeneralError, "UpdateSeededStepErrors.UpdatePackage.V1::MethodA() threw an error."))
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-seeded-step-errors/cls/UpdateSeededStepErrors/UpdatePackage/V2.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-seeded-step-errors/cls/UpdateSeededStepErrors/UpdatePackage/V2.cls
@@ -1,0 +1,19 @@
+Class UpdateSeededStepErrors.UpdatePackage.V2 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return []
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateSeededStepErrors.UpdatePackage.V2::MethodA()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-seeded-step-errors/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-seeded-step-errors/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-seeded-step-errors.ZPM">
+    <Module>
+      <Name>update-seeded-step-errors</Name>
+      <Version>2.1.1</Version>
+      <Resource Name="UpdateSeededStepErrors.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateSeededStepErrors.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-simple/cls/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-simple/cls/UpdatePackage/V1.cls
@@ -3,12 +3,12 @@ Class UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
 
 ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
 {
-    return ["MethodA", "MethodC"]
+    return ["MethodB", "MethodC"]
 }
 
 ClassMethod GetOrderedMethods() As %Library.DynamicArray
 {
-    return ["MethodB"]
+    return ["MethodA"]
 }
 
 ClassMethod MethodA()

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-step-added-to-older-version-class/cls/UpdateStepAddedOlderVersion/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-step-added-to-older-version-class/cls/UpdateStepAddedOlderVersion/UpdatePackage/V1.cls
@@ -1,0 +1,29 @@
+Class UpdateStepAddedOlderVersion.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V1::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-step-added-to-older-version-class/cls/UpdateStepAddedOlderVersion/UpdatePackage/V2.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-step-added-to-older-version-class/cls/UpdateStepAddedOlderVersion/UpdatePackage/V2.cls
@@ -1,0 +1,24 @@
+Class UpdateStepAddedOlderVersion.UpdatePackage.V2 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V2::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V2::MethodB()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-step-added-to-older-version-class/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-step-added-to-older-version-class/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-step-added-to-older-version-class.ZPM">
+    <Module>
+      <Name>update-step-added-to-older-version-class</Name>
+      <Version>2.1.1</Version>
+      <Resource Name="UpdateStepAddedOlderVersion.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateStepAddedOlderVersion.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-step-errors/cls/UpdateStepErrors/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-step-errors/cls/UpdateStepErrors/UpdatePackage/V1.cls
@@ -1,0 +1,29 @@
+Class UpdateStepErrors.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateStepErrors.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateStepErrors.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateStepErrors.UpdatePackage.V1::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-step-errors/cls/UpdateStepErrors/UpdatePackage/V2.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-step-errors/cls/UpdateStepErrors/UpdatePackage/V2.cls
@@ -1,0 +1,30 @@
+Class UpdateStepErrors.UpdatePackage.V2 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateStepErrors.UpdatePackage.V2::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateStepErrors.UpdatePackage.V2::MethodB()"
+    $$$ThrowOnError($$$ERROR($$$GeneralError, "UpdateStepErrors.UpdatePackage.V2::MethodB() threw an error."))
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateStepErrors.UpdatePackage.V2::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-step-errors/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-2.x/update-step-errors/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-step-errors.ZPM">
+    <Module>
+      <Name>update-step-errors</Name>
+      <Version>2.1.1</Version>
+      <Resource Name="UpdateStepErrors.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateStepErrors.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-3.x/update-step-added-to-older-version-class/cls/UpdateStepAddedOlderVersion/UpdatePackage/V1.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-3.x/update-step-added-to-older-version-class/cls/UpdateStepAddedOlderVersion/UpdatePackage/V1.cls
@@ -1,0 +1,34 @@
+Class UpdateStepAddedOlderVersion.UpdatePackage.V1 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodD", "MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V1::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V1::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V1::MethodC()"
+}
+
+ClassMethod MethodD()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V1::MethodD()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-3.x/update-step-added-to-older-version-class/cls/UpdateStepAddedOlderVersion/UpdatePackage/V2.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-3.x/update-step-added-to-older-version-class/cls/UpdateStepAddedOlderVersion/UpdatePackage/V2.cls
@@ -1,0 +1,29 @@
+Class UpdateStepAddedOlderVersion.UpdatePackage.V2 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA", "MethodC"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return ["MethodB"]
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V2::MethodA()"
+}
+
+ClassMethod MethodB()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V2::MethodB()"
+}
+
+ClassMethod MethodC()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V2::MethodC()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-3.x/update-step-added-to-older-version-class/cls/UpdateStepAddedOlderVersion/UpdatePackage/V3.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-3.x/update-step-added-to-older-version-class/cls/UpdateStepAddedOlderVersion/UpdatePackage/V3.cls
@@ -1,0 +1,19 @@
+Class UpdateStepAddedOlderVersion.UpdatePackage.V3 Extends %IPM.General.Update.VersionBase
+{
+
+ClassMethod GetOrderedMethodsPrimaryOnly() As %Library.DynamicArray
+{
+    return ["MethodA"]
+}
+
+ClassMethod GetOrderedMethods() As %Library.DynamicArray
+{
+    return []
+}
+
+ClassMethod MethodA()
+{
+    write !, "This is UpdateStepAddedOlderVersion.UpdatePackage.V3::MethodA()"
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-3.x/update-step-added-to-older-version-class/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/update-test/update-modules-3.x/update-step-added-to-older-version-class/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="update-step-added-to-older-version-class.ZPM">
+    <Module>
+      <Name>update-step-added-to-older-version-class</Name>
+      <Version>3.5.0</Version>
+      <Resource Name="UpdateStepAddedOlderVersion.UpdatePackage.PKG" />
+      <UpdatePackage>UpdateStepAddedOlderVersion.UpdatePackage</UpdatePackage>
+    </Module>
+  </Document>
+</Export>


### PR DESCRIPTION
NOTE: This PR should cover all checkbox items in the "In Scope" section. See below for tests that are a) already written or b) out of scope.

To run: `verify zpm -only -DUnitTest.Case=Test.PM.Integration.Update`

Issue: https://github.com/intersystems/ipm/issues/550

## Update testing To-Dos

### In Scope
1. Create the following modules:
- [x] Module with dependencies
- [x] Module with dependencies added as part of an update
- [x] Module with dependencies removed as part of an update
- [x] Module without any update methods (in either the current or updated module)
- [x] Module with new update method added to an older major version
- [x] Module with changed update method order for the major version to update to
- [x] Module with an update step to run that throws an error (should fail)
- [x] Module with a seeded update step that throws an error (should succeed)
- [x] Module with a dependency whose update step that throws an error
- [x] Module with an `<Invoke>` that throws an error during a lifecycle phase
- [x] Module with a dependency with an `<Invoke>` that throws an error during a lifecycle phase

2. Add the following test cases to the update suite:
- [x] Create a generic update test to be run on all the modules WITH ERRORS and verify that each module update fails
- [x] Running update on a module that has not been installed fails
- [x] Passing in a -path to update with a module name that does not match the given name fails
- [x] Trying to update the same module at the same time in the same namespace fails
- [x] Running update AFTER an an update process was killed mid-update is successful

3. Add the following tests to the install suite:
- [x]  Verify that the UpdateStep table is properly seeded at install/load, regardless of whether the module is provided in a tarball or local directory
- [x] Verify that attempting to run install/load without the force flag fails if a module is already installed
- [x] Verify that rows in the UpdateStep table are properly removed when the module is uninstalled
- [x] Verify that, if trying to uninstall a dependency module (should throw an error), it errors out and no update metadata is removed
- [x] Verify that running install/load when a module is already installed (no matter the version) succeeds in dev mode and fails otherwise

### Already Merged
1. Create the following module:
- Module without dependencies (simplest case)

3. Create a generic update test to be run on all the modules WITHOUT ERRORS that does the following:
- Note: Run it once with -dev flag
- Rows have been added to the UpdateStep table for each update method in the appropriate range of V# classes for 1) the base module and 2) each of its dependencies
- The correct update steps are run (e.g. starting at the correct step within the correct major version)
- Correct versions of dependency modules are installed

4. Create tests for the following cases (to be run on the simplest module): 
- Running update twice on the same module to new version is successful
- Running update with an older version throws an error immediately
- Running update with a version that doesn't exist in any configured repository throws an error immediately
- Running the same update command twice in a row results in a no-op on all update steps the second time
- Running update with a -path flag (so loading the newer version from a local tarball)

### Out of Scope
1. Update CI pipeline to add another IRIS instance which is mirrored. Initialize the main IRIS container as the primary and the new container as the backup.

2. Update tests above to be mirror-aware.
- Check that the correct subset of update steps are run on each mirror member corresponding to its mirror membership types

3. Add logging checks to the generic update test to be run on all modules WITHOUT errors

4. Add a rollback check to the generic update test run on all the modules WITH ERRORS:
- Verify that, in addition to erroring out the update, all update-related logic is rolled back (the old module is still installed and no new UpdateStep objects exist)

5. Add a check for propagation of Developer Mode on install/load/update (-dev should NOT cause dependencies to also be installed in Developer Mode unless those modules exist in configured source control)