### PR TITLE
Removed required=true from module parameter in uninstall command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #363: `help load` and `help install` will now mention that setting the `dev` flag will not roll back transactions on failure
 - #884: Fix missing module version in error message when dependency resolution fails to find suitable version
 - #838: Improve error messages when installation fails
+- #924: Make "module" parameter not required for "uninstall" command so -all modifier works
 
 ### Changed
 - #639: All modules installed in developer mode can now be edited, even if they do not contain "snapshot" in the version string

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -437,7 +437,7 @@ reinstall -env /path/to/env1.json;/path/to/env2.json example-package
 </example>
 
 <!-- Parameters -->
-<parameter name="module" required="true" description="Name of module to uninstall" />
+<parameter name="module" description="Name of module to uninstall" />
 
 <!-- Modifiers -->
 <modifier name="all" aliases="a" description="Uninstalls all modules installed in the current namespace." />


### PR DESCRIPTION
Discovered this bug when testing the update framework because we fixed some CLI parsing so required fields are actually checked now. This will break the uninstall -all command if left as required.