### PR TITLE
Fix packaging HL7 resources

### DIFF
--- a/src/cls/IPM/ResourceProcessor/Default/Document.cls
+++ b/src/cls/IPM/ResourceProcessor/Default/Document.cls
@@ -262,6 +262,18 @@ Method OnExportItem(
             set tSC = $$Export^%apiRTN(pItemName,pFullExportPath,"Save for Source Control","WNSK\UTF8\",tExportFlags)
             set pItemHandled = 1
         }
+
+        // Edge case of .HL7 being handled as .xml but needing the file name of the document itself
+        do ##class(%RoutineMgr).UserType(pItemName, .docclass, .doctype)
+        if 'pItemHandled && (docclass = "EnsLib.HL7.SchemaDocument") && (doctype = "xml") {
+            set hl7ItemName = ""
+            do ..ResourceReference.Children.GetNext(.hl7ItemName)
+            if (hl7ItemName '= "") {
+                $$$ThrowOnError($system.OBJ.Export(hl7ItemName,pFullExportPath,tExportFlags))
+                set pItemHandled = 1
+            }
+        }
+
         write:tVerbose !,"Exporting '",pItemName,"' to '",pFullExportPath,"'"
     } catch e {
         set tSC = e.AsStatus()


### PR DESCRIPTION
This fix is related to an issue a team found when packaging HL7 resources in IPM. Specifically, the packaged version of the HL7 file in the tarball seems to be cleared out of its contents with just the Export tags present in the XML.

After some investigation, found that exporting of the HL7 resource goes based off of the file name. However, in this case, the HL7 file was imported under the document name tag specified in the xml. Using that name instead does export the file with contents.