### PR TITLE
Fix CLI parser issue where -path data gets stuffed into -verbose position

### DIFF
--- a/src/cls/IPM/CLI.cls
+++ b/src/cls/IPM/CLI.cls
@@ -506,6 +506,7 @@ ClassMethod %ParseCommandInput(
                         set tDataName = tDataAlias
                         if $data(tCommandStructure(modifierSubscript,"modifiers",tModifier,"dataValue"),tDataValue) {
                             do ..SetData(.pCommandInfo,tDataAlias,tDataValue)
+                            set tDataName = ""
                             set tState = $$$PREARGUMENT
                         } else {
                             set tState = $$$MODIFIERVALUE
@@ -514,6 +515,7 @@ ClassMethod %ParseCommandInput(
                         set tState = $$$MODIFIERVALUE
                     } else {
                         set pCommandInfo("modifiers",tModifier) = ""
+                        set tDataName = ""
                         set tState = $$$PREARGUMENT
                     }
                     set tAccum = ""


### PR DESCRIPTION
Bug - Command from CLI being parsed incorrectly:
zpm:USER>update -v -path /path/to/local/module/ update-simple
tParsedCommandInfo="update"
tParsedCommandInfo("data","Verbose")="/path/to/local/module/" tParsedCommandInfo("data","zpm","Verbose")="/path/to/local/module/" tParsedCommandInfo("parameters","module")="update-simple"

Fixed by resetting tDataName on each iteration where a modifier is being set in %ParseCommandInput()