### PR TITLE
Fix 899 CLI parser parses modifiers incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.4] - Unreleased
+
+### Fixed
+- #899: Fixed CLI parser parses modifiers incorrectly
+
 ## [0.10.3] - 2025-09-17
 
 ### Fixed

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="Cache" version="25">
 <Document name="ZPM.ZPM"><Module>
   <Name>ZPM</Name>
-  <Version>0.10.3-SNAPSHOT</Version>
+  <Version>0.10.4-SNAPSHOT</Version>
   <ExternalName>IPM</ExternalName>
   <Description>InterSystems Package Manager (IPM) provides development tools and infrastructure for defining, building, distributing, and installing modules and applications.</Description>
   <Keywords>Package Manager</Keywords>
@@ -41,7 +41,7 @@
   <PythonWheel Name="typing_extensions-4.12.2-py3-none-any.whl" ExtraPipFlags="--no-deps"/>
   <PythonWheel Name="urllib3-2.3.0-py3-none-any.whl" ExtraPipFlags="--no-deps"/>
 
-  <!-- Pure python implementation of rpds-py for offline installation or behind a firewall. 
+  <!-- Pure python implementation of rpds-py for offline installation or behind a firewall.
     This intentionally and necessarily masks possible installation of the real rpds-py package
     for the sake of working in a container environment with durable %SYS. -->
   <FileCopy Name="modules/python/rpds.py" Target="${mgrdir}python/rpds.py"/>

--- a/src/cls/IPM/CLI.cls
+++ b/src/cls/IPM/CLI.cls
@@ -441,6 +441,7 @@ ClassMethod %ParseCommandInput(
         set tModifier = ""
         set tDataName = ""
         set tParamCount = 0
+        set tIsCustomData = 0
         set tPreEscapeState = ""
         for {
             set tChar = $extract(pCommandString,tPos)
@@ -506,6 +507,7 @@ ClassMethod %ParseCommandInput(
                         set tDataName = tDataAlias
                         if $data(tCommandStructure(modifierSubscript,"modifiers",tModifier,"dataValue"),tDataValue) {
                             do ..SetData(.pCommandInfo,tDataAlias,tDataValue)
+                            set tDataName = ""
                             set tState = $$$PREARGUMENT
                         } else {
                             set tState = $$$MODIFIERVALUE
@@ -514,13 +516,15 @@ ClassMethod %ParseCommandInput(
                         set tState = $$$MODIFIERVALUE
                     } else {
                         set pCommandInfo("modifiers",tModifier) = ""
+                        set tDataName = ""
                         set tState = $$$PREARGUMENT
                     }
                     set tAccum = ""
                 } elseif (tState = $$$MODIFIERVALUE) {
                     if ($get(tDataName) '= "") {
-                        do ..SetData(.pCommandInfo,tDataName,tAccum,1)
+                        do ..SetData(.pCommandInfo,tDataName,tAccum,tIsCustomData)
                         set tDataName = ""
+                        set tIsCustomData = 0
                     } else {
                         set pCommandInfo("modifiers",tModifier) = tAccum
                     }
@@ -581,7 +585,8 @@ ClassMethod %ParseCommandInput(
                     continue
                 } elseif (tState = $$$MODIFIERVALUEQUOTED) {
                     if ($get(tDataName) '= "") {
-                        do ..SetData(.pCommandInfo,tDataName,tAccum,1)
+                        do ..SetData(.pCommandInfo,tDataName,tAccum,tIsCustomData)
+                        set tIsCustomData = 0
                     } else {
                         set pCommandInfo("modifiers",tModifier) = tAccum
                     }
@@ -629,6 +634,7 @@ ClassMethod %ParseCommandInput(
                     if (tAccum = "") && (tDataPrefix '= "") && (tChar = tDataPrefix) {
                         set tState = $$$DATANAME
                         set tDataName = ""
+                        set tIsCustomData = 1
                         continue
                     }
                 }
@@ -645,7 +651,18 @@ ClassMethod %ParseCommandInput(
                 set tState = tPreEscapeState
             }
         }
-
+        if ($get(pCommandInfo) '= "") {
+            set commandName = pCommandInfo
+            for i=1:1 {
+                set paramName = $get(tCommandStructure(pCommandInfo,"parameters",i))
+                quit:paramName=""
+                if $get(tCommandStructure(pCommandInfo,"parameters",paramName,"required"),0) {
+                    if $get(pCommandInfo("parameters",paramName)) = "" {
+                        $$$ThrowStatus($$$ERROR($$$GeneralError,$$$FormatText("Non-empty value required for parameter %1",$$$QUOTE(paramName))))
+                    }
+                }
+            }
+        }
         // TODO: Extra validation.
     } catch e {
         if e.%IsA("%Exception.SystemException") {

--- a/src/cls/IPM/CLI.cls
+++ b/src/cls/IPM/CLI.cls
@@ -651,18 +651,6 @@ ClassMethod %ParseCommandInput(
                 set tState = tPreEscapeState
             }
         }
-        if ($get(pCommandInfo) '= "") {
-            set commandName = pCommandInfo
-            for i=1:1 {
-                set paramName = $get(tCommandStructure(pCommandInfo,"parameters",i))
-                quit:paramName=""
-                if $get(tCommandStructure(pCommandInfo,"parameters",paramName,"required"),0) {
-                    if $get(pCommandInfo("parameters",paramName)) = "" {
-                        $$$ThrowStatus($$$ERROR($$$GeneralError,$$$FormatText("Non-empty value required for parameter %1",$$$QUOTE(paramName))))
-                    }
-                }
-            }
-        }
         // TODO: Extra validation.
     } catch e {
         if e.%IsA("%Exception.SystemException") {

--- a/tests/unit_tests/Test/PM/Unit/CLI.cls
+++ b/tests/unit_tests/Test/PM/Unit/CLI.cls
@@ -4,89 +4,160 @@ Class Test.PM.Unit.CLI Extends %UnitTest.TestCase
 
 Method TestParser()
 {
-	
+
 	// Test cases
-	Set tCommands($i(tCommands)) = "help -v repo"
-	Set tResults(tCommands)="help"
-	Set tResults(tCommands,"modifiers","verbose")=""
-	Set tResults(tCommands,"parameters","command")="repo"
-	
-	Set tCommands($i(tCommands)) = "repo -name UTFILE -fs -path ""C:\\Program Files\\stuff\\"" -depth 42"
-	Set tResults(tCommands)="repo"
-	Set tResults(tCommands,"modifiers","depth")=42
-	Set tResults(tCommands,"modifiers","filesystem")=""
-	Set tResults(tCommands,"modifiers","name")="UTFILE"
-	Set tResults(tCommands,"modifiers","path")="C:\Program Files\stuff\"
-	
-	Set tCommands($i(tCommands)) = "ZPM activate -dev -DUIFW.force=1"
+	set tCommands($increment(tCommands)) = "help -v repo"
+	set tResults(tCommands)="help"
+	set tResults(tCommands,"modifiers","verbose")=""
+	set tResults(tCommands,"parameters","command")="repo"
+
+	set tCommands($increment(tCommands)) = "repo -name UTFILE -fs -path ""C:\\Program Files\\stuff\\"" -depth 42"
+	set tResults(tCommands)="repo"
+	set tResults(tCommands,"modifiers","depth")=42
+	set tResults(tCommands,"modifiers","filesystem")=""
+	set tResults(tCommands,"modifiers","name")="UTFILE"
+	set tResults(tCommands,"modifiers","path")="C:\Program Files\stuff\"
+
+	set tCommands($increment(tCommands)) = "ZPM activate -dev -DUIFW.force=1"
 	// Old behavior:
 	/*
 	Set tResults(tCommands)="module-action"
 	Set tResults(tCommands,"parameters","actions")="activate -dev -DUIFW.force=1"
 	Set tResults(tCommands,"parameters","module")="ZPM"
 	*/
-	Set tResults(tCommands)="module-action"
-	Set tResults(tCommands,"parameters","actions")="activate"
-	Set tResults(tCommands,"parameters","module")="ZPM"
-	Set tResults(tCommands,"data","DeveloperMode")=1
-	Set tResults(tCommands,"data","UIFW","force")=1
-	
-	Set tCommands($i(tCommands)) = "ZPM clean install -dev -DUIFW.force=1 -DSomething=""quoted\"" value"""
+	set tResults(tCommands)="module-action"
+	set tResults(tCommands,"parameters","actions")="activate"
+	set tResults(tCommands,"parameters","module")="ZPM"
+	set tResults(tCommands,"data","DeveloperMode")=1
+	set tResults(tCommands,"data","UIFW","force")=1
+
+	set tCommands($increment(tCommands)) = "ZPM clean install -dev -DUIFW.force=1 -DSomething=""quoted\"" value"""
 	// Old behavior:
 	/*
 	Set tResults(tCommands)="module-action"
 	Set tResults(tCommands,"parameters","actions")="clean install -dev -DUIFW.force=1 -DSomething=""quoted"" value"""
 	Set tResults(tCommands,"parameters","module")="ZPM"
 	*/
-	Set tResults(tCommands)="module-action"
-	Set tResults(tCommands,"parameters","actions")="clean install"
-	Set tResults(tCommands,"parameters","module")="ZPM"
-	Set tResults(tCommands,"data","DeveloperMode")=1
-	Set tResults(tCommands,"data","UIFW","force")=1
-	Set tResults(tCommands,"data","zpm","Something")="quoted"" value"
-	Set tResults(tCommands,"data","Something")="quoted"" value"
-	
-	Set tCommands($i(tCommands)) = "module-action isc-dev publish"
-	Set tResults(tCommands)="module-action"
-	Set tResults(tCommands,"parameters","actions")="publish"
-	Set tResults(tCommands,"parameters","module")="isc-dev"
-	
-	Set tCommands($i(tCommands)) = "list-installed -t"
-	Set tResults(tCommands)="list-installed"
-	Set tResults(tCommands,"modifiers","tree")=""
-	
-	Set tCommands($i(tCommands)) = "install SomeModule"
-	Set tResults(tCommands)="install"
-	Set tResults(tCommands,"parameters","module")="SomeModule"
-	
-	Set tCommands($i(tCommands)) = "install SomeModule 0.0.1-prerelease.42+snapshot"
-	Set tResults(tCommands)="install"
-	Set tResults(tCommands,"parameters","module")="SomeModule"
-	Set tResults(tCommands,"parameters","version")="0.0.1-prerelease.42+snapshot"
-	
-	Set tCommands($i(tCommands)) = "repo -r -n registry -url http://iris-test:52774/registry/ -user ""user"" -pass ""pass"""
-	Set tResults(tCommands)="repo"
-	Set tResults(tCommands,"modifiers","name")="registry"
-	Set tResults(tCommands,"modifiers","remote")=""
-	Set tResults(tCommands,"modifiers","url")="http://iris-test:52774/registry/"
-	Set tResults(tCommands,"modifiers","username")="user"
-	Set tResults(tCommands,"modifiers","password")="pass"
-	
+	set tResults(tCommands)="module-action"
+	set tResults(tCommands,"parameters","actions")="clean install"
+	set tResults(tCommands,"parameters","module")="ZPM"
+	set tResults(tCommands,"data","DeveloperMode")=1
+	set tResults(tCommands,"data","UIFW","force")=1
+	set tResults(tCommands,"data","zpm","Something")="quoted"" value"
+	set tResults(tCommands,"data","Something")="quoted"" value"
+
+	set tCommands($increment(tCommands)) = "module-action isc-dev publish"
+	set tResults(tCommands)="module-action"
+	set tResults(tCommands,"parameters","actions")="publish"
+	set tResults(tCommands,"parameters","module")="isc-dev"
+
+	set tCommands($increment(tCommands)) = "list-installed -t"
+	set tResults(tCommands)="list-installed"
+	set tResults(tCommands,"modifiers","tree")=""
+
+	set tCommands($increment(tCommands)) = "install SomeModule"
+	set tResults(tCommands)="install"
+	set tResults(tCommands,"parameters","module")="SomeModule"
+
+	set tCommands($increment(tCommands)) = "install SomeModule 0.0.1-prerelease.42+snapshot"
+	set tResults(tCommands)="install"
+	set tResults(tCommands,"parameters","module")="SomeModule"
+	set tResults(tCommands,"parameters","version")="0.0.1-prerelease.42+snapshot"
+
+	set tCommands($increment(tCommands)) = "repo -r -n registry -url http://iris-test:52774/registry/ -user ""user"" -pass ""pass"""
+	set tResults(tCommands)="repo"
+	set tResults(tCommands,"modifiers","name")="registry"
+	set tResults(tCommands,"modifiers","remote")=""
+	set tResults(tCommands,"modifiers","url")="http://iris-test:52774/registry/"
+	set tResults(tCommands,"modifiers","username")="user"
+	set tResults(tCommands,"modifiers","password")="pass"
+
 	/*
-	Set tCommands($i(tCommands)) = 
+	Set tCommands($i(tCommands)) =
 	Set tResults(tCommands)=
 	Set tResults(tCommands,
 	*/
-	
+
+    // defaulted dataValue (-v) followed by a valued modifier
+    // Expect: -v -> data("Verbose")=1, and -env value goes to data("EnvFiles") (NOT into "Verbose")
+    set tCommands($increment(tCommands)) = "install SomeModule -v -env C:\env1.json;C:\env2.json"
+    set tResults(tCommands)="install"
+    set tResults(tCommands,"parameters","module")="SomeModule"
+    set tResults(tCommands,"data","Verbose")=1
+    set tResults(tCommands,"data","EnvFiles")="C:\env1.json;C:\env2.json"
+
+    // defaulted dataValue (-q) followed by a valued modifier
+    // Expect: -q -> data("Verbose")=0, and -env captured correctly
+    set tCommands($increment(tCommands)) = "install SomeModule -q -env /etc/env1.json;/etc/env2.json"
+    set tResults(tCommands)="install"
+    set tResults(tCommands,"parameters","module")="SomeModule"
+    set tResults(tCommands,"data","Verbose")=0
+    set tResults(tCommands,"data","EnvFiles")="/etc/env1.json;/etc/env2.json"
+
+    // module-action + phase modifiers
+    // Expect: -v sets data("Verbose")=1, -path goes to data("Path"), and -export-deps maps to data("ExportDependencies")
+    set tCommands($increment(tCommands)) = "module-action MyModule package -v -path /tmp/pkg -export-deps 1"
+    set tResults(tCommands)="module-action"
+    set tResults(tCommands,"parameters","module")="MyModule"
+    set tResults(tCommands,"parameters","actions")="package"
+    set tResults(tCommands,"data","Verbose")=1
+    set tResults(tCommands,"data","Path")="/tmp/pkg"
+    set tResults(tCommands,"data","ExportDependencies")=1
+
+    // defaulted dataValue (-dev) followed by a valued modifier
+    // Expect: -dev -> data("DeveloperMode")=1, and -extra-pip-flags captured correctly
+    set tCommands($increment(tCommands)) = "load -dev -extra-pip-flags ""--timeout 30"" C:\code\my-module\"
+    set tResults(tCommands)="load"
+    set tResults(tCommands,"parameters","path")="C:\code\my-module\"
+    set tResults(tCommands,"data","DeveloperMode")=1
+    set tResults(tCommands,"data","ExtraPipFlags")="--timeout 30"
+
+    // Recognized alias should NOT mirror under data("zpm",...)
+	// Expects no data("zpm","EnvFiles")
+    set tCommands($increment(tCommands)) = "install SomeModule -env C:\a.json;C:\b.json"
+    set tResults(tCommands)="install"
+    set tResults(tCommands,"parameters","module")="SomeModule"
+    set tResults(tCommands,"data","EnvFiles")="C:\a.json;C:\b.json"
+
+    // Recognized alias with a preceding defaulted dataValue (-v) should NOT mirror under data("zpm",...)
+    set tCommands($increment(tCommands)) = "install SomeModule -v -env /etc/a.json;/etc/b.json"
+    set tResults(tCommands)="install"
+    set tResults(tCommands,"parameters","module")="SomeModule"
+    set tResults(tCommands,"data","Verbose")=1
+    set tResults(tCommands,"data","EnvFiles")="/etc/a.json;/etc/b.json"
+
+    // module-action with valued aliases; no zpm copies for aliases
+    set tCommands($increment(tCommands)) = "module-action MyModule package -v -path /tmp/pkg -export-deps 1"
+    set tResults(tCommands)="module-action"
+    set tResults(tCommands,"parameters","module")="MyModule"
+    set tResults(tCommands,"parameters","actions")="package"
+    set tResults(tCommands,"data","Verbose")=1
+    set tResults(tCommands,"data","Path")="/tmp/pkg"
+    set tResults(tCommands,"data","ExportDependencies")=1
+
+    // load with defaulted alias then valued alias; no zpm copy for alias
+    set tCommands($increment(tCommands)) = "load -dev -extra-pip-flags ""--timeout 30"" C:\code\my-module\"
+    set tResults(tCommands)="load"
+    set tResults(tCommands,"parameters","path")="C:\code\my-module\"
+    set tResults(tCommands,"data","DeveloperMode")=1
+    set tResults(tCommands,"data","ExtraPipFlags")="--timeout 30"
+
+    // Mix of -D and recognized alias
+    set tCommands($increment(tCommands)) = "install SomeModule -DEnvFiles=/etc/one;/etc/two -env /etc/three;/etc/four"
+    set tResults(tCommands)="install"
+    set tResults(tCommands,"parameters","module")="SomeModule"
+    set tResults(tCommands,"data","EnvFiles")="/etc/three;/etc/four"
+    set tResults(tCommands,"data","zpm","EnvFiles")="/etc/one;/etc/two"
+
 	// Verify output matches
-	For i=1:1:tCommands {
-		Kill tParsedCommandInfo,tExpectedCommandInfo
-		Do $$$AssertStatusOK(##class(%IPM.Main).%ParseCommandInput(tCommands(i),.tParsedCommandInfo))
-		Merge tExpectedCommandInfo = tResults(i)
-		If '$$$AssertTrue(..CompareArrays(.tParsedCommandInfo,.tExpectedCommandInfo,.tMessage),"Parsed correctly: "_tCommands(i)) {
-			Do $$$LogMessage(tMessage)
-			Write !,"Expected:",! zw tExpectedCommandInfo
-			Write !,"Actual:",! zw tParsedCommandInfo
+	for i=1:1:tCommands {
+		kill tParsedCommandInfo,tExpectedCommandInfo
+		do $$$AssertStatusOK(##class(%IPM.Main).%ParseCommandInput(tCommands(i),.tParsedCommandInfo))
+		merge tExpectedCommandInfo = tResults(i)
+		if '$$$AssertTrue(..CompareArrays(.tParsedCommandInfo,.tExpectedCommandInfo,.tMessage),"Parsed correctly: "_tCommands(i)) {
+			do $$$LogMessage(tMessage)
+			write !,"Expected:",! zwrite tExpectedCommandInfo
+			write !,"Actual:",! zwrite tParsedCommandInfo
 		}
 	}
 }
@@ -94,29 +165,29 @@ Method TestParser()
 Method TestRepository()
 {
 	// Cleanup
-	Do ..RunCommand("repo -delete-all")
-	Do ..RunCommand("repo -list")
-	
-	// Create repositories
-	Set tDir = ##class(%File).ManagerDirectory()
-	Do ##class(%Studio.General).GetWebServerPort(.tPort)
-	Set tUrl = "https://pm.community.intersystems.com/"
-	Do ..AssertNoException("repo -name UTFILE -fs -path "_tDir_" -depth 1")
-	Do ..AssertNoException("repo -n UTSERVER -r -url "_tUrl)
-	Do ..RunCommand("repo -list")
-	
-	// Update repositories
-	Do ..AssertNoException("repo -n UTFILE -fs -snapshots 0")
-	Do ..AssertNoException("repo -name UTSERVER -r -prereleases 0 -url http://registry/")
-	Do ..AssertNoException("repo -name TEST -r -prereleases 0 -url http://newregistry/ -publish 1")
-	Do ..RunCommand("repo -list")
-	
-	// Cleanup (again)
-	Do ..RunCommand("repo -n UTFILE -delete")
-	Do ..RunCommand("repo -name UTSERVER -delete")
-	Do ..RunCommand("repo -name TEST -delete")
+	do ..RunCommand("repo -delete-all")
+	do ..RunCommand("repo -list")
 
-	Do ..RunCommand("repo -r -name registry -reset-defaults")
+	// Create repositories
+	set tDir = ##class(%File).ManagerDirectory()
+	do ##class(%Studio.General).GetWebServerPort(.tPort)
+	set tUrl = "https://pm.community.intersystems.com/"
+	do ..AssertNoException("repo -name UTFILE -fs -path "_tDir_" -depth 1")
+	do ..AssertNoException("repo -n UTSERVER -r -url "_tUrl)
+	do ..RunCommand("repo -list")
+
+	// Update repositories
+	do ..AssertNoException("repo -n UTFILE -fs -snapshots 0")
+	do ..AssertNoException("repo -name UTSERVER -r -prereleases 0 -url http://registry/")
+	do ..AssertNoException("repo -name TEST -r -prereleases 0 -url http://newregistry/ -publish 1")
+	do ..RunCommand("repo -list")
+
+	// Cleanup (again)
+	do ..RunCommand("repo -n UTFILE -delete")
+	do ..RunCommand("repo -name UTSERVER -delete")
+	do ..RunCommand("repo -name TEST -delete")
+
+	do ..RunCommand("repo -r -name registry -reset-defaults")
 }
 
 Method TestModifiers()
@@ -139,24 +210,24 @@ Method CompareModifiers(
 	do ##class(%IPM.Main).%ParseCommandInput(module_" "_phase_" "+commandModifiers,.info1)
 	do ##class(%IPM.Main).%ParseCommandInput(phase_" "_module_" "+commandModifiers,.info2)
 
-	If '$$$AssertTrue(..CompareArrays(.info1,.info2,.tMessage),"module-action and lifecycle phase allow for same modifiers") {
-		Do $$$LogMessage(tMessage)
-		Write !,"module-action accepted modifiers:",! zw info1
-		Write !,phase_" accepted modifiers:",! zw info2
+	if '$$$AssertTrue(..CompareArrays(.info1,.info2,.tMessage),"module-action and lifecycle phase allow for same modifiers") {
+		do $$$LogMessage(tMessage)
+		write !,"module-action accepted modifiers:",! zwrite info1
+		write !,phase_" accepted modifiers:",! zwrite info2
 	}
 }
 
 Method RunCommand(pCommand As %String)
 {
-	Do ##class(%IPM.Main).Shell(pCommand)
-	Do $$$LogMessage("Run command: "_pCommand)
+	do ##class(%IPM.Main).Shell(pCommand)
+	do $$$LogMessage("Run command: "_pCommand)
 }
 
 Method AssertNoException(pCommand As %String)
 {
-	Do ##class(%IPM.Main).ShellInternal(pCommand,.tException)
-	If '$$$AssertEquals(tException,"","No exceptions occurred running command: "_pCommand) {
-		Do $$$LogMessage(tException.DisplayString())
+	do ##class(%IPM.Main).ShellInternal(pCommand,.tException)
+	if '$$$AssertEquals(tException,"","No exceptions occurred running command: "_pCommand) {
+		do $$$LogMessage(tException.DisplayString())
 	}
 }
 
@@ -171,47 +242,47 @@ Method CompareArrays(
 	ByRef second,
 	Output pMessage) As %Boolean [ PublicList = (tRef1, tRef2, first, second) ]
 {
-    New tRef1,tRef2
-    Set pMessage = ""
-    Set tEqual = 1
-    Set tRef1 = "first"
-    Set tRef2 = "second"
-    While (tRef1 '= "") || (tRef2 '= "") {
+    new tRef1,tRef2
+    set pMessage = ""
+    set tEqual = 1
+    set tRef1 = "first"
+    set tRef2 = "second"
+    while (tRef1 '= "") || (tRef2 '= "") {
         #; See if the subscript is the same for both arrays.
         #; If not, one of them has a subscript the other doesn't, and they're not equal.
-        If ($Piece(tRef1,"first",2) '= $Piece(tRef2,"second",2)) {
-            Set tEqual = 0
-            Set pMessage = "Different subscripts encountered by $Query: "_
-                $Case(tRef1,"":"<end>",:tRef1)_"; "_$Case(tRef2,"":"<end>",:tRef2)
-            Quit
+        if ($piece(tRef1,"first",2) '= $piece(tRef2,"second",2)) {
+            set tEqual = 0
+            set pMessage = "Different subscripts encountered by $Query: "_
+                $case(tRef1,"":"<end>",:tRef1)_"; "_$case(tRef2,"":"<end>",:tRef2)
+            quit
         }
-        
-        Kill tRef1Value,tRef2Value
-        Set tRef1Data = $Data(@tRef1,tRef1Value)
-        Set tRef2Data = $Data(@tRef2,tRef2Value)
+
+        kill tRef1Value,tRef2Value
+        set tRef1Data = $data(@tRef1,tRef1Value)
+        set tRef2Data = $data(@tRef2,tRef2Value)
         #; See if the $Data values are the same for the two.
         #; This is really only useful to detect if one of the arrays is undefined on the first pass;
         #; $Query only returns subscripts with data.
         #; This will catch only one being defined, or one being an array and
         #; ​the other being a regular variable.
-        If (tRef1Data '= tRef2Data) {
-            Set tEqual = 0
-            Set pMessage = "$Data("_tRef1_")="_tRef1Data_"; $Data("_tRef2_")="_tRef2Data
-            Quit
-        } ElseIf (tRef1Data#2) && (tRef2Data#2) {
+        if (tRef1Data '= tRef2Data) {
+            set tEqual = 0
+            set pMessage = "$Data("_tRef1_")="_tRef1Data_"; $Data("_tRef2_")="_tRef2Data
+            quit
+        } elseif (tRef1Data#2) && (tRef2Data#2) {
             #; See if the value at the subscript is the same for both arrays.
             #; If not, they're not equal.
-            If (tRef1Value '= tRef2Value) {
-                Set tEqual = 0
-                Set pMessage = tRef1_"="_@tRef1_"; "_tRef2_"="_@tRef2
-                Quit
+            if (tRef1Value '= tRef2Value) {
+                set tEqual = 0
+                set pMessage = tRef1_"="_@tRef1_"; "_tRef2_"="_@tRef2
+                quit
             }
         }
-        
-        Set tRef1 = $Query(@tRef1)
-        Set tRef2 = $Query(@tRef2)
+
+        set tRef1 = $query(@tRef1)
+        set tRef2 = $query(@tRef2)
     }
-    Quit tEqual
+    quit tEqual
 }
 
 }


### PR DESCRIPTION
Fix 899 CLI parser parses modifiers incorrectly.

Case 1:
the following command: zpm "update -v -path /path/to/local/module/ myModule" gets /path/to/local/module/ assigned into  the Verbose subscript.

Case 2:
Non-custom modifiers get assigned to "zpm" subscript
eg. 
Expected:
tExpectedCommandInfo="install"
tExpectedCommandInfo("data","EnvFiles")="C:\env1.json;C:\env2.json"
tExpectedCommandInfo("data","Verbose")=1
tExpectedCommandInfo("parameters","module")="SomeModule"
Actual:
tParsedCommandInfo="install"
tParsedCommandInfo("data","EnvFiles")="C:\env1.json;C:\env2.json"
tParsedCommandInfo("data","Verbose")=1
tParsedCommandInfo("data","zpm","EnvFiles")="C:\env1.json;C:\env2.json"
tParsedCommandInfo("parameters","module")="SomeModule"

Also use auto-formatting to reformat Unit Test CLI class.