### PR TITLE
feat(cli): add -outdated modifier in list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #992: Implement automatic history purge logic
 - #973: Enables CORS and JWT configuration for WebApplications in module.xml
+- #1095: add -outdated modifier in list command
 
 ### Fixed
 - #1001: The `unmap` and `enable` commands will now only activate CPF merge once after all namespaces have been configured instead after every namespace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #992: Implement automatic history purge logic
 - #973: Enables CORS and JWT configuration for WebApplications in module.xml
-- #1095: add -outdated modifier in list command
+- #1095: Add -outdated modifier in list command
 
 ### Fixed
 - #1001: The `unmap` and `enable` commands will now only activate CPF merge once after all namespaces have been configured instead after every namespace

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -526,6 +526,9 @@ reinstall -env /path/to/env1.json;/path/to/env2.json example-package
 <example description="Shows all installed Python packages.">
     list -python
 </example>
+<example description="Lists all installed modules with available updates in the registry.">
+    list -outdated
+</example>
 
 <!-- Parameters -->
 <parameter name="searchString" description="Search string, * can be used." />
@@ -538,6 +541,7 @@ reinstall -env /path/to/env1.json;/path/to/env2.json example-package
 <modifier name="showupstream" aliases="su" description="If specified, show the latest version for each module in configured repos if it's different than the local version." />
 <modifier name="repository" aliases="repo" value="true" description="If specified, only show modules installed that belong to the provided repository." />
 <modifier name="python" aliases="py" description="If specified, lists installed Embedded Python libraries instead of IPM modules." />
+<modifier name="outdated" aliases="o" description="Lists installed modules that have available updates in the registry." />
 </command>
 
 <command name="list-dependents" aliases="dependents">
@@ -2757,6 +2761,12 @@ ClassMethod ListInstalled(ByRef pCommandInfo) [ Private ]
 		do ..DisplayModules(.list,,,, .tModifiers)
 		quit
 	}
+    if $data(pCommandInfo("modifiers","outdated")) {
+        merge tModifiers = pCommandInfo("modifiers")
+        do ..GetOutdatedModulesList(.list)
+        do ..DisplayModules(.list,,,, .tModifiers)
+        quit
+    }
     if (''$data(pCommandInfo("modifiers","tree"))) {
         // Show tree of dependencies as well.
         // Modules that are dependencies for no other are shown at the top level.
@@ -2821,8 +2831,7 @@ ClassMethod GetListModule(
 {
     new $namespace
     set $namespace=ns
-    set tRes = ##class(%SQL.Statement).%ExecDirect(,
-        "select * from %IPM_Storage.ModuleItem")
+    set tRes = ##class(%SQL.Statement).%ExecDirect(, "select * from %IPM_Storage.ModuleItem")
     $$$ThrowSQLIfError(tRes.%SQLCODE,tRes.%Message)
     set in=""
     while tRes.%Next(.tSC) {
@@ -4169,6 +4178,30 @@ ClassMethod Update(ByRef pCommandInfo)
         // Call ..Install() in order to install the newer version of the module.
         do ..Install(.pCommandInfo, log)
     }
+}
+
+ClassMethod GetOutdatedModulesList(Output List)
+{
+    do ..GetListModules($namespace,,.installedModules)
+    do ..GetUpstreamPackageVersions(.serverModuleVersions)
+    set width = 0
+    for i=1:1:installedModules {
+        set moduleInfo = installedModules(i)
+        set moduleName = $listget(moduleInfo)
+        continue:moduleName="zpm"
+        set currentVersion =  $listget(moduleInfo,2)
+        if $data(serverModuleVersions(moduleName)) {
+            set reg = $order(serverModuleVersions(moduleName,""),1,versionString)
+            if currentVersion'=versionString {
+                set currentwidth = $length(moduleName)
+                set List($increment(List)) = $listbuild(moduleName,$$$FormattedLine($$$Red, currentVersion)_"  "_$$$FormattedLine($$$Green,versionString))
+                if width<currentwidth {
+                    set width = currentwidth
+                }
+            }
+        }
+    }
+    set List("width") = width
 }
 
 ClassMethod GetPythonInstalledLibs(Output list)

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -541,7 +541,7 @@ reinstall -env /path/to/env1.json;/path/to/env2.json example-package
 <modifier name="showupstream" aliases="su" description="If specified, show the latest version for each module in configured repos if it's different than the local version." />
 <modifier name="repository" aliases="repo" value="true" description="If specified, only show modules installed that belong to the provided repository." />
 <modifier name="python" aliases="py" description="If specified, lists installed Embedded Python libraries instead of IPM modules." />
-<modifier name="outdated" aliases="o" description="Lists installed modules that have available updates in the registry." />
+<modifier name="outdated" aliases="o" description="If specified, only lists installed modules that have available updates in the registry. Modules installed only as dependencies are skipped." />
 </command>
 
 <command name="list-dependents" aliases="dependents">
@@ -4182,13 +4182,31 @@ ClassMethod Update(ByRef pCommandInfo)
 
 ClassMethod GetOutdatedModulesList(Output List)
 {
-    do ..GetListModules($namespace,,.installedModules)
+    // Get the dependencies list to prevent displaying an outdated list
+    set List=""
+    set depRes = ##class(%SQL.Statement).%ExecDirect(,
+            "select ModuleItem->Name ModName,Dependencies_Name DepName,Dependencies_VersionString DepVer "_
+            "from %IPM_Storage.ModuleItem_Dependencies")
+    $$$ThrowSQLIfError(depRes.%SQLCODE, depRes.%Message)
+    while depRes.%Next(.sc) {
+        $$$ThrowOnError(sc)
+        set visitedMap($zconvert(depRes.%Get("DepName"),"l")) = 1
+    }
+    $$$ThrowOnError(sc)
+
+    do ..GetListModules($namespace, , .installedModules)
     do ..GetUpstreamPackageVersions(.serverModuleVersions)
+
     set width = 0
     for i=1:1:installedModules {
         set moduleInfo = installedModules(i)
         set moduleName = $listget(moduleInfo)
-        continue:moduleName="zpm"
+
+        // Skip processing if the module is a dependency module
+        if moduleName="zpm"||($data(visitedMap(moduleName))) {
+            continue
+        }
+
         set currentVersion =  $listget(moduleInfo,2)
         if $data(serverModuleVersions(moduleName)) {
             set reg = $order(serverModuleVersions(moduleName,""),1,versionString)

--- a/tests/unit_tests/Test/PM/Unit/CLI.cls
+++ b/tests/unit_tests/Test/PM/Unit/CLI.cls
@@ -352,4 +352,43 @@ Method TestUninstallWithoutModuleName()
     do $$$AssertNotTrue(exists, "Module removed successfully.")
 }
 
+/// Validates that the '-outdated' modifier correctly identifies and displays modules with newer registry versions
+Method TestListOutdatedModules()
+{
+    set moduleName = "irisjwt"
+    if $isobject(##class(%IPM.Storage.Module).NameOpen(moduleName)) {
+        do $$$LogMessage(moduleName_" already exist. So uninstalling the module")
+        do ..RunCommand("uninstall "_moduleName)
+    }
+
+    set status = ..RunCommand("install "_moduleName_" 1.0.0")
+    do $$$AssertStatusOK(status, moduleName_" installed at version 1.0.0")
+    do ##class(%IPM.Main).GetOutdatedModulesList(.list)
+
+    set found = 0
+    for i=1:1:list {
+        set moduleInfo = list(i)
+        set currentModuleName = $listget(moduleInfo, 1)
+        set versionString = $listget(moduleInfo, 2)
+
+        // Scrub ANSI color codes
+        set matcher = ##class(%Regex.Matcher).%New("\x1b\[[0-9;]*m", versionString)
+        set cleanString = matcher.ReplaceAll("")
+
+        set cleanString = $zstrip(cleanString, "<>W")
+        set currentVersion = $piece(cleanString, "  ", 1)
+        set serverVersion = $piece(cleanString, "  ", 2)
+        if (moduleName = currentModuleName) {
+            set found = 1
+        }
+        if currentVersion'=serverVersion {
+            do $$$AssertNotEquals(currentVersion, serverVersion, "Version mismatch detected for "_moduleName)
+            do $$$LogMessage(currentVersion_"  "_serverVersion)
+            do $$$LogMessage("Currently installed "_currentModuleName_" (local:"_currentVersion_") has a newer version available (server:"_serverVersion_")")
+        }
+    }
+    do $$$AssertTrue(found, "The module "_moduleName_" was found in the outdated list")
+    do ..RunCommand("list -o")
+}
+
 }


### PR DESCRIPTION
## Description:

Introduced the `-outdated` modifier (alias `-o`) to the `list` command to allow users to quickly identify installed modules with newer versions available in the registry.

#586

### Key Changes:

* **New Modifier:** Added `-outdated` and the short-form alias `-o` to the `list-installed` command logic.

```objectscript
zpm:USER>list -o
irisjwt 1.0.0  1.0.1
```
### CLI Documentation Update:

| Component | Text |
| --- | --- |
| **Modifier** | `-outdated, -o` |
| **Description** | Lists installed modules that have available updates in the registry. |
| **Example** | `list -outdated` |

### Testing Performed:

1. Executed `list -o` and verified that only modules with pending updates are displayed.
2. Confirmed that the output adheres to the existing project format (`Module : OldVersion NewVersion`).