### PR TITLE
Fix some issues with uninstall -all (#58 and #908)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #299: Prevent Japanese (and other UNICODE) characters from being garbled when outputting unit test results
 - #819: Drastically increase `zpm "info"` speed when many dependent packages have been installed
 - #888: Fixed `zpm "list -tree"` showing packages as `[missing]` because of case mismatch
+- #58: Prevent uninstallation of dependent module without `-force` flag
+- #908: `uninstall -all -force` will attempt to uninstall all modules even if dependency resolution fails
 
 ## [0.10.3] - 2025-09-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #819: Drastically increase `zpm "info"` speed when many dependent packages have been installed
 - #888: Fixed `zpm "list -tree"` showing packages as `[missing]` because of case mismatch
 - #58: Prevent uninstallation of dependent module without `-force` flag
-- #908: `uninstall -all -force` will attempt to uninstall all modules even if dependency resolution fails
+- #908: Fix case where `uninstall -all` would fail because of incomplete dependency information
 
 ## [0.10.3] - 2025-09-17
 

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -255,46 +255,46 @@ Method CheckBeforeClean(
 	ByRef pParams,
 	Output pSkip As %Boolean = 0) As %Status
 {
-  set tSC = $$$OK
-  try {
-    set tVerbose = $get(pParams("Verbose"))
-    set tLevel = $get(pParams("Clean","Level"),0)
-    set tRecurse = $get(pParams("Clean","Recurse"),1)
+    set tSC = $$$OK
+    try {
+        set tVerbose = $get(pParams("Verbose"))
+        set tLevel = $get(pParams("Clean","Level"),0)
+        set tRecurse = $get(pParams("Clean","Recurse"),1)
 
-    if (..Module.GlobalScope && '$get(pParams("Clean","GlobalScope"))) {
-      do ..Log("Clean SKIPPED - module has global scope.")
-      set pSkip = 1
-      quit
-    }
-
-    if '$get(pParams("Clean","Force")) {
-      // Check to see if anything depends on this module and return an error status if it does.
-      set tSC = ##class(%IPM.Utils.Module).GetDependentsList(.tList,,..Module.Name)
-      if $$$ISERR(tSC) {
-        quit
-      }
-
-      set tModList = ""
-      for i=1:1:tList.Count() {
-        set tName = tList.GetAt(i).Name
-        if '$data(pParams("Clean","Cycle",tName)) {
-          set tModList = tModList_$listbuild(tName)
+        if (..Module.GlobalScope && '$get(pParams("Clean","GlobalScope"))) {
+            do ..Log("Clean SKIPPED - module has global scope.")
+            set pSkip = 1
+            quit
         }
-      }
 
-      if ($listlength(tModList) > 0) && (tLevel > 0) {
-        do ..Log("Clean SKIPPED - required by " _ $listlength(tModList) _ " other module" _ $case($listlength(tModList),1:"",:"s") _ ". (" _ $listtostring(tModList,"; ") _ ")")
-        set pSkip = 1
-        quit
-      }
+        if '$get(pParams("Clean","Force")) {
+            // Check to see if anything depends on this module and return an error status if it does.
+            set tSC = ##class(%IPM.Utils.Module).GetDependentsList(.tList,,..Module.Name)
+            if $$$ISERR(tSC) {
+                quit
+            }
+
+            set tModList = ""
+            for i=1:1:tList.Count() {
+                set tName = tList.GetAt(i).Name
+                if '$data(pParams("Clean","Cycle",tName)) {
+                    set tModList = tModList_$listbuild(tName)
+                }
+            }
+
+            if ($listlength(tModList) > 0) && (tLevel > 0) {
+                do ..Log("Clean SKIPPED - required by " _ $listlength(tModList) _ " other module" _ $case($listlength(tModList),1:"",:"s") _ ". (" _ $listtostring(tModList,"; ") _ ")")
+                set pSkip = 1
+                quit
+            }
+        }
+    } catch e {
+        set tSC = e.AsStatus()
     }
-  } catch e {
-    set tSC = e.AsStatus()
-  }
-  if pSkip {
-    set pParams("Clean","Skip",..Module.Name) = ""
-  }
-  quit tSC
+    if pSkip {
+        set pParams("Clean","Skip",..Module.Name) = ""
+    }
+    quit tSC
 }
 
 Method %Clean(ByRef pParams) As %Status

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -255,48 +255,46 @@ Method CheckBeforeClean(
 	ByRef pParams,
 	Output pSkip As %Boolean = 0) As %Status
 {
-    set tSC = $$$OK
-    try {
-        set tVerbose = $get(pParams("Verbose"))
-        set tLevel = $get(pParams("Clean","Level"),0)
-        set tRecurse = $get(pParams("Clean","Recurse"),1)
+  set tSC = $$$OK
+  try {
+    set tVerbose = $get(pParams("Verbose"))
+    set tLevel = $get(pParams("Clean","Level"),0)
+    set tRecurse = $get(pParams("Clean","Recurse"),1)
 
-        if (..Module.GlobalScope && '$get(pParams("Clean","GlobalScope"))) {
-            do ..Log("Clean SKIPPED - module has global scope.")
-            set pSkip = 1
-            quit
-        }
-
-        if '$get(pParams("Clean","Force")) {
-            // Check to see if anything depends on this module and return an error status if it does.
-            set tSC = ##class(%IPM.Utils.Module).GetDependentsList(.tList,,..Module.Name)
-            if $$$ISERR(tSC) {
-                quit
-            }
-
-            set tModList = ""
-            for i=1:1:tList.Count() {
-                set tName = tList.GetAt(i).Name
-                if '$data(pParams("Clean","Cycle",tName)) {
-                    set tModList = tModList_$listbuild(tName)
-                }
-            }
-
-            if ($listlength(tModList) > 0) {
-                if (tLevel > 0) && tVerbose {
-                    do ..Log("Clean SKIPPED - required by ",$listlength(tModList)," other module",$case($listlength(tModList),1:"",:"s"),". (",$listtostring(tModList,"; "),")")
-                    set pSkip = 1
-                    quit
-                }
-            }
-        }
-    } catch e {
-        set tSC = e.AsStatus()
+    if (..Module.GlobalScope && '$get(pParams("Clean","GlobalScope"))) {
+      do ..Log("Clean SKIPPED - module has global scope.")
+      set pSkip = 1
+      quit
     }
-    if pSkip {
-        set pParams("Clean","Skip",..Module.Name) = ""
+
+    if '$get(pParams("Clean","Force")) {
+      // Check to see if anything depends on this module and return an error status if it does.
+      set tSC = ##class(%IPM.Utils.Module).GetDependentsList(.tList,,..Module.Name)
+      if $$$ISERR(tSC) {
+        quit
+      }
+
+      set tModList = ""
+      for i=1:1:tList.Count() {
+        set tName = tList.GetAt(i).Name
+        if '$data(pParams("Clean","Cycle",tName)) {
+          set tModList = tModList_$listbuild(tName)
+        }
+      }
+
+      if ($listlength(tModList) > 0) && (tLevel > 0) {
+        do ..Log("Clean SKIPPED - required by " _ $listlength(tModList) _ " other module" _ $case($listlength(tModList),1:"",:"s") _ ". (" _ $listtostring(tModList,"; ") _ ")")
+        set pSkip = 1
+        quit
+      }
     }
-    quit tSC
+  } catch e {
+    set tSC = e.AsStatus()
+  }
+  if pSkip {
+    set pParams("Clean","Skip",..Module.Name) = ""
+  }
+  quit tSC
 }
 
 Method %Clean(ByRef pParams) As %Status

--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -822,48 +822,48 @@ ClassMethod UninstallAll(
 {
   set tSC = $$$OK
   try {
-    // Get all dependency graphs for the namespace.
-    set tSC = ..BuildAllDependencyGraphs(,.tGraphs,.errorList)
-    $$$ThrowOnError(tSC)
-    if ($get(errorList,0) > 0) && pForce {
-      // If forcing uninstallation of everything and dependency resolution has failed,
-      // brute force uninstall everything anyway
-      do ##class(%IPM.Main).GetListModules(,,.list)
-      for i = 1:1:list {
-        set moduleName = $listget(list(i), 1)
-        if moduleName = $$$IPMModuleName {
-          // don't uninstall IPM itself
-          continue
-        }
+    // Build simple dependency graph for all installed modules based on
+    //  1) the list of all installed modules
+    //  2) dependencies as listed in %IPM.Storage.Module.Dependencies
+    // tModuleNames(moduleName) = "" for all modules
+    // tModuleNames(dependency,moduleName) = "" if moduleName depends on dependency
+    // tDependsOn(moduleName,dependency) = "" if moduleName depends on dependency
+    // this is not recursive, so if A depends on B and B depends on C, neither tModulesNames(C,A) nor tDependsOn(A,C) are set
 
-        write !,"Uninstalling ",moduleName
-        set tOneSC = ##class(%IPM.Storage.Module).Uninstall(moduleName,pForce,,.tParams)
-        if $$$ISERR(tOneSC) {
-          write !,"Error uninstalling ",moduleName,": ",$system.Status.GetErrorText(tOneSC)
-          set tSC = $system.Status.AppendStatus(tSC,tOneSC)
-          set tFailedModules(moduleName) = ""
-        }
-      }
-      quit
+    set depRes = ##class(%SQL.Statement).%ExecDirect(,
+      "select ModuleItem->Name ModName,Dependencies_Name DepName "_
+      "from %IPM_Storage.ModuleItem_Dependencies")
+    $$$ThrowSQLIfError(depRes.%SQLCODE, depRes.%Message)
+    while depRes.%Next(.sc) {
+      $$$ThrowOnError(sc)
+      set modName = depRes.%Get("ModName")
+      set depName = depRes.%Get("DepName")
+      set tModuleNames(depName, modName) = ""
+      set tDependsOn(modName, depName) = ""
+    }
+    $$$ThrowOnError(sc)
+
+    // Get list of all installed modules
+    do ##class(%IPM.Main).GetListModules(,,.modList)
+    for i = 1:1:modList {
+      set name = $listget(modList(i),1)
+      set simpleModList(name) = ""
+      // list of modules must be from here because modules without dependencies won't appear in %IPM_Storage.ModuleItem_Dependencies
+      set tModuleNames(name) = ""
     }
 
-    // Build arrays mapping dependencies in both directions.
-    // Doesn't need to be recursive.
-    for tIndex=1:1:$get(tGraphs) {
-      set tModuleName = $listget(tGraphs(tIndex),2)
-      set tModuleNames(tModuleName) = ""
-      set tDependency = ""
-      for {
-        set tDependency = $order(tGraphs(tIndex,tDependency),1,tData)
-        if (tDependency = "") {
-          quit
+    // Iterate through list of modules to uninstall, removing any that are missing
+    set module = ""
+    for {
+      set module = $order(tModuleNames(module))
+      if (module = "") {
+        quit
+      }
+      if '$data(simpleModList(module)) {
+        if $get(pParams("Verbose")) {
+          write !,"WARNING: module ",module," is missing, skipping uninstall",!
         }
-        if ($listget(tData,2) '= "") {
-          // This is not actually installed locally.
-          continue
-        }
-        set tDependsOn(tModuleName,tDependency) = ""
-        set tModuleNames(tDependency,tModuleName) = ""
+        kill tModuleNames(module)
       }
     }
 

--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -820,100 +820,121 @@ ClassMethod UninstallAll(
 	pForce As %Boolean,
 	ByRef pParams) As %Status
 {
-    set tSC = $$$OK
-    try {
-        // Get all dependency graphs for the namespace.
-        set tSC = ..BuildAllDependencyGraphs(,.tGraphs)
-        $$$ThrowOnError(tSC)
-
-        // Build arrays mapping dependencies in both directions.
-        // Doesn't need to be recursive.
-        for tIndex=1:1:$get(tGraphs) {
-            set tModuleName = $listget(tGraphs(tIndex),2)
-            set tModuleNames(tModuleName) = ""
-            set tDependency = ""
-            for {
-                set tDependency = $order(tGraphs(tIndex,tDependency),1,tData)
-                if (tDependency = "") {
-                    quit
-                }
-                if ($listget(tData,2) '= "") {
-                    // This is not actually installed locally.
-                    continue
-                }
-                set tDependsOn(tModuleName,tDependency) = ""
-                set tModuleNames(tDependency,tModuleName) = ""
-            }
+  set tSC = $$$OK
+  try {
+    // Get all dependency graphs for the namespace.
+    set tSC = ..BuildAllDependencyGraphs(,.tGraphs,.errorList)
+    $$$ThrowOnError(tSC)
+    if ($get(errorList,0) > 0) && pForce {
+      // If forcing uninstallation of everything and dependency resolution has failed,
+      // brute force uninstall everything anyway
+      do ##class(%IPM.Main).GetListModules(,,.list)
+      for i = 1:1:list {
+        set moduleName = $listget(list(i), 1)
+        if moduleName = $$$IPMModuleName {
+          // don't uninstall IPM itself
+          continue
         }
 
-        set tProgressMade = 1
-        for {
-            if '$data(tModuleNames) {
+        write !,"Uninstalling ",moduleName
+        set tOneSC = ##class(%IPM.Storage.Module).Uninstall(moduleName,pForce,,.tParams)
+        if $$$ISERR(tOneSC) {
+          write !,"Error uninstalling ",moduleName,": ",$system.Status.GetErrorText(tOneSC)
+          set tSC = $system.Status.AppendStatus(tSC,tOneSC)
+          set tFailedModules(moduleName) = ""
+        }
+      }
+      quit
+    }
+
+    // Build arrays mapping dependencies in both directions.
+    // Doesn't need to be recursive.
+    for tIndex=1:1:$get(tGraphs) {
+      set tModuleName = $listget(tGraphs(tIndex),2)
+      set tModuleNames(tModuleName) = ""
+      set tDependency = ""
+      for {
+        set tDependency = $order(tGraphs(tIndex,tDependency),1,tData)
+        if (tDependency = "") {
+          quit
+        }
+        if ($listget(tData,2) '= "") {
+          // This is not actually installed locally.
+          continue
+        }
+        set tDependsOn(tModuleName,tDependency) = ""
+        set tModuleNames(tDependency,tModuleName) = ""
+      }
+    }
+
+    set tProgressMade = 1
+    for {
+      if '$data(tModuleNames) {
+        quit
+      }
+      if 'tProgressMade {
+        set tFirstSC = $$$ERROR($$$GeneralError,"Unable to uninstall all modules.")
+        set tSC = $system.Status.AppendStatus(tFirstSC,tSC) // Append any previous errors (which may be causes or unrelated)
+        $$$ThrowStatus(tSC)
+      }
+      set tProgressMade = 0
+
+      // Loop over "dependents" array to delete each module that has nothing left that depends on it.
+      // If a module fails to uninstall, modules that it depends on will not be uninstalled, unless
+      // pForce is true.
+      set tModuleName = ""
+      for {
+        set tModuleName = $order(tModuleNames(tModuleName))
+        if (tModuleName = "") {
+          quit
+        }
+
+        if tModuleName = $$$IPMModuleName {
+          // don't uninstall IPM itself
+          kill tModuleNames(tModuleName)
+          continue
+        }
+
+        if ($data(tModuleNames(tModuleName)) > 1) {
+          // If there are dependencies left that have not been uninstalled yet, skip this module.
+          continue
+        }
+
+        if $data(tFailedModules(tModuleName)) {
+          // If we have already tried unsuccessfully to uninstall a given module, don't try again.
+          continue
+        }
+
+        kill tParams
+        merge tParams = pParams
+        write !,"Uninstalling ",tModuleName
+        set tOneSC = ##class(%IPM.Storage.Module).Uninstall(tModuleName,pForce,,.tParams)
+        if $$$ISOK(tOneSC) || pForce {
+          // If we are forcing uninstallation of everything that can be uninstalled,
+          // treat the module in question as uninstalled even if something went fatally wrong.
+          set tDependentModule = ""
+          for {
+            set tDependentModule = $order(tDependsOn(tModuleName,tDependentModule))
+            if (tDependentModule = "") {
                 quit
             }
-            if 'tProgressMade {
-                set tFirstSC = $$$ERROR($$$GeneralError,"Unable to uninstall all modules.")
-                set tSC = $system.Status.AppendStatus(tFirstSC,tSC) // Append any previous errors (which may be causes or unrelated)
-                $$$ThrowStatus(tSC)
-            }
-            set tProgressMade = 0
-
-            // Loop over "dependents" array to delete each module that has nothing left that depends on it.
-            // If a module fails to uninstall, modules that it depends on will not be uninstalled, unless
-            // pForce is true.
-            set tModuleName = ""
-            for {
-                set tModuleName = $order(tModuleNames(tModuleName))
-                if (tModuleName = "") {
-                    quit
-                }
-
-                if tModuleName = $$$IPMModuleName {
-                    // don't uninstall IPM itself
-                    kill tModuleNames(tModuleName)
-                    continue
-                }
-
-                if ($data(tModuleNames(tModuleName)) > 1) {
-                    // If there are dependencies left that have not been uninstalled yet, skip this module.
-                    continue
-                }
-
-                if $data(tFailedModules(tModuleName)) {
-                    // If we have already tried unsuccessfully to uninstall a given module, don't try again.
-                    continue
-                }
-
-                kill tParams
-                merge tParams = pParams
-                write !,"Uninstalling ",tModuleName
-                set tOneSC = ##class(%IPM.Storage.Module).Uninstall(tModuleName,pForce,,.tParams)
-                if $$$ISOK(tOneSC) || pForce {
-                    // If we are forcing uninstallation of everything that can be uninstalled,
-                    // treat the module in question as uninstalled even if something went fatally wrong.
-                    set tDependentModule = ""
-                    for {
-                        set tDependentModule = $order(tDependsOn(tModuleName,tDependentModule))
-                        if (tDependentModule = "") {
-                            quit
-                        }
-                        kill tModuleNames(tDependentModule,tModuleName)
-                    }
-                    kill tDependsOn(tModuleName)
-                    kill tModuleNames(tModuleName)
-                    set tProgressMade = 1
-                }
-                if $$$ISERR(tOneSC) {
-                    write !,"Error uninstalling ",tModuleName,": ",$system.Status.GetErrorText(tOneSC)
-                    set tSC = $system.Status.AppendStatus(tSC,tOneSC)
-                    set tFailedModules(tModuleName) = ""
-                }
-            }
+            kill tModuleNames(tDependentModule,tModuleName)
+          }
+          kill tDependsOn(tModuleName)
+          kill tModuleNames(tModuleName)
+          set tProgressMade = 1
         }
-    } catch e {
-        set tSC = e.AsStatus()
+        if $$$ISERR(tOneSC) {
+          write !,"Error uninstalling ",tModuleName,": ",$system.Status.GetErrorText(tOneSC)
+          set tSC = $system.Status.AppendStatus(tSC,tOneSC)
+          set tFailedModules(tModuleName) = ""
+        }
+      }
     }
-    quit tSC
+  } catch e {
+    set tSC = e.AsStatus()
+  }
+  quit tSC
 }
 
 /// If <var>pSnapshots</var> is empty, lists all modules.

--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -820,121 +820,121 @@ ClassMethod UninstallAll(
 	pForce As %Boolean,
 	ByRef pParams) As %Status
 {
-  set tSC = $$$OK
-  try {
-    // Build simple dependency graph for all installed modules based on
-    //  1) the list of all installed modules
-    //  2) dependencies as listed in %IPM.Storage.Module.Dependencies
-    // tModuleNames(moduleName) = "" for all modules
-    // tModuleNames(dependency,moduleName) = "" if moduleName depends on dependency
-    // tDependsOn(moduleName,dependency) = "" if moduleName depends on dependency
-    // this is not recursive, so if A depends on B and B depends on C, neither tModulesNames(C,A) nor tDependsOn(A,C) are set
+    set tSC = $$$OK
+    try {
+        // Build simple dependency graph for all installed modules based on
+        //  1) the list of all installed modules
+        //  2) dependencies as listed in %IPM.Storage.Module.Dependencies
+        // tModuleNames(moduleName) = "" for all modules
+        // tModuleNames(dependency,moduleName) = "" if moduleName depends on dependency
+        // tDependsOn(moduleName,dependency) = "" if moduleName depends on dependency
+        // this is not recursive, so if A depends on B and B depends on C, neither tModulesNames(C,A) nor tDependsOn(A,C) are set
 
-    set depRes = ##class(%SQL.Statement).%ExecDirect(,
-      "select ModuleItem->Name ModName,Dependencies_Name DepName "_
-      "from %IPM_Storage.ModuleItem_Dependencies")
-    $$$ThrowSQLIfError(depRes.%SQLCODE, depRes.%Message)
-    while depRes.%Next(.sc) {
-      $$$ThrowOnError(sc)
-      set modName = depRes.%Get("ModName")
-      set depName = depRes.%Get("DepName")
-      set tModuleNames(depName, modName) = ""
-      set tDependsOn(modName, depName) = ""
-    }
-    $$$ThrowOnError(sc)
-
-    // Get list of all installed modules
-    do ##class(%IPM.Main).GetListModules(,,.modList)
-    for i = 1:1:modList {
-      set name = $listget(modList(i),1)
-      set simpleModList(name) = ""
-      // list of modules must be from here because modules without dependencies won't appear in %IPM_Storage.ModuleItem_Dependencies
-      set tModuleNames(name) = ""
-    }
-
-    // Iterate through list of modules to uninstall, removing any that are missing
-    set module = ""
-    for {
-      set module = $order(tModuleNames(module))
-      if (module = "") {
-        quit
-      }
-      if '$data(simpleModList(module)) {
-        if $get(pParams("Verbose")) {
-          write !,"WARNING: module ",module," is missing, skipping uninstall",!
+        set depRes = ##class(%SQL.Statement).%ExecDirect(,
+            "select ModuleItem->Name ModName,Dependencies_Name DepName "_
+            "from %IPM_Storage.ModuleItem_Dependencies")
+        $$$ThrowSQLIfError(depRes.%SQLCODE, depRes.%Message)
+        while depRes.%Next(.sc) {
+            $$$ThrowOnError(sc)
+            set modName = depRes.%Get("ModName")
+            set depName = depRes.%Get("DepName")
+            set tModuleNames(depName, modName) = ""
+            set tDependsOn(modName, depName) = ""
         }
-        kill tModuleNames(module)
-      }
-    }
+        $$$ThrowOnError(sc)
 
-    set tProgressMade = 1
-    for {
-      if '$data(tModuleNames) {
-        quit
-      }
-      if 'tProgressMade {
-        set tFirstSC = $$$ERROR($$$GeneralError,"Unable to uninstall all modules.")
-        set tSC = $system.Status.AppendStatus(tFirstSC,tSC) // Append any previous errors (which may be causes or unrelated)
-        $$$ThrowStatus(tSC)
-      }
-      set tProgressMade = 0
-
-      // Loop over "dependents" array to delete each module that has nothing left that depends on it.
-      // If a module fails to uninstall, modules that it depends on will not be uninstalled, unless
-      // pForce is true.
-      set tModuleName = ""
-      for {
-        set tModuleName = $order(tModuleNames(tModuleName))
-        if (tModuleName = "") {
-          quit
+        // Get list of all installed modules
+        do ##class(%IPM.Main).GetListModules(,,.modList)
+        for i = 1:1:modList {
+            set name = $listget(modList(i),1)
+            set simpleModList(name) = ""
+            // list of modules must be from here because modules without dependencies won't appear in %IPM_Storage.ModuleItem_Dependencies
+            set tModuleNames(name) = ""
         }
 
-        if tModuleName = $$$IPMModuleName {
-          // don't uninstall IPM itself
-          kill tModuleNames(tModuleName)
-          continue
-        }
-
-        if ($data(tModuleNames(tModuleName)) > 1) {
-          // If there are dependencies left that have not been uninstalled yet, skip this module.
-          continue
-        }
-
-        if $data(tFailedModules(tModuleName)) {
-          // If we have already tried unsuccessfully to uninstall a given module, don't try again.
-          continue
-        }
-
-        kill tParams
-        merge tParams = pParams
-        write !,"Uninstalling ",tModuleName
-        set tOneSC = ##class(%IPM.Storage.Module).Uninstall(tModuleName,pForce,,.tParams)
-        if $$$ISOK(tOneSC) || pForce {
-          // If we are forcing uninstallation of everything that can be uninstalled,
-          // treat the module in question as uninstalled even if something went fatally wrong.
-          set tDependentModule = ""
-          for {
-            set tDependentModule = $order(tDependsOn(tModuleName,tDependentModule))
-            if (tDependentModule = "") {
+        // Iterate through list of modules to uninstall, removing any that are missing
+        set module = ""
+        for {
+            set module = $order(tModuleNames(module))
+            if (module = "") {
                 quit
             }
-            kill tModuleNames(tDependentModule,tModuleName)
-          }
-          kill tDependsOn(tModuleName)
-          kill tModuleNames(tModuleName)
-          set tProgressMade = 1
+            if '$data(simpleModList(module)) {
+                if $get(pParams("Verbose")) {
+                    write !,"WARNING: module ",module," is missing, skipping uninstall",!
+                }
+                kill tModuleNames(module)
+            }
         }
-        if $$$ISERR(tOneSC) {
-          write !,"Error uninstalling ",tModuleName,": ",$system.Status.GetErrorText(tOneSC)
-          set tSC = $system.Status.AppendStatus(tSC,tOneSC)
-          set tFailedModules(tModuleName) = ""
+
+        set tProgressMade = 1
+        for {
+            if '$data(tModuleNames) {
+                quit
+            }
+            if 'tProgressMade {
+                set tFirstSC = $$$ERROR($$$GeneralError,"Unable to uninstall all modules.")
+                set tSC = $system.Status.AppendStatus(tFirstSC,tSC) // Append any previous errors (which may be causes or unrelated)
+                $$$ThrowStatus(tSC)
+            }
+            set tProgressMade = 0
+
+            // Loop over "dependents" array to delete each module that has nothing left that depends on it.
+            // If a module fails to uninstall, modules that it depends on will not be uninstalled, unless
+            // pForce is true.
+            set tModuleName = ""
+            for {
+                set tModuleName = $order(tModuleNames(tModuleName))
+                if (tModuleName = "") {
+                    quit
+                }
+
+                if tModuleName = $$$IPMModuleName {
+                    // don't uninstall IPM itself
+                    kill tModuleNames(tModuleName)
+                    continue
+                }
+
+                if ($data(tModuleNames(tModuleName)) > 1) {
+                    // If there are dependencies left that have not been uninstalled yet, skip this module.
+                    continue
+                }
+
+                if $data(tFailedModules(tModuleName)) {
+                    // If we have already tried unsuccessfully to uninstall a given module, don't try again.
+                    continue
+                }
+
+                kill tParams
+                merge tParams = pParams
+                write !,"Uninstalling ",tModuleName
+                set tOneSC = ##class(%IPM.Storage.Module).Uninstall(tModuleName,pForce,,.tParams)
+                if $$$ISOK(tOneSC) || pForce {
+                    // If we are forcing uninstallation of everything that can be uninstalled,
+                    // treat the module in question as uninstalled even if something went fatally wrong.
+                    set tDependentModule = ""
+                    for {
+                        set tDependentModule = $order(tDependsOn(tModuleName,tDependentModule))
+                        if (tDependentModule = "") {
+                            quit
+                        }
+                        kill tModuleNames(tDependentModule,tModuleName)
+                    }
+                    kill tDependsOn(tModuleName)
+                    kill tModuleNames(tModuleName)
+                    set tProgressMade = 1
+                }
+                if $$$ISERR(tOneSC) {
+                    write !,"Error uninstalling ",tModuleName,": ",$system.Status.GetErrorText(tOneSC)
+                    set tSC = $system.Status.AppendStatus(tSC,tOneSC)
+                    set tFailedModules(tModuleName) = ""
+                }
+            }
         }
-      }
+    } catch e {
+        set tSC = e.AsStatus()
     }
-  } catch e {
-    set tSC = e.AsStatus()
-  }
-  quit tSC
+    quit tSC
 }
 
 /// If <var>pSnapshots</var> is empty, lists all modules.

--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -871,7 +871,6 @@ ClassMethod UninstallAll(
                 if tModuleName = $$$IPMModuleName {
                     // don't uninstall IPM itself
                     kill tModuleNames(tModuleName)
-                    set tProgressMade = 1
                     continue
                 }
 

--- a/tests/integration_tests/Test/PM/Integration/Uninstall.cls
+++ b/tests/integration_tests/Test/PM/Integration/Uninstall.cls
@@ -3,25 +3,46 @@ Class Test.PM.Integration.Uninstall Extends Test.PM.Integration.Base
 
 Method TestSimpleUninstallAll()
 {
-    // install a few modules
-    set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
+  // install a few modules
+  set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
 
-    set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/simple-app/")
-    set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
-    do $$$AssertStatusOK(status,"Loaded SimpleApp module successfully. " _ moduleDir)
+  set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/simple-app/")
+  set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
+  do $$$AssertStatusOK(status,"Loaded SimpleApp module successfully. " _ moduleDir)
 
-    set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/simple-module/")
-    set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
-    do $$$AssertStatusOK(status,"Loaded SimpleModule module successfully. " _ moduleDir)
+  set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/simple-module/")
+  set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
+  do $$$AssertStatusOK(status,"Loaded SimpleModule module successfully. " _ moduleDir)
 
-    // call "uninstall -f -all"
-    set status = ##class(%IPM.Main).Shell("uninstall -f -all")
-    do $$$AssertStatusOK(status,"Uninstalled everything successfully.")
+  // call "uninstall -f -all"
+  set status = ##class(%IPM.Main).Shell("uninstall -f -all")
+  do $$$AssertStatusOK(status,"Uninstalled everything successfully.")
 
-    // verify everything except IPM is uninstalled
-    do ##class(%IPM.Main).GetListModules(,,.list)
-    do $$$AssertTrue(list=1, "Only one module left")
-    do $$$AssertTrue($list(list(1))="zpm", "IPM has not been uninstalled")
+  // verify everything except IPM is uninstalled
+  do ##class(%IPM.Main).GetListModules(,,.list)
+  do $$$AssertTrue(list=1, "Only one module left")
+  do $$$AssertTrue($list(list(1))="zpm", "IPM has not been uninstalled")
+}
+
+Method TestUninstallAllForce()
+{
+  set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
+  set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/uninstall/")
+  set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
+  do $$$AssertStatusOK(status,"Loaded uninstall module successfully. " _ moduleDir)
+
+  // force uninstall dependent module
+  set status = ##class(%IPM.Main).Shell("uninstall uninstall-a -force")
+  do $$$AssertStatusOK(status,"uninstall-a forcefully uninstalled successfully. " _ moduleDir)
+
+  // call "uninstall -f -all"
+  set status = ##class(%IPM.Main).Shell("uninstall -f -all")
+  do $$$AssertStatusOK(status,"Uninstalled everything successfully.")
+
+  // verify everything except IPM is uninstalled
+  do ##class(%IPM.Main).GetListModules(,,.list)
+  do $$$AssertTrue(list=1, "Only one module left")
+  do $$$AssertTrue($list(list(1))="zpm", "IPM has not been uninstalled")
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/Uninstall.cls
+++ b/tests/integration_tests/Test/PM/Integration/Uninstall.cls
@@ -3,63 +3,63 @@ Class Test.PM.Integration.Uninstall Extends Test.PM.Integration.Base
 
 Method TestSimpleUninstallAll()
 {
-  // install a few modules
-  set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
+    // install a few modules
+    set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
 
-  set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/simple-app/")
-  set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
-  do $$$AssertStatusOK(status,"Loaded SimpleApp module successfully. " _ moduleDir)
+    set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/simple-app/")
+    set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
+    do $$$AssertStatusOK(status,"Loaded SimpleApp module successfully. " _ moduleDir)
 
-  set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/simple-module/")
-  set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
-  do $$$AssertStatusOK(status,"Loaded SimpleModule module successfully. " _ moduleDir)
+    set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/simple-module/")
+    set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
+    do $$$AssertStatusOK(status,"Loaded SimpleModule module successfully. " _ moduleDir)
 
-  // call "uninstall -f -all"
-  set status = ##class(%IPM.Main).Shell("uninstall -f -all")
-  do $$$AssertStatusOK(status,"Uninstalled everything successfully.")
+    // call "uninstall -f -all"
+    set status = ##class(%IPM.Main).Shell("uninstall -f -all")
+    do $$$AssertStatusOK(status,"Uninstalled everything successfully.")
 
-  // verify everything except IPM is uninstalled
-  do ##class(%IPM.Main).GetListModules(,,.list)
-  do $$$AssertTrue(list=1, "Only one module left")
-  do $$$AssertTrue($list(list(1))="zpm", "IPM has not been uninstalled")
+    // verify everything except IPM is uninstalled
+    do ##class(%IPM.Main).GetListModules(,,.list)
+    do $$$AssertTrue(list=1, "Only one module left")
+    do $$$AssertTrue($list(list(1))="zpm", "IPM has not been uninstalled")
 }
 
 Method TestUninstallAllNoForce()
 {
-  set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
-  set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/uninstall/")
-  set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
-  do $$$AssertStatusOK(status,"Loaded uninstall module successfully. " _ moduleDir)
+    set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
+    set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/uninstall/")
+    set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
+    do $$$AssertStatusOK(status,"Loaded uninstall module successfully. " _ moduleDir)
 
-  // call "uninstall -all"
-  set status = ##class(%IPM.Main).Shell("uninstall -all")
-  do $$$AssertStatusOK(status,"Uninstalled everything successfully.")
+    // call "uninstall -all"
+    set status = ##class(%IPM.Main).Shell("uninstall -all")
+    do $$$AssertStatusOK(status,"Uninstalled everything successfully.")
 
-  // verify everything except IPM is uninstalled
-  do ##class(%IPM.Main).GetListModules(,,.list)
-  do $$$AssertTrue(list=1, "Only one module left")
-  do $$$AssertTrue($list(list(1))="zpm", "IPM has not been uninstalled")
+    // verify everything except IPM is uninstalled
+    do ##class(%IPM.Main).GetListModules(,,.list)
+    do $$$AssertTrue(list=1, "Only one module left")
+    do $$$AssertTrue($list(list(1))="zpm", "IPM has not been uninstalled")
 }
 
 Method TestUninstallAllForce()
 {
-  set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
-  set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/uninstall/")
-  set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
-  do $$$AssertStatusOK(status,"Loaded uninstall module successfully. " _ moduleDir)
+    set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
+    set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/uninstall/")
+    set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
+    do $$$AssertStatusOK(status,"Loaded uninstall module successfully. " _ moduleDir)
 
-  // force uninstall dependent module
-  set status = ##class(%IPM.Main).Shell("uninstall uninstall-a -force")
-  do $$$AssertStatusOK(status,"uninstall-a forcefully uninstalled successfully. " _ moduleDir)
+    // force uninstall dependent module
+    set status = ##class(%IPM.Main).Shell("uninstall uninstall-a -force")
+    do $$$AssertStatusOK(status,"uninstall-a forcefully uninstalled successfully. " _ moduleDir)
 
-  // call "uninstall -f -all"
-  set status = ##class(%IPM.Main).Shell("uninstall -f -all")
-  do $$$AssertStatusOK(status,"Uninstalled everything successfully.")
+    // call "uninstall -f -all"
+    set status = ##class(%IPM.Main).Shell("uninstall -f -all")
+    do $$$AssertStatusOK(status,"Uninstalled everything successfully.")
 
-  // verify everything except IPM is uninstalled
-  do ##class(%IPM.Main).GetListModules(,,.list)
-  do $$$AssertTrue(list=1, "Only one module left")
-  do $$$AssertTrue($list(list(1))="zpm", "IPM has not been uninstalled")
+    // verify everything except IPM is uninstalled
+    do ##class(%IPM.Main).GetListModules(,,.list)
+    do $$$AssertTrue(list=1, "Only one module left")
+    do $$$AssertTrue($list(list(1))="zpm", "IPM has not been uninstalled")
 }
 
 }

--- a/tests/integration_tests/Test/PM/Integration/Uninstall.cls
+++ b/tests/integration_tests/Test/PM/Integration/Uninstall.cls
@@ -24,6 +24,23 @@ Method TestSimpleUninstallAll()
   do $$$AssertTrue($list(list(1))="zpm", "IPM has not been uninstalled")
 }
 
+Method TestUninstallAllNoForce()
+{
+  set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
+  set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/uninstall/")
+  set status = ##class(%IPM.Main).Shell("load " _ moduleDir)
+  do $$$AssertStatusOK(status,"Loaded uninstall module successfully. " _ moduleDir)
+
+  // call "uninstall -all"
+  set status = ##class(%IPM.Main).Shell("uninstall -all")
+  do $$$AssertStatusOK(status,"Uninstalled everything successfully.")
+
+  // verify everything except IPM is uninstalled
+  do ##class(%IPM.Main).GetListModules(,,.list)
+  do $$$AssertTrue(list=1, "Only one module left")
+  do $$$AssertTrue($list(list(1))="zpm", "IPM has not been uninstalled")
+}
+
 Method TestUninstallAllForce()
 {
   set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))

--- a/tests/integration_tests/Test/PM/Integration/_data/uninstall/.modules/a/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/uninstall/.modules/a/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="uninstall-a.ZPM">
+    <Module>
+      <Name>uninstall-a</Name>
+      <Version>0.0.1</Version>
+      <Packaging>module</Packaging>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/uninstall/.modules/b/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/uninstall/.modules/b/module.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="uninstall-b.ZPM">
+    <Module>
+      <Name>uninstall-b</Name>
+      <Version>0.0.1</Version>
+      <Packaging>module</Packaging>
+      <Dependencies>
+        <ModuleReference>
+          <Name>uninstall-a</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/uninstall/.modules/c/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/uninstall/.modules/c/module.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="uninstall-c.ZPM">
+    <Module>
+      <Name>uninstall-c</Name>
+      <Version>0.0.1</Version>
+      <Packaging>module</Packaging>
+      <Dependencies>
+        <ModuleReference>
+          <Name>uninstall-a</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+        <ModuleReference>
+          <Name>uninstall-d</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/uninstall/.modules/d/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/uninstall/.modules/d/module.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="uninstall-d.ZPM">
+    <Module>
+      <Name>uninstall-d</Name>
+      <Version>0.0.1</Version>
+      <Packaging>module</Packaging>
+      <Dependencies>
+        <ModuleReference>
+          <Name>uninstall-a</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+        <ModuleReference>
+          <Name>uninstall-f</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/uninstall/.modules/e/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/uninstall/.modules/e/module.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="uninstall-e.ZPM">
+    <Module>
+      <Name>uninstall-e</Name>
+      <Version>0.0.1</Version>
+      <Packaging>module</Packaging>
+      <Dependencies>
+        <ModuleReference>
+          <Name>uninstall-a</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+        <ModuleReference>
+          <Name>uninstall-b</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/uninstall/.modules/f/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/uninstall/.modules/f/module.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="uninstall-f.ZPM">
+    <Module>
+      <Name>uninstall-f</Name>
+      <Version>0.0.1</Version>
+      <Packaging>module</Packaging>
+      <Dependencies>
+        <ModuleReference>
+          <Name>uninstall-a</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+        <ModuleReference>
+          <Name>uninstall-b</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+        <ModuleReference>
+          <Name>uninstall-e</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/uninstall/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/uninstall/module.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="uninstall-parent.ZPM">
+    <Module>
+      <Name>uninstall-parent</Name>
+      <Version>0.0.1</Version>
+      <Packaging>module</Packaging>
+      <Dependencies>
+        <ModuleReference>
+          <Name>uninstall-a</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+        <ModuleReference>
+          <Name>uninstall-b</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+        <ModuleReference>
+          <Name>uninstall-c</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+        <ModuleReference>
+          <Name>uninstall-e</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+        <ModuleReference>
+          <Name>uninstall-f</Name>
+          <Version>0.0.1</Version>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>


### PR DESCRIPTION
Fixes #58 
Fixes #908

Rewrites UninstallAll() to use the module and dependency information in %IPM.Storage.Module instead of relying on BuildDependencyGraph().

(Side note: hilariously enough before this fix, `uninstall -f <dependent-module>` succeeded in uninstalling but `uninstall -f -verbose <dependent-module>` did not.)