### PR TITLE
feat: implement 'locate-resource' command for resource-to-module mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.7] - Unreleased
+
+### Added
+- #1081: Implement locate-resource command for resource-to-module mapping
+
+
 ## [0.10.6] - Unreleased
 
 ### Added
 - #1024: Added flag -export-python-deps to publish command
-- #1081: implement locate command for resource-to-module mapping
 
 ### Fixed
 - #996: Ensure COS commands execute in exec under a dedicated, isolated context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - #1024: Added flag -export-python-deps to publish command
+- #1081: implement locate command for resource-to-module mapping
 
 ### Fixed
 - #996: Ensure COS commands execute in exec under a dedicated, isolated context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ modules are.
 
 ### Added
 - #1024: Added flag -export-python-deps to publish command
+- #1081: implement locate command for resource-to-module mapping
 
 ### Fixed
 - #996: Ensure COS commands execute in exec under a dedicated, isolated context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - #1178: Add `-password-env` and `-token-env` modifiers to the `repo` command to read the password/token from a named environment variable (secure alternatives to `-password` and `-token`).
+- #1081: Implement locate-resource command for resource-to-module mapping
 
 ## [0.10.8] - 2026-07-08
 
@@ -66,7 +67,6 @@ modules are.
 
 ### Added
 - #1024: Added flag -export-python-deps to publish command
-- #1081: implement locate command for resource-to-module mapping
 
 ### Fixed
 - #996: Ensure COS commands execute in exec under a dedicated, isolated context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - #1117: Add `sync` command for incremental loading of changed files in dev-mode modules. Detects modified files since last sync using SHA-1 hash and recompiles only what is stale. Supports `-delete` for processing removed files and `-test` for running changed test-phase unit tests.
+- #1081: Implement `locate-resource` command for resource-to-module mapping
 
 ## [0.10.9] - 2026-08-05
 
 ### Added
 - #1178: Add `-password-env` and `-token-env` modifiers to the `repo` command to read the password/token from a named environment variable (secure alternatives to `-password` and `-token`).
-- #1081: Implement locate-resource command for resource-to-module mapping
 
 ### Changed
 - #1186: Change %IPM.Main:ShellScript() to return a status.

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -791,11 +791,11 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
 	<example description="Show details of history item with ID 3 and information for each undergone lifecyle phase">history details 3 -phases</example>
 </command>
 
-<command name="locate" aliases="loc">
+<command name="locate-resource">
     <description>Find the module that owns a specific resource.</description>
-    <parameter name="resource" description="resource: The full name of the resource (e.g., My.Class.cls, Utils.inc)." />
-    <example description="Finds the module containing the specified class.">locate %IPM.Main.cls</example>
-    <example description="Finds the module containing the specified include file.">loc %IPM.Common.inc</example>
+    <parameter name="resource" required="true" description="resource: The full name of the resource (e.g., My.Class.cls, Utils.inc)." />
+    <example description="Finds the module containing the specified class.">locate-resource %IPM.Main.cls</example>
+    <example description="Finds the module containing the specified include file.">locate-resource %IPM.Common.inc</example>
 </command>
 
 </commands>
@@ -1040,7 +1040,7 @@ ClassMethod ShellInternal(
                 do ..Information(.tCommandInfo)
 			} elseif (tCommandInfo = "history") {
 				do ..History(.tCommandInfo)
-            } elseif (tCommandInfo = "locate") {
+            } elseif (tCommandInfo = "locate-resource") {
 				do ..Locate(.tCommandInfo)
             }
         } catch pException {
@@ -4063,12 +4063,9 @@ ClassMethod Update(ByRef pCommandInfo)
 ClassMethod Locate(ByRef CommandInfo)
 {
     set resource = $get(CommandInfo("parameters","resource"))
-    if resource="" {
-        $$$ThrowOnError($$$ERROR($$$GeneralError,"Resource name is required."))
-    }
     set moduleName = ##class(%IPM.ExtensionBase.Utils).GetHomeModuleName(resource)
     if (moduleName="") {
-        write $$$FormattedLine($$$Red, "Resource '"_ resource_"' is not currently mapped to an installed module.")
+        write $$$FormattedLine($$$Red, "Resource '"_ resource_"' is not currently part of an installed module.")
         quit
     }
     set showFields = ""

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1041,7 +1041,7 @@ ClassMethod ShellInternal(
 			} elseif (tCommandInfo = "history") {
 				do ..History(.tCommandInfo)
             } elseif (tCommandInfo = "locate-resource") {
-				do ..Locate(.tCommandInfo)
+				do ..LocateResource(.tCommandInfo)
             }
         } catch pException {
             if (pException.Code = $$$ERCTRLC) {
@@ -4060,7 +4060,7 @@ ClassMethod Update(ByRef pCommandInfo)
     }
 }
 
-ClassMethod Locate(ByRef CommandInfo)
+ClassMethod LocateResource(ByRef CommandInfo)
 {
     set resource = $get(CommandInfo("parameters","resource"))
     set moduleName = ##class(%IPM.ExtensionBase.Utils).GetHomeModuleName(resource)

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -791,6 +791,13 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
 	<example description="Show details of history item with ID 3 and information for each undergone lifecyle phase">history details 3 -phases</example>
 </command>
 
+<command name="locate" aliases="loc">
+    <description>Find the module that owns a specific resource.</description>
+    <parameter name="resource" description="resource: The full name of the resource (e.g., My.Class.cls, Utils.inc)." />
+    <example description="Finds the module containing the specified class.">locate %IPM.Main.cls</example>
+    <example description="Finds the module containing the specified include file.">loc %IPM.Common.inc</example>
+</command>
+
 </commands>
 }
 
@@ -1033,6 +1040,8 @@ ClassMethod ShellInternal(
                 do ..Information(.tCommandInfo)
 			} elseif (tCommandInfo = "history") {
 				do ..History(.tCommandInfo)
+            } elseif (tCommandInfo = "locate") {
+				do ..Locate(.tCommandInfo)
             }
         } catch pException {
             if (pException.Code = $$$ERCTRLC) {
@@ -4049,6 +4058,23 @@ ClassMethod Update(ByRef pCommandInfo)
         // Call ..Install() in order to install the newer version of the module.
         do ..Install(.pCommandInfo, log)
     }
+}
+
+ClassMethod Locate(ByRef CommandInfo)
+{
+    set resource = $get(CommandInfo("parameters","resource"))
+    if resource="" {
+        $$$ThrowOnError($$$ERROR($$$GeneralError,"Resource name is required."))
+    }
+    set moduleName = ##class(%IPM.ExtensionBase.Utils).GetHomeModuleName(resource)
+    if (moduleName="") {
+        write $$$FormattedLine($$$Red, "Resource '"_ resource_"' is not currently mapped to an installed module.")
+        quit
+    }
+    set showFields = ""
+    write !
+    do ..GetListModules(,moduleName, .list)
+    do ..DisplayModules(.list,,,, .tModifiers)
 }
 
 ClassMethod GetPythonInstalledLibs(Output list)

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1106,7 +1106,7 @@ ClassMethod ShellInternal(
 			} elseif (tCommandInfo = "history") {
 				do ..History(.tCommandInfo)
             } elseif (tCommandInfo = "locate-resource") {
-				do ..Locate(.tCommandInfo)
+				do ..LocateResource(.tCommandInfo)
             }
         } catch pException {
             if (pException.Code = $$$ERCTRLC) {
@@ -4334,7 +4334,7 @@ ClassMethod Update(ByRef pCommandInfo)
     }
 }
 
-ClassMethod Locate(ByRef CommandInfo)
+ClassMethod LocateResource(ByRef CommandInfo)
 {
     set resource = $get(CommandInfo("parameters","resource"))
     set moduleName = ##class(%IPM.ExtensionBase.Utils).GetHomeModuleName(resource)

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -810,7 +810,7 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
     <example description="Display the current history retention setting.">config get HistoryRetain</example>
 </command>
 
-<command name="locate-resource">
+<command name="locate-resource" aliases="locate">
     <description>Find the module that owns a specific resource.</description>
     <parameter name="resource" required="true" description="resource: The full name of the resource (e.g., My.Class.cls, Utils.inc)." />
     <example description="Finds the module containing the specified class.">locate-resource %IPM.Main.cls</example>

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -810,6 +810,13 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
     <example description="Display the current history retention setting.">config get HistoryRetain</example>
 </command>
 
+<command name="locate" aliases="loc">
+    <description>Find the module that owns a specific resource.</description>
+    <parameter name="resource" description="resource: The full name of the resource (e.g., My.Class.cls, Utils.inc)." />
+    <example description="Finds the module containing the specified class.">locate %IPM.Main.cls</example>
+    <example description="Finds the module containing the specified include file.">loc %IPM.Common.inc</example>
+</command>
+
 </commands>
 }
 
@@ -1098,6 +1105,8 @@ ClassMethod ShellInternal(
                 do ..Information(.tCommandInfo)
 			} elseif (tCommandInfo = "history") {
 				do ..History(.tCommandInfo)
+            } elseif (tCommandInfo = "locate") {
+				do ..Locate(.tCommandInfo)
             }
         } catch pException {
             if (pException.Code = $$$ERCTRLC) {
@@ -4323,6 +4332,23 @@ ClassMethod Update(ByRef pCommandInfo)
         // Call ..Install() in order to install the newer version of the module.
         do ..Install(.pCommandInfo, log)
     }
+}
+
+ClassMethod Locate(ByRef CommandInfo)
+{
+    set resource = $get(CommandInfo("parameters","resource"))
+    if resource="" {
+        $$$ThrowOnError($$$ERROR($$$GeneralError,"Resource name is required."))
+    }
+    set moduleName = ##class(%IPM.ExtensionBase.Utils).GetHomeModuleName(resource)
+    if (moduleName="") {
+        write $$$FormattedLine($$$Red, "Resource '"_ resource_"' is not currently mapped to an installed module.")
+        quit
+    }
+    set showFields = ""
+    write !
+    do ..GetListModules(,moduleName, .list)
+    do ..DisplayModules(.list,,,, .tModifiers)
 }
 
 ClassMethod GetPythonInstalledLibs(Output list)

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -810,11 +810,11 @@ generate /my/path -export 00000,PacketName2,IgnorePacket2^00000,PacketName3,Igno
     <example description="Display the current history retention setting.">config get HistoryRetain</example>
 </command>
 
-<command name="locate" aliases="loc">
+<command name="locate-resource">
     <description>Find the module that owns a specific resource.</description>
-    <parameter name="resource" description="resource: The full name of the resource (e.g., My.Class.cls, Utils.inc)." />
-    <example description="Finds the module containing the specified class.">locate %IPM.Main.cls</example>
-    <example description="Finds the module containing the specified include file.">loc %IPM.Common.inc</example>
+    <parameter name="resource" required="true" description="resource: The full name of the resource (e.g., My.Class.cls, Utils.inc)." />
+    <example description="Finds the module containing the specified class.">locate-resource %IPM.Main.cls</example>
+    <example description="Finds the module containing the specified include file.">locate-resource %IPM.Common.inc</example>
 </command>
 
 </commands>
@@ -1105,7 +1105,7 @@ ClassMethod ShellInternal(
                 do ..Information(.tCommandInfo)
 			} elseif (tCommandInfo = "history") {
 				do ..History(.tCommandInfo)
-            } elseif (tCommandInfo = "locate") {
+            } elseif (tCommandInfo = "locate-resource") {
 				do ..Locate(.tCommandInfo)
             }
         } catch pException {
@@ -4337,12 +4337,9 @@ ClassMethod Update(ByRef pCommandInfo)
 ClassMethod Locate(ByRef CommandInfo)
 {
     set resource = $get(CommandInfo("parameters","resource"))
-    if resource="" {
-        $$$ThrowOnError($$$ERROR($$$GeneralError,"Resource name is required."))
-    }
     set moduleName = ##class(%IPM.ExtensionBase.Utils).GetHomeModuleName(resource)
     if (moduleName="") {
-        write $$$FormattedLine($$$Red, "Resource '"_ resource_"' is not currently mapped to an installed module.")
+        write $$$FormattedLine($$$Red, "Resource '"_ resource_"' is not currently part of an installed module.")
         quit
     }
     set showFields = ""

--- a/tests/unit_tests/Test/PM/Unit/CLI.cls
+++ b/tests/unit_tests/Test/PM/Unit/CLI.cls
@@ -329,4 +329,23 @@ Method TestUninstallWithoutModuleName()
     do $$$AssertNotTrue(exists, "Module removed successfully.")
 }
 
+Method TestLocateCommand()
+{
+    do $$$LogMessage("Testing 'loc' alias with .inc resource")
+    set status = ..RunCommand("loc %IPM.Common.inc")
+    do $$$AssertStatusOK(status, "Alias 'loc' executed successfully")
+
+    do $$$LogMessage("Testing 'locate' command with .cls resource")
+    set status = ..RunCommand("locate %IPM.Main.cls")
+    do $$$AssertStatusOK(status, "Command 'locate' executed successfully")
+
+    do $$$LogMessage("Testing locate with non-existing resource")
+    set status = ..RunCommand("locate Test.Sample.inc")
+    do $$$AssertStatusOK(status, "Gracefully handled non-existing resource")
+
+    do $$$LogMessage("Testing locate without required argument")
+    set status = ..RunCommand("locate")
+    do $$$AssertStatusNotOK(status, "Handled missing argument")
+}
+
 }

--- a/tests/unit_tests/Test/PM/Unit/CLI.cls
+++ b/tests/unit_tests/Test/PM/Unit/CLI.cls
@@ -331,20 +331,20 @@ Method TestUninstallWithoutModuleName()
 
 Method TestLocateCommand()
 {
-    do $$$LogMessage("Testing 'loc' alias with .inc resource")
-    set status = ..RunCommand("loc %IPM.Common.inc")
+    do $$$LogMessage("Testing 'locate-resource' alias with .inc resource")
+    set status = ..RunCommand("locate-resource %IPM.Common.inc")
     do $$$AssertStatusOK(status, "Alias 'loc' executed successfully")
 
-    do $$$LogMessage("Testing 'locate' command with .cls resource")
-    set status = ..RunCommand("locate %IPM.Main.cls")
-    do $$$AssertStatusOK(status, "Command 'locate' executed successfully")
+    do $$$LogMessage("Testing 'locate-resource' command with .cls resource")
+    set status = ..RunCommand("locate-resource %IPM.Main.cls")
+    do $$$AssertStatusOK(status, "Command 'locate-resource' executed successfully")
 
-    do $$$LogMessage("Testing locate with non-existing resource")
-    set status = ..RunCommand("locate Test.Sample.inc")
+    do $$$LogMessage("Testing locate-resource with non-existing resource")
+    set status = ..RunCommand("locate-resource Test.Sample.inc")
     do $$$AssertStatusOK(status, "Gracefully handled non-existing resource")
 
-    do $$$LogMessage("Testing locate without required argument")
-    set status = ..RunCommand("locate")
+    do $$$LogMessage("Testing locate-resource without required argument")
+    set status = ..RunCommand("locate-resource")
     do $$$AssertStatusNotOK(status, "Handled missing argument")
 }
 

--- a/tests/unit_tests/Test/PM/Unit/CLI.cls
+++ b/tests/unit_tests/Test/PM/Unit/CLI.cls
@@ -660,20 +660,46 @@ Method TestSortListVersionPrerelease()
 
 Method TestLocateCommand()
 {
-    do $$$LogMessage("Testing 'loc' alias with .inc resource")
-    set status = ..RunCommand("loc %IPM.Common.inc")
-    do $$$AssertStatusOK(status, "Alias 'loc' executed successfully")
+    set ipmModule = ##class(%IPM.Storage.Module).NameOpen("zpm",,.sc)
+    do $$$AssertStatusOK(sc, "Opened zpm module to get version")
+    set ipmVersion = ipmModule.VersionString
 
-    do $$$LogMessage("Testing 'locate' command with .cls resource")
-    set status = ..RunCommand("locate %IPM.Main.cls")
-    do $$$AssertStatusOK(status, "Command 'locate' executed successfully")
+    do $$$LogMessage("Testing locate-resource with .inc resource")
+    do ##class(%IPM.Utils.Module).BeginCaptureOutput(.cookie)
+    set status = ##class(%IPM.Main).Shell("locate-resource %IPM.Common.inc")
+    do ##class(%IPM.Utils.Module).EndCaptureOutput(cookie, .output)
+    do $$$AssertStatusOK(status, "locate-resource %IPM.Common.inc executed successfully")
+    set content = ""
+    set i = ""
+    for {
+        set i = $order(output(i))
+        quit:i=""
+        set content = content _ output(i) _ $char(10)
+    }
+    do $$$AssertTrue(content [ "zpm", "output contains module name 'zpm'")
+    do $$$AssertTrue(content [ ipmVersion, "output contains IPM version "_ipmVersion)
 
-    do $$$LogMessage("Testing locate with non-existing resource")
-    set status = ..RunCommand("locate Test.Sample.inc")
+    do $$$LogMessage("Testing locate-resource with .cls resource")
+    do ##class(%IPM.Utils.Module).BeginCaptureOutput(.cookie)
+    set status = ##class(%IPM.Main).Shell("locate-resource %IPM.Main.cls")
+    do ##class(%IPM.Utils.Module).EndCaptureOutput(cookie, .output)
+    do $$$AssertStatusOK(status, "locate-resource %IPM.Main.cls executed successfully")
+    set content = ""
+    set i = ""
+    for {
+        set i = $order(output(i))
+        quit:i=""
+        set content = content _ output(i) _ $char(10)
+    }
+    do $$$AssertTrue(content [ "zpm", "output contains module name 'zpm'")
+    do $$$AssertTrue(content [ ipmVersion, "output contains IPM version "_ipmVersion)
+
+    do $$$LogMessage("Testing locate-resource with non-existing resource")
+    set status = ..RunCommand("locate-resource Test.Sample.inc")
     do $$$AssertStatusOK(status, "Gracefully handled non-existing resource")
 
-    do $$$LogMessage("Testing locate without required argument")
-    set status = ..RunCommand("locate")
+    do $$$LogMessage("Testing locate-resource without required argument")
+    set status = ..RunCommand("locate-resource")
     do $$$AssertStatusNotOK(status, "Handled missing argument")
 }
 

--- a/tests/unit_tests/Test/PM/Unit/CLI.cls
+++ b/tests/unit_tests/Test/PM/Unit/CLI.cls
@@ -658,4 +658,23 @@ Method TestSortListVersionPrerelease()
     do $$$AssertEquals($listget(sorted(6),1), "snap", "version desc: snap (1.0.0-SNAPSHOT)")
 }
 
+Method TestLocateCommand()
+{
+    do $$$LogMessage("Testing 'loc' alias with .inc resource")
+    set status = ..RunCommand("loc %IPM.Common.inc")
+    do $$$AssertStatusOK(status, "Alias 'loc' executed successfully")
+
+    do $$$LogMessage("Testing 'locate' command with .cls resource")
+    set status = ..RunCommand("locate %IPM.Main.cls")
+    do $$$AssertStatusOK(status, "Command 'locate' executed successfully")
+
+    do $$$LogMessage("Testing locate with non-existing resource")
+    set status = ..RunCommand("locate Test.Sample.inc")
+    do $$$AssertStatusOK(status, "Gracefully handled non-existing resource")
+
+    do $$$LogMessage("Testing locate without required argument")
+    set status = ..RunCommand("locate")
+    do $$$AssertStatusNotOK(status, "Handled missing argument")
+}
+
 }


### PR DESCRIPTION
## Add `locate-resource` command to identify resource owner modules

### Description

This PR introduces the `locate-resource` command to the IPM shell. It allows developers to quickly identify which module "owns" a specific resource (Class, Routine, Include file, etc.). The `locate-resource` command provides a native CLI wrapper around the existing `FindHomeModule` logic to get the owning module and its current version in a format consistent with the `list` command.

fixes: #1073 

### Key Features

* **Alias Support:** Supports both `locate-resource`.
* **Resource Versatility:** Works with `.cls`, `.inc`, `.mac`, and other registered resource types.
* **Consistent UI:** Output matches the standard ZPM list format: `<ModuleName> <Version>`.
* **Robust Error Handling:** Validates required arguments and provides clear feedback if a resource is unmapped.

## Unit Test
A new test suite `TestLocateCommand` was added to verify the command's behavior across different scenarios.

**Unit Test Results:**

```objectscript
zpm:USER>locate-resource %IPM.Main.cls

zpm 0.10.6-SNAPSHOT
zpm:USER>locate-resource %IPM.Main.cls

zpm 0.10.6-SNAPSHOT
zpm:USER>loc Testify.Home.cls

testify 1.0.2
zpm:USER>locate-resource Test.Main.cls
Resource 'Test.Main.cls' is not currently mapped to an installed module.
zpm:USER>
```
* **Success:** `locate-resource %IPM.Common.inc` returns the correct module.
* **Success:** `locate-resource %IPM.Main.cls` returns the correct module.
* **Resilience:** Gracefully handles non-existent resources.
* **Validation:** Correctly catches missing arguments via shell validation.