### PR TITLE
feat: add semantic sorting and shortcuts to list-installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - #1024: Added flag -export-python-deps to publish command
+- #1079: add semantic sorting and shortcuts to list-installed
 
 ### Fixed
 - #996: Ensure COS commands execute in exec under a dedicated, isolated context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #971: Adds structured test output formats (JSON, YAML, Toon). Use `-f <format>` for a one-shot override or `config set TestReportFormat <format>` for a persistent default. Without either, legacy output is shown. Also adds `-output-file` for writing results to a file (including JUnit XML via `.xml` extension) and improves `-quiet` to suppress build noise.
 - #870: When running tests for just a single suite or class, will only load and compile the relevant classes instead of all the tests
 - #843: Optionally include tests when packaging using either the `-include-tests` flag or `<IncludeTests>1</IncludeTests>` in module.xml
+- #1079: Add semantic sorting and shortcuts to list-installed
 
 ### Fixed
 - #964: Fix poor error handling on some install failures due to incorrect error message variable in embedded SQL
@@ -42,7 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - #1024: Added flag -export-python-deps to publish command
-- #1079: add semantic sorting and shortcuts to list-installed
 
 ### Fixed
 - #996: Ensure COS commands execute in exec under a dedicated, isolated context

--- a/src/cls/IPM/General/SemanticVersion.cls
+++ b/src/cls/IPM/General/SemanticVersion.cls
@@ -116,8 +116,10 @@ Method IsBackwardCompatibleWith(pVersion As %IPM.General.SemanticVersion) As %Bo
 
 /// Returns 1 if this version is a later version than <var>pVersion</var>. <br />
 /// From <a href="http://semver.org/spec/v2.0.0.html#spec-item-11">the SemVer 2.0.0 specification</a>: <br />
-/// 1.0.0-alpha &lt; 1.0.0-alpha.1 &lt; 1.0.0-alpha.beta &lt; 1.0.0-beta &lt; 1.0.0-beta.2 &lt; 1.0.0-beta.11 &lt; 1.0.0-rc.1 &lt; 1.0.0
-/// Also, two prerelease versions with mismatched major/minor/patch should *not* follow each other; see: <a href="https://github.com/npm/node-semver#prerelease-tags">node-semver</a>
+/// 1.0.0-alpha &lt; 1.0.0-alpha.1 &lt; 1.0.0-alpha.beta &lt; 1.0.0-beta &lt; 1.0.0-beta.2 &lt; 1.0.0-beta.11 &lt; 1.0.0-rc.1 &lt; 1.0.0 <br />
+/// Also, two prerelease versions with mismatched major/minor/patch should *not* follow each other; see: <a href="https://github.com/npm/node-semver#prerelease-tags">node-semver</a> <br />
+/// This defines a partial order: two pre-release versions with different major/minor/patch are incomparable
+/// (both return 0), so callers must not assume a total order over all version strings.
 Method Follows(pVersion As %IPM.General.SemanticVersion) As %Boolean
 {
     set tFollows = (..Major > pVersion.Major) ||

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -531,14 +531,14 @@ reinstall -env /path/to/env1.json;/path/to/env2.json example-package
     list -python
 </example>
 
-<example description="Shortforms: n, d, v. Add '-d' for descending (e.g., d-d).">
+<example description="Sort by name ascending (default). Shortforms: n=name, d=date, v=version. Append -d for descending.">
     list -s [name|date|version]
 </example>
 
-<example description="Shows installed modules in descending order">
+<example description="Sort by name descending">
     list -s name-desc
 </example>
-<example description="Shows installed modules in decending based on the installation date">
+<example description="Sort by installation date descending">
     list -s d-d
 </example>
 
@@ -553,7 +553,7 @@ reinstall -env /path/to/env1.json;/path/to/env2.json example-package
 <modifier name="showupstream" aliases="su" description="If specified, show the latest version for each module in configured repos if it's different than the local version." />
 <modifier name="repository" aliases="repo" value="true" description="If specified, only show modules installed that belong to the provided repository." />
 <modifier name="python" aliases="py" description="If specified, lists installed Embedded Python libraries instead of IPM modules." />
-<modifier name="sort" aliases="s" value="true" description="Sort the list. Options: name, name-desc, date, date-desc, version, version-desc" />
+<modifier name="sort" aliases="s" value="true" description="Sort the list. Default (no -s) is ascending by name with IPM on top. Options: name, name-desc, date, date-desc, version, version-desc. Shortforms: n, d, v; append -d for descending (e.g. n-d, d-d, v-d). Has no effect with -tree or -python." />
 </command>
 
 <command name="list-dependents" aliases="dependents">
@@ -2868,44 +2868,77 @@ ClassMethod ListInstalled(ByRef pCommandInfo) [ Private ]
         merge tModifiers = pCommandInfo("modifiers")
         set sortMode = $$$lcase($get(pCommandInfo("modifiers", "sort")))
 
-        if sortMode'="" {
-            set newlist =""
-            set type = $extract(sortMode, 1) // "d", "n", or "v"
-            set isDesc = (sortMode [ "-d")
-            set sortMode = $case(type, "n":"name", "d":"date", "v":"version", :"name")
-            if isDesc {
-                set sortMode = sortMode_"-desc"
-            }
-            for i=1:1:list {
-                set entry = list(i)
-                set name = $listget(entry,1)
-                set entry = entry_$listbuild(i)
-                if sortMode["name"{
-                    set newlist($$$lcase(name),i)=entry
-                } elseif sortMode["date" {
-                    set date = $listget(entry,6)
-                    set newlist(date,name) = entry
-                } elseif sortMode["version" {
-                    set newlist($listfromstring($listget(entry,2),"."),name) = entry
+        // Always sort; default is name ascending
+        do ..SortList(.list, $select(sortMode'="":sortMode, 1:"n"))
+
+        // IPM itself always appears first regardless of sort order.
+        // Position 1 holds the display name (e.g. "IPM (zpm)"); extract the actual name
+        // from inside the parentheses when present, otherwise use the display name as-is.
+        for i=1:1:list {
+            set displayName = $listget(list(i),1)
+            set actualName = $select(displayName["(": $piece($piece(displayName,"(",2),")",1), 1: displayName)
+            if $$$lcase(actualName) = $$$IPMModuleName {
+                set ipmEntry = list(i)
+                for j=i:-1:2 {
+                    set list(j) = list(j-1)
                 }
-                kill list(i)
-            }
-            set direction = $select(sortMode [ "desc": -1, 1: 1)
-            set sub = ""
-            if $data(newlist)>1 {
-                // create new list based on the sorting
-                for {
-                    set sub = $order(newlist(sub),direction) quit:sub=""
-                    set mod=""
-                    for {
-                        set mod = $order(newlist(sub,mod),direction,data) quit:mod=""
-                        set list($increment(mlist))=data
-                    }
-                }
+                set list(1) = ipmEntry
+                quit
             }
         }
+
         do ..DisplayModules(.list,,,, .tModifiers)
     }
+}
+
+/// Sort a module list in-place.
+/// sortMode is a raw sort string: first char "n"=name, "d"=date, "v"=version;
+/// append "-d" for descending (e.g. "n-d", "d-d", "v-d"). Default: ascending by name.
+/// List entries are $listbuild(name, versionString, externalName, developerMode, root, lastUpdated).
+ClassMethod SortList(ByRef list, sortModeRaw As %String) [ Internal ]
+{
+    set newlist = ""
+    set rawLower = $$$lcase(sortModeRaw)
+    set type = $extract(rawLower, 1) // "n"=name, "d"=date, "v"=version; default ascending by name
+    set isDesc = (rawLower [ "-d")
+    set sortMode = $case(type, "n":"name", "d":"date", "v":"version", :"name")
+    if isDesc {
+        set sortMode = sortMode_"-desc"
+    }
+    set mlist = 0
+    for i=1:1:list {
+        set entry = list(i)
+        set name = $listget(entry,1)
+        set entry = entry_$listbuild(i)
+        if sortMode = "name" || (sortMode = "name-desc") {
+            set newlist($$$lcase(name),i) = entry
+        } elseif sortMode = "date" || (sortMode = "date-desc") {
+            set date = $listget(entry,6)
+            set newlist(date,name) = entry
+        } elseif sortMode = "version" || (sortMode = "version-desc") {
+            // Build a zero-padded key so "1.10.0" sorts after "1.9.0" (numeric, not lexicographic)
+            set vParts = $listfromstring($listget(entry,2),".")
+            set vKey = $translate($justify($listget(vParts,1),5)," ","0")_"."_
+                       $translate($justify($listget(vParts,2),5)," ","0")_"."_
+                       $translate($justify($listget(vParts,3),5)," ","0")
+            set newlist(vKey,name) = entry
+        }
+        kill list(i)
+    }
+    set direction = $select(isDesc: -1, 1: 1)
+    set sub = ""
+    // if newlist is not empty, reconstruct list in sorted order
+    if $data(newlist)>1 {
+        for {
+            set sub = $order(newlist(sub),direction) quit:sub=""
+            set mod=""
+            for {
+                set mod = $order(newlist(sub,mod),direction,data) quit:mod=""
+                set list($increment(mlist)) = data
+            }
+        }
+    }
+    set list = mlist
 }
 
 /// Get module list in currently namespace

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2867,37 +2867,40 @@ ClassMethod ListInstalled(ByRef pCommandInfo) [ Private ]
         }
         merge tModifiers = pCommandInfo("modifiers")
         set sortMode = $$$lcase($get(pCommandInfo("modifiers", "sort")))
-        set type = $extract(sortMode, 1) // "d", "n", or "v"
-        set isDesc = (sortMode [ "-d")
-        set sortMode = $case(type, "n":"name", "d":"date", "v":"version", :"name")
-        if isDesc {
-            set sortMode = sortMode_"-desc"
-        }
-        set newlist =""
+
         if sortMode'="" {
+            set newlist =""
+            set type = $extract(sortMode, 1) // "d", "n", or "v"
+            set isDesc = (sortMode [ "-d")
+            set sortMode = $case(type, "n":"name", "d":"date", "v":"version", :"name")
+            if isDesc {
+                set sortMode = sortMode_"-desc"
+            }
             for i=1:1:list {
                 set entry = list(i)
                 set name = $listget(entry,1)
                 set entry = entry_$listbuild(i)
                 if sortMode["name"{
-                    set newlist($$$lcase(name))=entry
-                }
-                if sortMode["date" {
+                    set newlist($$$lcase(name),i)=entry
+                } elseif sortMode["date" {
                     set date = $listget(entry,6)
-                    set newlist(date)=entry
-                }
-                if sortMode["version" {
-                    set newlist($listfromstring($listget(entry,2),"."))=entry
+                    set newlist(date,name) = entry
+                } elseif sortMode["version" {
+                    set newlist($listfromstring($listget(entry,2),"."),name) = entry
                 }
                 kill list(i)
             }
             set direction = $select(sortMode [ "desc": -1, 1: 1)
-            set mod = ""
+            set sub = ""
             if $data(newlist)>1 {
                 // create new list based on the sorting
                 for {
-                    set mod = $order(newlist(mod),direction,data) quit:mod=""
-                    set list($increment(mlist))=data
+                    set sub = $order(newlist(sub),direction) quit:sub=""
+                    set mod=""
+                    for {
+                        set mod = $order(newlist(sub,mod),direction,data) quit:mod=""
+                        set list($increment(mlist))=data
+                    }
                 }
             }
         }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -531,6 +531,17 @@ reinstall -env /path/to/env1.json;/path/to/env2.json example-package
     list -python
 </example>
 
+<example description="Shortforms: n, d, v. Add '-d' for descending (e.g., d-d).">
+    list -s [name|date|version]
+</example>
+
+<example description="Shows installed modules in decending">
+    list -s name-desc
+</example>
+<example description="Shows installed modules in decending based on the installation date">
+    list -s d-d
+</example>
+
 <!-- Parameters -->
 <parameter name="searchString" description="Search string, * can be used." />
 
@@ -542,6 +553,7 @@ reinstall -env /path/to/env1.json;/path/to/env2.json example-package
 <modifier name="showupstream" aliases="su" description="If specified, show the latest version for each module in configured repos if it's different than the local version." />
 <modifier name="repository" aliases="repo" value="true" description="If specified, only show modules installed that belong to the provided repository." />
 <modifier name="python" aliases="py" description="If specified, lists installed Embedded Python libraries instead of IPM modules." />
+<modifier name="sort" aliases="s" value="true" description="Sort the list. Options: name, name-desc, date, date-desc, version, version-desc" />
 </command>
 
 <command name="list-dependents" aliases="dependents">
@@ -2854,6 +2866,41 @@ ClassMethod ListInstalled(ByRef pCommandInfo) [ Private ]
             }
         }
         merge tModifiers = pCommandInfo("modifiers")
+        set sortMode = $$$lcase($get(pCommandInfo("modifiers", "sort")))
+        set type = $extract(sortMode, 1) // "d", "n", or "v"
+        set isDesc = (sortMode [ "-d")
+        set sortMode = $case(type, "n":"name", "d":"date", "v":"version", :"name")
+        if isDesc {
+            set sortMode = sortMode_"-desc"
+        }
+        set newlist =""
+        if sortMode'="" {
+            for i=1:1:list {
+                 set entry = list(i)
+                set name = $listget(entry,1)
+                set entry = entry_$listbuild(i)
+                if sortMode["name"{
+                    set newlist($$$lcase(name))=entry
+                }
+                if sortMode["date"{
+                    set date = $listget(entry,6)
+                    set newlist(date)=entry
+                }
+                if sortMode["version" {
+                    set newlist($listfromstring($listget(entry,2),"."))=entry
+                }
+                kill list(i)
+            }
+            set direction = $select(sortMode [ "desc": -1, 1: 1)
+            set mod = ""
+            if $data(newlist)>1 {
+                // create new list based on the sorting
+                for {
+                    set mod = $order(newlist(mod),direction,data) quit:mod=""
+                    set list($increment(mlist))=data
+                }
+            }
+        }
         do ..DisplayModules(.list,,,, .tModifiers)
     }
 }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -535,7 +535,7 @@ reinstall -env /path/to/env1.json;/path/to/env2.json example-package
     list -s [name|date|version]
 </example>
 
-<example description="Shows installed modules in decending">
+<example description="Shows installed modules in descending order">
     list -s name-desc
 </example>
 <example description="Shows installed modules in decending based on the installation date">
@@ -2876,13 +2876,13 @@ ClassMethod ListInstalled(ByRef pCommandInfo) [ Private ]
         set newlist =""
         if sortMode'="" {
             for i=1:1:list {
-                 set entry = list(i)
+                set entry = list(i)
                 set name = $listget(entry,1)
                 set entry = entry_$listbuild(i)
                 if sortMode["name"{
                     set newlist($$$lcase(name))=entry
                 }
-                if sortMode["date"{
+                if sortMode["date" {
                     set date = $listget(entry,6)
                     set newlist(date)=entry
                 }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2868,36 +2868,22 @@ ClassMethod ListInstalled(ByRef pCommandInfo) [ Private ]
         merge tModifiers = pCommandInfo("modifiers")
         set sortMode = $$$lcase($get(pCommandInfo("modifiers", "sort")))
 
-        // Always sort; default is name ascending
+        // Always sort; default is name ascending; IPM is always positioned first
         do ..SortList(.list, $select(sortMode'="":sortMode, 1:"n"))
-
-        // IPM itself always appears first regardless of sort order.
-        // Position 1 holds the display name (e.g. "IPM (zpm)"); extract the actual name
-        // from inside the parentheses when present, otherwise use the display name as-is.
-        for i=1:1:list {
-            set displayName = $listget(list(i),1)
-            set actualName = $select(displayName["(": $piece($piece(displayName,"(",2),")",1), 1: displayName)
-            if $$$lcase(actualName) = $$$IPMModuleName {
-                set ipmEntry = list(i)
-                for j=i:-1:2 {
-                    set list(j) = list(j-1)
-                }
-                set list(1) = ipmEntry
-                quit
-            }
-        }
 
         do ..DisplayModules(.list,,,, .tModifiers)
     }
 }
 
-/// Sort a module list in-place.
+/// Sort a module list in-place. IPM is always placed first regardless of sort direction.
 /// sortMode is a raw sort string: first char "n"=name, "d"=date, "v"=version;
 /// append "-d" for descending (e.g. "n-d", "d-d", "v-d"). Default: ascending by name.
-/// List entries are $listbuild(name, versionString, externalName, developerMode, root, lastUpdated).
+/// List entries are $listbuild(label, versionString, externalName, developerMode, root, lastUpdated)
+/// where label may be "ExternalName (internalName)" (e.g. "IPM (zpm)").
 ClassMethod SortList(ByRef list, sortModeRaw As %String) [ Internal ]
 {
     set newlist = ""
+    set ipmEntry = ""
     set rawLower = $$$lcase(sortModeRaw)
     set type = $extract(rawLower, 1) // "n"=name, "d"=date, "v"=version; default ascending by name
     set isDesc = (rawLower [ "-d")
@@ -2908,22 +2894,38 @@ ClassMethod SortList(ByRef list, sortModeRaw As %String) [ Internal ]
     set mlist = 0
     for i=1:1:list {
         set entry = list(i)
-        set name = $listget(entry,1)
+        set label = $listget(entry,1)
+        // label may be "ExternalName (internalName)"; extract internal name to detect IPM
+        set internalName = $select(label["(": $piece($piece(label,"(",2),")",1), 1: label)
+        if $$$lcase(internalName) = $$$IPMModuleName {
+            set ipmEntry = entry
+            kill list(i)
+            continue
+        }
+        // guard against LastUpdated being absent — read field 6 before entry is extended with tiebreaker
+        set date = $listget(entry,6)
         set entry = entry_$listbuild(i)
         if sortMode = "name" || (sortMode = "name-desc") {
-            set newlist($$$lcase(name),i) = entry
+            set newlist($$$lcase(label),i) = entry
         } elseif sortMode = "date" || (sortMode = "date-desc") {
-            set date = $listget(entry,6)
-            set newlist(date,name) = entry
+            set newlist(date,label) = entry
         } elseif sortMode = "version" || (sortMode = "version-desc") {
-            // Build a zero-padded key so "1.10.0" sorts after "1.9.0" (numeric, not lexicographic)
-            set vParts = $listfromstring($listget(entry,2),".")
-            set vKey = $translate($justify($listget(vParts,1),5)," ","0")_"."_
-                       $translate($justify($listget(vParts,2),5)," ","0")_"."_
-                       $translate($justify($listget(vParts,3),5)," ","0")
-            set newlist(vKey,name) = entry
+            // Use SemanticVersion to parse the version string so all formats are handled correctly.
+            // Build a padded string key: pre-releases sort before their release (pre-release="~" means
+            // "no pre-release" and "~" collates after any alphabetic string, so releases sort last).
+            // Build metadata is ignored per semver spec.
+            set sv = ##class(%IPM.General.SemanticVersion).FromString($listget(entry,2))
+            set vKey = $translate($justify(sv.Major,5)," ","0")_"."_
+                       $translate($justify(sv.Minor,5)," ","0")_"."_
+                       $translate($justify(sv.Patch,5)," ","0")_"."_
+                       $select(sv.Prerelease'="": sv.Prerelease, 1: "~")
+            set newlist(vKey,label) = entry
         }
         kill list(i)
+    }
+    // IPM always goes first; place it at position 1 before the sorted entries
+    if ipmEntry '= "" {
+        set list($increment(mlist)) = ipmEntry
     }
     set direction = $select(isDesc: -1, 1: 1)
     set sub = ""

--- a/src/cls/IPM/Storage/QualifiedModuleInfo.cls
+++ b/src/cls/IPM/Storage/QualifiedModuleInfo.cls
@@ -20,6 +20,8 @@ Method %OnNew(
         set ..Version = pResolvedReference.Version
         set ..Deployed = pResolvedReference.Deployed
         set ..PlatformVersions = pResolvedReference.PlatformVersions
+        set ..VersionString = pResolvedReference.VersionString
+        set ..AllVersions = pResolvedReference.AllVersions
     }
     quit $$$OK
 }

--- a/src/cls/IPM/Storage/QualifiedModuleInfo.cls
+++ b/src/cls/IPM/Storage/QualifiedModuleInfo.cls
@@ -20,8 +20,6 @@ Method %OnNew(
         set ..Version = pResolvedReference.Version
         set ..Deployed = pResolvedReference.Deployed
         set ..PlatformVersions = pResolvedReference.PlatformVersions
-        set ..VersionString = pResolvedReference.VersionString
-        set ..AllVersions = pResolvedReference.AllVersions
     }
     quit $$$OK
 }

--- a/tests/unit_tests/Test/PM/Unit/CLI.cls
+++ b/tests/unit_tests/Test/PM/Unit/CLI.cls
@@ -151,6 +151,11 @@ Method TestParser()
     set tResults(tCommands,"data","EnvFiles")="/etc/three;/etc/four"
     set tResults(tCommands,"data","zpm","EnvFiles")="/etc/one;/etc/two"
 
+    // sort modifier parses correctly
+    set tCommands($increment(tCommands)) = "list -s name"
+    set tResults(tCommands)="list-installed"
+    set tResults(tCommands,"modifiers","sort")="name"
+
 	// Verify output matches
 	for i=1:1:tCommands {
 		kill tParsedCommandInfo,tExpectedCommandInfo
@@ -373,16 +378,73 @@ Method TestReportFormatConfiguration()
     }
 }
 
-Method TestListSortingFlags()
+Method TestSortList()
 {
-    do $$$LogMessage("Testing list-installed sorting flags")
-    set status = ..RunCommand("list")
-    set status = ..RunCommand("list -s n")
-    do $$$AssertStatusOK(status, "Sort by name command executed successfully")
-    set status = ..RunCommand("list -s v-d")
-    do $$$AssertStatusOK(status, "Sort by version descending executed successfully")
-    set status = ..RunCommand("list -s d-d")
-    do $$$AssertStatusOK(status, "Sort by date descending executed successfully")
+    // Build a synthetic list matching the format produced by GetListModules:
+    // $listbuild(name, versionString, externalName, developerMode, root, lastUpdated)
+    // Deliberately different orderings per field so each sort is independently verified:
+    //   name asc:    apple, mango, zebra
+    //   date asc:    mango (jan01), zebra (jan02), apple (jan03)
+    //   version asc: zebra (1.0.0), apple (2.0.0), mango (3.0.0)
+    set list = 3
+    set list(1) = $listbuild("zebra", "1.0.0", "", 0, "", "2026-01-02 10:00:00")
+    set list(2) = $listbuild("apple", "2.0.0", "", 0, "", "2026-01-03 10:00:00")
+    set list(3) = $listbuild("mango", "3.0.0", "", 0, "", "2026-01-01 10:00:00")
+
+    // Sort by name ascending: apple, mango, zebra
+    kill sorted  merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "n")
+    do $$$AssertEquals($listget(sorted(1),1), "apple", "name asc: first is apple")
+    do $$$AssertEquals($listget(sorted(2),1), "mango", "name asc: second is mango")
+    do $$$AssertEquals($listget(sorted(3),1), "zebra", "name asc: third is zebra")
+
+    // Sort by name descending: zebra, mango, apple
+    kill sorted  merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "n-d")
+    do $$$AssertEquals($listget(sorted(1),1), "zebra", "name desc: first is zebra")
+    do $$$AssertEquals($listget(sorted(2),1), "mango", "name desc: second is mango")
+    do $$$AssertEquals($listget(sorted(3),1), "apple", "name desc: third is apple")
+
+    // Sort by date ascending: mango (jan01), zebra (jan02), apple (jan03)
+    kill sorted  merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "d")
+    do $$$AssertEquals($listget(sorted(1),1), "mango", "date asc: first is mango")
+    do $$$AssertEquals($listget(sorted(2),1), "zebra", "date asc: second is zebra")
+    do $$$AssertEquals($listget(sorted(3),1), "apple", "date asc: third is apple")
+
+    // Sort by date descending: apple (jan03), zebra (jan02), mango (jan01)
+    kill sorted  merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "d-d")
+    do $$$AssertEquals($listget(sorted(1),1), "apple", "date desc: first is apple")
+    do $$$AssertEquals($listget(sorted(2),1), "zebra", "date desc: second is zebra")
+    do $$$AssertEquals($listget(sorted(3),1), "mango", "date desc: third is mango")
+
+    // Sort by version ascending: zebra (1.0.0), apple (2.0.0), mango (3.0.0)
+    kill sorted  merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "v")
+    do $$$AssertEquals($listget(sorted(1),1), "zebra", "version asc: first is zebra")
+    do $$$AssertEquals($listget(sorted(2),1), "apple", "version asc: second is apple")
+    do $$$AssertEquals($listget(sorted(3),1), "mango", "version asc: third is mango")
+
+    // Sort by version descending: mango (3.0.0), apple (2.0.0), zebra (1.0.0)
+    kill sorted  merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "v-d")
+    do $$$AssertEquals($listget(sorted(1),1), "mango", "version desc: first is mango")
+    do $$$AssertEquals($listget(sorted(2),1), "apple", "version desc: second is apple")
+    do $$$AssertEquals($listget(sorted(3),1), "zebra", "version desc: third is zebra")
+
+    // Edge case: empty list — should not crash
+    kill sorted  set sorted = 0
+    do ##class(%IPM.Main).SortList(.sorted, "n")
+    do $$$AssertEquals(sorted, 0, "empty list: count is 0")
+
+    // Edge case: single-item list — should not crash or lose the item
+    kill sorted
+    set sorted = 1
+    set sorted(1) = $listbuild("only", "1.0.0", "", 0, "", "2026-01-01 10:00:00")
+    do ##class(%IPM.Main).SortList(.sorted, "n")
+    do $$$AssertEquals(sorted, 1, "single item: count is 1")
+    do $$$AssertEquals($listget(sorted(1),1), "only", "single item: item preserved")
 }
 
 }

--- a/tests/unit_tests/Test/PM/Unit/CLI.cls
+++ b/tests/unit_tests/Test/PM/Unit/CLI.cls
@@ -373,4 +373,16 @@ Method TestReportFormatConfiguration()
     }
 }
 
+Method TestListSortingFlags()
+{
+    do $$$LogMessage("Testing list-installed sorting flags")
+    set status = ..RunCommand("list")
+    set status = ..RunCommand("list -s n")
+    do $$$AssertStatusOK(status, "Sort by name command executed successfully")
+    set status = ..RunCommand("list -s v-d")
+    do $$$AssertStatusOK(status, "Sort by version descending executed successfully")
+    set status = ..RunCommand("list -s d-d")
+    do $$$AssertStatusOK(status, "Sort by date descending executed successfully")
+}
+
 }

--- a/tests/unit_tests/Test/PM/Unit/CLI.cls
+++ b/tests/unit_tests/Test/PM/Unit/CLI.cls
@@ -151,10 +151,34 @@ Method TestParser()
     set tResults(tCommands,"data","EnvFiles")="/etc/three;/etc/four"
     set tResults(tCommands,"data","zpm","EnvFiles")="/etc/one;/etc/two"
 
-    // sort modifier parses correctly
+    // sort modifier parses correctly — long and short forms, ascending and descending
     set tCommands($increment(tCommands)) = "list -s name"
     set tResults(tCommands)="list-installed"
     set tResults(tCommands,"modifiers","sort")="name"
+
+    set tCommands($increment(tCommands)) = "list -s n"
+    set tResults(tCommands)="list-installed"
+    set tResults(tCommands,"modifiers","sort")="n"
+
+    set tCommands($increment(tCommands)) = "list -s n-d"
+    set tResults(tCommands)="list-installed"
+    set tResults(tCommands,"modifiers","sort")="n-d"
+
+    set tCommands($increment(tCommands)) = "list -s date"
+    set tResults(tCommands)="list-installed"
+    set tResults(tCommands,"modifiers","sort")="date"
+
+    set tCommands($increment(tCommands)) = "list -s d-d"
+    set tResults(tCommands)="list-installed"
+    set tResults(tCommands,"modifiers","sort")="d-d"
+
+    set tCommands($increment(tCommands)) = "list -s v"
+    set tResults(tCommands)="list-installed"
+    set tResults(tCommands,"modifiers","sort")="v"
+
+    set tCommands($increment(tCommands)) = "list -s version-desc"
+    set tResults(tCommands)="list-installed"
+    set tResults(tCommands,"modifiers","sort")="version-desc"
 
 	// Verify output matches
 	for i=1:1:tCommands {
@@ -380,8 +404,8 @@ Method TestReportFormatConfiguration()
 
 Method TestSortList()
 {
-    // Build a synthetic list matching the format produced by GetListModules:
-    // $listbuild(name, versionString, externalName, developerMode, root, lastUpdated)
+    // Build a synthetic list matching the format SortList receives (post label substitution by ListInstalled):
+    // $listbuild(label, versionString, externalName, developerMode, root, lastUpdated)
     // Deliberately different orderings per field so each sort is independently verified:
     //   name asc:    apple, mango, zebra
     //   date asc:    mango (jan01), zebra (jan02), apple (jan03)
@@ -392,49 +416,56 @@ Method TestSortList()
     set list(3) = $listbuild("mango", "3.0.0", "", 0, "", "2026-01-01 10:00:00")
 
     // Sort by name ascending: apple, mango, zebra
-    kill sorted  merge sorted = list
+    kill sorted
+    merge sorted = list
     do ##class(%IPM.Main).SortList(.sorted, "n")
     do $$$AssertEquals($listget(sorted(1),1), "apple", "name asc: first is apple")
     do $$$AssertEquals($listget(sorted(2),1), "mango", "name asc: second is mango")
     do $$$AssertEquals($listget(sorted(3),1), "zebra", "name asc: third is zebra")
 
     // Sort by name descending: zebra, mango, apple
-    kill sorted  merge sorted = list
+    kill sorted
+    merge sorted = list
     do ##class(%IPM.Main).SortList(.sorted, "n-d")
     do $$$AssertEquals($listget(sorted(1),1), "zebra", "name desc: first is zebra")
     do $$$AssertEquals($listget(sorted(2),1), "mango", "name desc: second is mango")
     do $$$AssertEquals($listget(sorted(3),1), "apple", "name desc: third is apple")
 
     // Sort by date ascending: mango (jan01), zebra (jan02), apple (jan03)
-    kill sorted  merge sorted = list
+    kill sorted
+    merge sorted = list
     do ##class(%IPM.Main).SortList(.sorted, "d")
     do $$$AssertEquals($listget(sorted(1),1), "mango", "date asc: first is mango")
     do $$$AssertEquals($listget(sorted(2),1), "zebra", "date asc: second is zebra")
     do $$$AssertEquals($listget(sorted(3),1), "apple", "date asc: third is apple")
 
     // Sort by date descending: apple (jan03), zebra (jan02), mango (jan01)
-    kill sorted  merge sorted = list
+    kill sorted
+    merge sorted = list
     do ##class(%IPM.Main).SortList(.sorted, "d-d")
     do $$$AssertEquals($listget(sorted(1),1), "apple", "date desc: first is apple")
     do $$$AssertEquals($listget(sorted(2),1), "zebra", "date desc: second is zebra")
     do $$$AssertEquals($listget(sorted(3),1), "mango", "date desc: third is mango")
 
     // Sort by version ascending: zebra (1.0.0), apple (2.0.0), mango (3.0.0)
-    kill sorted  merge sorted = list
+    kill sorted
+    merge sorted = list
     do ##class(%IPM.Main).SortList(.sorted, "v")
     do $$$AssertEquals($listget(sorted(1),1), "zebra", "version asc: first is zebra")
     do $$$AssertEquals($listget(sorted(2),1), "apple", "version asc: second is apple")
     do $$$AssertEquals($listget(sorted(3),1), "mango", "version asc: third is mango")
 
     // Sort by version descending: mango (3.0.0), apple (2.0.0), zebra (1.0.0)
-    kill sorted  merge sorted = list
+    kill sorted
+    merge sorted = list
     do ##class(%IPM.Main).SortList(.sorted, "v-d")
     do $$$AssertEquals($listget(sorted(1),1), "mango", "version desc: first is mango")
     do $$$AssertEquals($listget(sorted(2),1), "apple", "version desc: second is apple")
     do $$$AssertEquals($listget(sorted(3),1), "zebra", "version desc: third is zebra")
 
     // Edge case: empty list — should not crash
-    kill sorted  set sorted = 0
+    kill sorted
+    set sorted = 0
     do ##class(%IPM.Main).SortList(.sorted, "n")
     do $$$AssertEquals(sorted, 0, "empty list: count is 0")
 
@@ -445,6 +476,126 @@ Method TestSortList()
     do ##class(%IPM.Main).SortList(.sorted, "n")
     do $$$AssertEquals(sorted, 1, "single item: count is 1")
     do $$$AssertEquals($listget(sorted(1),1), "only", "single item: item preserved")
+
+}
+
+Method TestSortListIPMFirst()
+{
+    // IPM always appears first regardless of sort direction.
+    // Entries use the label format produced by ListInstalled before SortList is called:
+    // plain internal name ("zpm") or formatted "ExternalName (internalName)" ("IPM (zpm)")
+    set list = 3
+    set list(1) = $listbuild("zebra", "1.0.0", "", 0, "", "2026-01-02 10:00:00")
+    set list(2) = $listbuild("IPM (zpm)", "0.10.0", "", 0, "", "2026-01-03 10:00:00")
+    set list(3) = $listbuild("apple", "2.0.0", "", 0, "", "2026-01-01 10:00:00")
+
+    kill sorted
+    merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "n")
+    do $$$AssertEquals($listget(sorted(1),1), "IPM (zpm)", "IPM first (name asc)")
+
+    kill sorted
+    merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "n-d")
+    do $$$AssertEquals($listget(sorted(1),1), "IPM (zpm)", "IPM first (name desc)")
+
+    kill sorted
+    merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "d")
+    do $$$AssertEquals($listget(sorted(1),1), "IPM (zpm)", "IPM first (date asc)")
+
+    kill sorted
+    merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "v-d")
+    do $$$AssertEquals($listget(sorted(1),1), "IPM (zpm)", "IPM first (version desc)")
+}
+
+Method TestSortListSemanticVersions()
+{
+    // Verify numeric component ordering: "1.10.0" must sort after "1.9.0".
+    // Pre-release and build metadata cases are covered in TestSortListVersionPrerelease.
+    set list = 4
+    set list(1) = $listbuild("alpha", "1.10.2", "", 0, "", "2026-01-01 10:00:00")
+    set list(2) = $listbuild("beta",  "1.9.10", "", 0, "", "2026-01-02 10:00:00")
+    set list(3) = $listbuild("gamma", "1.10.1", "", 0, "", "2026-01-03 10:00:00")
+    set list(4) = $listbuild("delta", "2.0.0",  "", 0, "", "2026-01-04 10:00:00")
+
+    // Double-check ordering with Follows before relying on it in sort assertions
+    do $$$AssertTrue(##class(%IPM.General.SemanticVersion).FromString("1.10.1").Follows(##class(%IPM.General.SemanticVersion).FromString("1.9.10")), "1.10.1 follows 1.9.10")
+    do $$$AssertTrue(##class(%IPM.General.SemanticVersion).FromString("1.10.2").Follows(##class(%IPM.General.SemanticVersion).FromString("1.10.1")), "1.10.2 follows 1.10.1")
+    do $$$AssertTrue(##class(%IPM.General.SemanticVersion).FromString("2.0.0").Follows(##class(%IPM.General.SemanticVersion).FromString("1.10.2")), "2.0.0 follows 1.10.2")
+
+    // Version ascending: beta (1.9.10) < gamma (1.10.1) < alpha (1.10.2) < delta (2.0.0)
+    kill sorted
+    merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "v")
+    do $$$AssertEquals($listget(sorted(1),1), "beta",  "version asc: first is beta (1.9.10)")
+    do $$$AssertEquals($listget(sorted(2),1), "gamma", "version asc: second is gamma (1.10.1)")
+    do $$$AssertEquals($listget(sorted(3),1), "alpha", "version asc: third is alpha (1.10.2)")
+    do $$$AssertEquals($listget(sorted(4),1), "delta", "version asc: fourth is delta (2.0.0)")
+
+    // Version descending: reverse of above
+    kill sorted
+    merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "v-d")
+    do $$$AssertEquals($listget(sorted(1),1), "delta", "version desc: first is delta (2.0.0)")
+    do $$$AssertEquals($listget(sorted(2),1), "alpha", "version desc: second is alpha (1.10.2)")
+    do $$$AssertEquals($listget(sorted(3),1), "gamma", "version desc: third is gamma (1.10.1)")
+    do $$$AssertEquals($listget(sorted(4),1), "beta",  "version desc: fourth is beta (1.9.10)")
+}
+
+Method TestSortListVersionPrerelease()
+{
+    // Verify pre-release and build metadata sort correctly per semver spec:
+    //   pre-release < release with same major.minor.patch
+    //   build metadata is ignored (treated as release)
+    //   pre-release ordering is case-sensitive (consistent with SemanticVersion.Follows):
+    //     uppercase letters (A-Z, 65-90) sort before lowercase (a-z, 97-122)
+    //     so "SNAPSHOT" (S=83) < "alpha" (a=97) < "beta.1" < "rc.1"
+    //   "~" (126) is used as the key suffix for release/build-only versions so they sort last
+    // Expected ascending order:
+    //   snap  (1.0.0-SNAPSHOT)   — pre-release, S=83 sorts before lowercase labels
+    //   a     (1.0.0-alpha)      — pre-release
+    //   b     (1.0.0-beta.1)     — pre-release
+    //   c     (1.0.0-rc.1)       — pre-release
+    //   bld   (1.0.0+build.42)   — build metadata only: treated same as release (key suffix "~")
+    //   rel   (1.0.0)            — release (key suffix "~"), "rel" > "bld" as secondary key
+    set list = 6
+    set list(1) = $listbuild("rel",  "1.0.0",           "", 0, "", "2026-01-01 10:00:00")
+    set list(2) = $listbuild("snap", "1.0.0-SNAPSHOT",  "", 0, "", "2026-01-02 10:00:00")
+    set list(3) = $listbuild("a",    "1.0.0-alpha",     "", 0, "", "2026-01-03 10:00:00")
+    set list(4) = $listbuild("bld",  "1.0.0+build.42",  "", 0, "", "2026-01-04 10:00:00")
+    set list(5) = $listbuild("b",    "1.0.0-beta.1",    "", 0, "", "2026-01-05 10:00:00")
+    set list(6) = $listbuild("c",    "1.0.0-rc.1",      "", 0, "", "2026-01-06 10:00:00")
+
+    // Follows is a partial order — pairs with different MMP where both have pre-release are incomparable.
+    // Our sort imposes a total order (every entry gets a string key), so these Follows checks only
+    // validate the pairs that semver itself defines an answer for.
+    do $$$AssertTrue(##class(%IPM.General.SemanticVersion).FromString("1.0.0").Follows(##class(%IPM.General.SemanticVersion).FromString("1.0.0-SNAPSHOT")), "release follows pre-release (SNAPSHOT)")
+    do $$$AssertTrue(##class(%IPM.General.SemanticVersion).FromString("1.0.0").Follows(##class(%IPM.General.SemanticVersion).FromString("1.0.0-alpha")), "release follows pre-release (alpha)")
+    do $$$AssertTrue(##class(%IPM.General.SemanticVersion).FromString("1.0.0-beta.1").Follows(##class(%IPM.General.SemanticVersion).FromString("1.0.0-alpha")), "beta.1 follows alpha")
+    do $$$AssertTrue(##class(%IPM.General.SemanticVersion).FromString("1.0.0-rc.1").Follows(##class(%IPM.General.SemanticVersion).FromString("1.0.0-beta.1")), "rc.1 follows beta.1")
+
+    kill sorted
+    merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "v")
+    do $$$AssertEquals($listget(sorted(1),1), "snap", "version asc: snap (1.0.0-SNAPSHOT)")
+    do $$$AssertEquals($listget(sorted(2),1), "a",    "version asc: a (1.0.0-alpha)")
+    do $$$AssertEquals($listget(sorted(3),1), "b",    "version asc: b (1.0.0-beta.1)")
+    do $$$AssertEquals($listget(sorted(4),1), "c",    "version asc: c (1.0.0-rc.1)")
+    // rel and bld both have key suffix "~"; their relative order is by label (name)
+    do $$$AssertEquals($listget(sorted(5),1), "bld",  "version asc: bld (1.0.0+build.42)")
+    do $$$AssertEquals($listget(sorted(6),1), "rel",  "version asc: rel (1.0.0)")
+
+    kill sorted
+    merge sorted = list
+    do ##class(%IPM.Main).SortList(.sorted, "v-d")
+    do $$$AssertEquals($listget(sorted(1),1), "rel",  "version desc: rel (1.0.0)")
+    do $$$AssertEquals($listget(sorted(2),1), "bld",  "version desc: bld (1.0.0+build.42)")
+    do $$$AssertEquals($listget(sorted(3),1), "c",    "version desc: c (1.0.0-rc.1)")
+    do $$$AssertEquals($listget(sorted(4),1), "b",    "version desc: b (1.0.0-beta.1)")
+    do $$$AssertEquals($listget(sorted(5),1), "a",    "version desc: a (1.0.0-alpha)")
+    do $$$AssertEquals($listget(sorted(6),1), "snap", "version desc: snap (1.0.0-SNAPSHOT)")
 }
 
 }


### PR DESCRIPTION
## Enhanced Sorting for `list-installed`

### Overview

This PR introduces a new `-sort` (shortcut `-s`) modifier to the `list-installed` command. It allows users to organize their installed modules by **Name**, **Installation Date**, or **Semantic Version**, significantly improving manageability for environments with many packages

fixes: #1071

### Features Added

* **Three New Sort Modes:**
* `name`: Alphabetical sorting (case-insensitive).
* `date`: Chronological sorting based on when the module was installed.
* `version`: Semantic version sorting (handling Major.Minor.Patch logic).


* **Descending Order Support:** Added a `-desc` (or `-d`) suffix to all sort modes to reverse the output.
* **Power-User Shortcuts:** Implemented shorthand notation for faster CLI usage:
* `n`, `n-d` (Name)
* `d`, `d-d` (Date)
* `v`, `v-d` (Version)

### Testing Performed

Verified all combinations of sort keys and directions via the ZPM shell:

* Confirmed `list -s v-d` correctly places version `4.1.2` above `1.0.1`.
* Confirmed `list -s d-d` places the most recently installed module at the top.
* Validated that shortforms (e.g., `list -s n-d`) resolve correctly to their full counterparts.

```objectscript
zpm:USER>list 
IPM (zpm)         0.10.6-SNAPSHOT
irisJWT (irisjwt) 1.0.1
objectscript-math 0.0.5
testify           1.0.2
zpm:USER>list -s name-desc
testify           1.0.2
objectscript-math 0.0.5
irisJWT (irisjwt) 1.0.1
IPM (zpm)         0.10.6-SNAPSHOT
zpm:USER>list -s d-d
testify           1.0.2
irisJWT (irisjwt) 1.0.1
objectscript-math 0.0.5
IPM (zpm)         0.10.6-SNAPSHOT
zpm:USER>list -s v-d 
testify           1.0.2
irisJWT (irisjwt) 1.0.1
IPM (zpm)         0.10.6-SNAPSHOT
objectscript-math 0.0.5

```