### PR TITLE
Fix #299: Japanese characters in unit test results are garbled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - #899: Fixed CLI parser parses modifiers incorrectly
+- #299: Prevent Japanese (and other UNICODE) characters from being garbled when outputting unit test results
 
 ## [0.10.3] - 2025-09-17
 

--- a/src/cls/IPM/Test/JUnitOutput.cls
+++ b/src/cls/IPM/Test/JUnitOutput.cls
@@ -8,6 +8,7 @@ ClassMethod ToFile(
     set tSC = $$$OK
     try {
         set tFile = ##class(%Stream.FileCharacter).%New()
+        set tFile.TranslateTable="UTF8"
         do tFile.LinkToFile(pFileName)
 
         kill ^||TMP // results global


### PR DESCRIPTION
Fixes #299 