### PR TITLE
Fix v0.10.3 release blockers

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PM_URL: https://pm.community.intersystems.com/packages/-/all?allVersions=1
-      JQ_SCRIPT: reduce .[] as $item ([]; if $item.allVersions | length >= ${{ inputs.minVersionCount }} then . + [$item.name] else . end)
+      JQ_SCRIPT: reduce .[] as $item ([]; if ($item.allVersions | length >= ${{ inputs.minVersionCount }}) and ($item.name | contains(" ") | not) then . + [$item.name] else . end)
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -105,7 +105,7 @@ jobs:
               halt
           EOF
             echo "::endgroup::"
-          
+
             echo "::group::Test package $package"
             set +e
             timeout ${{ inputs.timeoutSeconds }}s docker exec -i $CONTAINER iris session IRIS <<- EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Format all files and add consistent formatting settings, format on save etc.
 - #848: Resource processing should be done in order of granularity
-- #779: Module default parameters specified in `<Defaults>` in the module.xml are used when loading/installing the module and not just when the module itself runs its lifecycle phases
+- #779: Module parameters specified in `<Defaults>` in the module.xml are used when loading/installing the module and not just when the module itself runs its lifecycle phases
 
 ## [0.10.2] - 2025-06-04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-ARG BASE=irepo.intersystems.com/intersystems/iris-community:2025.1
+ARG BASE=containers.intersystems.com/intersystems/iris-community:2025.1
 
 FROM ${BASE}
 
 ARG REGISTRY=https://pm.community.intersystems.com
 
 RUN --mount=type=bind,src=.,dst=/home/irisowner/zpm/ \
-    iris start iris && \
-    iris session IRIS < /home/irisowner/zpm/iris.script && \
-    iris stop iris quietly
+  iris start iris && \
+  iris session IRIS < /home/irisowner/zpm/iris.script && \
+  iris stop iris quietly

--- a/src/cls/IPM/General/SemanticVersionExpression.cls
+++ b/src/cls/IPM/General/SemanticVersionExpression.cls
@@ -25,18 +25,36 @@ Method ExpressionSet(value As %String) As %Status
   }
   set status = $$$OK
   try {
-    set options = $listfromstring(value,"||")
-    set ptr = 0
-    while $listnext(options,ptr,rangeExpr) {
-      set rangeExpr = $zstrip(rangeExpr,"<>W")
-      set status = ##class(%IPM.General.SemanticVersionExpression.Range).FromString(rangeExpr,.option)
-      if $$$ISERR(status) {
-        quit
+    if value["&&" {
+      set reqs = $listfromstring(value,"&&")
+      set ptr = 0
+      while $listnext(reqs,ptr,rangeExpr) {
+        set rangeExpr = $zstrip(rangeExpr,"<>W")
+        set rangeExpr = $zstrip(rangeExpr, "*", "()")
+        set status = ##class(%IPM.General.SemanticVersionExpression.Range).FromString(rangeExpr,.option)
+        if $$$ISERR(status) {
+          quit
+        }
+        if option.ToResolvedString() = "" {
+          continue
+        }
+        do ..AllOf.Insert(option)
       }
-      if option.ToResolvedString() = "" {
-        continue
+    } else {
+      set options = $listfromstring(value,"||")
+      set ptr = 0
+      while $listnext(options,ptr,rangeExpr) {
+        set rangeExpr = $zstrip(rangeExpr,"<>W")
+        set rangeExpr = $zstrip(rangeExpr, "*", "()")
+        set status = ##class(%IPM.General.SemanticVersionExpression.Range).FromString(rangeExpr,.option)
+        if $$$ISERR(status) {
+          quit
+        }
+        if option.ToResolvedString() = "" {
+          continue
+        }
+        do ..AnyOf.Insert(option)
       }
-      do ..AnyOf.Insert(option)
     }
     set i%Expression = value
   } catch e {
@@ -57,14 +75,23 @@ Method ToResolvedString() As %String
     for i=1:1:..AnyOf.Count() {
       set opt = ..AnyOf.GetAt(i)
       set resolvedString = opt.ToResolvedString()
-      set optList = optList_$listbuild("(" _ resolvedString _ ")")
+      if ..AnyOf.Count() > 1 {
+        set optList = optList_$listbuild("(" _ resolvedString _ ")")
+      } else {
+        set optList = optList_$listbuild(resolvedString)
+      }
     }
     quit $listtostring(optList," || ")
   }
   if ..AllOf.Count() {
     for i=1:1:..AllOf.Count() {
       set opt = ..AllOf.GetAt(i)
-      set optList = optList_$listbuild("(" _ opt.ToResolvedString() _ ")")
+      set resolvedString = opt.ToResolvedString()
+      if ..AllOf.Count() > 1 {
+        set optList = optList_$listbuild("(" _ resolvedString _ ")")
+      } else {
+        set optList = optList_$listbuild(resolvedString)
+      }
     }
     quit $listtostring(optList," && ")
   }

--- a/src/cls/IPM/General/SemanticVersionExpression/Comparator.cls
+++ b/src/cls/IPM/General/SemanticVersionExpression/Comparator.cls
@@ -42,6 +42,7 @@ ClassMethod FromString(
 	pExpr As %String,
 	Output pComparator As %IPM.General.SemanticVersionExpression.Comparator) As %Status
 {
+  set pExpr = $zstrip(pExpr, "*", "()")
   set tSC = $$$OK
   set pComparator = ..%New(pExpr)
   try {

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -593,6 +593,7 @@ Method GetDefaultParameters(Output pParams)
 
             // Convert "."-delimited pieces to subscripts in pParams
             set tPieces = $listfromstring(tDefault.Name,".")
+            kill tValue
             set tValue = tDefault.Value
             for tSubscript=$listlength(tPieces):-1:1 {
                 kill tData

--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -1123,33 +1123,12 @@ ClassMethod GetModuleDefaultsFromXML(
 	pDirectory As %String,
 	Output defaults)
 {
-  set object = ..GetModuleObjectFromPath(pDirectory, .found)
+  set module = ..GetModuleObjectFromPath(pDirectory, .found)
   if 'found {
     quit
   }
 
-  set packaging = object.Packaging
-  $$$ThrowOnError(##class(%IPM.Lifecycle.Base).GetBaseClassForPackaging(packaging, .lifecycleClass))
-
-  // Iterate through the default parameters
-  set defaults = 0
-  set key = ""
-  for {
-    set def = object.Defaults.GetNext(.key)
-    if key = "" {
-      quit
-    }
-    if ($classname(def) '= "%IPM.Storage.ModuleSetting.Parameter") {
-      continue
-    }
-    // Filter based on optional LifecycleClass
-    if (def.LifecycleClass '= "") && (def.LifecycleClass '= lifecycleClass) {
-      continue
-    }
-
-    set defaults = defaults + 1
-    set defaults(def.Name) = def.Value
-  }
+  do module.GetDefaultParameters(.defaults)
 }
 
 ClassMethod ExportDocumentForObject(

--- a/tests/unit_tests/Test/PM/Unit/Module.cls
+++ b/tests/unit_tests/Test/PM/Unit/Module.cls
@@ -38,10 +38,17 @@ Method TestEvaluateMacro()
 Method TestGetModuleDefaultsFromXML()
 {
   do ##class(%IPM.Utils.Module).GetModuleDefaultsFromXML("/home/irisowner/zpm/tests/integration_tests/Test/PM/Integration/_data/module-defaults/", .defaults)
-  do $$$AssertEquals(defaults,3)
   do $$$AssertEquals(defaults("ArbitraryDefault"), 1234)
   do $$$AssertEquals(defaults("NoLock"), 1)
   do $$$AssertEquals(defaults("Verbose"), 1)
+
+  set count = 0
+  set key = $order(defaults(""))
+  while (key'="") {
+    set count = count + 1
+    set key = $order(defaults(key))
+  }
+  do $$$AssertEquals(count, 3)
 }
 
 }

--- a/tests/unit_tests/Test/PM/Unit/SemVer/Expressions.cls
+++ b/tests/unit_tests/Test/PM/Unit/SemVer/Expressions.cls
@@ -187,6 +187,18 @@ Method TestAndedOr()
 
   // Test that you cannot ExpressionSet() an AND expression
   do $$$AssertStatusNotOK(sve3.ExpressionSet(">3.0.0"))
+
+  // Test FromString of AND'ed expression
+  do $$$AssertStatusOK(##class(%IPM.General.SemanticVersionExpression).FromString("(=1.1.2) && (>=1.0.1)",.sve4))
+  do $$$AssertTrue(sve4.IsSatisfiedBy(##class(%IPM.General.SemanticVersion).FromString("1.1.2")))
+  do $$$AssertNotTrue(sve4.IsSatisfiedBy(##class(%IPM.General.SemanticVersion).FromString("1.0.1")))
+  do $$$AssertNotTrue(sve4.IsSatisfiedBy(##class(%IPM.General.SemanticVersion).FromString("2.0.1")))
+
+  // Test alternate syntax
+  do $$$AssertStatusOK(##class(%IPM.General.SemanticVersionExpression).FromString("(1.1.2) && (^1.0.1)",.sve4))
+  do $$$AssertTrue(sve4.IsSatisfiedBy(##class(%IPM.General.SemanticVersion).FromString("1.1.2")))
+  do $$$AssertNotTrue(sve4.IsSatisfiedBy(##class(%IPM.General.SemanticVersion).FromString("1.0.1")))
+  do $$$AssertNotTrue(sve4.IsSatisfiedBy(##class(%IPM.General.SemanticVersion).FromString("2.0.1")))
 }
 
 Method TestOnTheFlyMigration()


### PR DESCRIPTION
This addresses a few issues from the v0.10.3 changes:

- Fix SemVer parsing bug (surfaced during regression testing of packages)
- Refactor code that gets module default parameters
- Update Dockerfile to pull from containers.intersystems.com instead of irepo.intersystems.com so GitHub Actions workflows can use anonymous tokens
- Prevent Test Major Packages workflow from breaking due to packages with spaces in their names

Running the Test Major Packages workflow with a 0.10.2 baseline shows no new failing package tests.
[v0.10.3](https://github.com/intersystems/ipm/actions/runs/17774805172/job/50519747348) vs [v0.10.2](https://github.com/intersystems/ipm/actions/runs/17775557983/job/50522230457)