### PR TITLE
Fix 1057: IPM cleanly uninstalls itself now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #1001: The `unmap` and `enable` commands will now only activate CPF merge once after all namespaces have been configured instead after every namespace
 - #1052: In a namespace with mapped IPM, the `info` command works again and the intro message displays the IPM version and where its mapped from
 - #1102: %IPM.Storage.QualifiedModuleInfo:%New() will now copy over version properties when passed in a resolvedReference
+- #1057: Fix IPM not cleaning up after itself on self-uninstall
 
 ## [0.10.6] - 2026-02-24
 

--- a/src/cls/IPM/CLI.cls
+++ b/src/cls/IPM/CLI.cls
@@ -981,7 +981,7 @@ ClassMethod FormatName(pName As %String) As %String
 
 ClassMethod TerminalPromptColor() As %String
 {
-    quit $case(##class(%IPM.Repo.UniversalSettings).GetValue("TerminalPrompt"),"green":$$$Green,"red":$$$Red,"magenta":$$$Magenta,"yellow":$$$Yellow,"blue":$$$Blue,"cyan":$$$Cyan,"none":$$$Default,:$$$Default)
+    quit $select(##class(%Dictionary.CompiledClass).%ExistsId("%IPM.Repo.UniversalSettings"):$case(##class(%IPM.Repo.UniversalSettings).GetValue("TerminalPrompt"),"green":$$$Green,"red":$$$Red,"magenta":$$$Magenta,"yellow":$$$Yellow,"blue":$$$Blue,"cyan":$$$Cyan,"none":$$$Default,:$$$Default),1:$$$Default)
 }
 
 }

--- a/src/cls/IPM/General/HistoryTemp.cls
+++ b/src/cls/IPM/General/HistoryTemp.cls
@@ -28,29 +28,32 @@ ClassMethod Init(
 /// Persist this more permanently by saving to the PersistedTwin
 Method %OnClose() As %Status [ Private, ServerOnly = 1 ]
 {
-    if ..PersistedTwin '= "" {
-        // copy all values to the Persisted Twin
-        set ..PersistedTwin.TimeStart = ..TimeStart
-        set ..PersistedTwin.TimeEnd = ..TimeEnd
-        set ..PersistedTwin.Action = ..Action
-        set ..PersistedTwin.Package = ..Package
-        set ..PersistedTwin.CommandString = ..CommandString
-        set ..PersistedTwin.UserName = ..UserName
-        set ..PersistedTwin.Version = ..Version
-        set ..PersistedTwin.SourceName = ..SourceName
-        set ..PersistedTwin.SourceMoniker = ..SourceMoniker
-        set ..PersistedTwin.SourceDetails = ..SourceDetails
-        set ..PersistedTwin.Success = ..Success
-        set ..PersistedTwin.Committed = ..Committed
-        set ..PersistedTwin.Phases = ..Phases
-        // Mark as finalized and record should be locked
-        set ..PersistedTwin.Finalized = 1
-    }
-    // Ensure the persisted twin is saved
-    set sc = ..%Save()
+    set sc = $$$OK
+    if $$$comClassDefined("%IPM.General.History") {
+        if (..PersistedTwin '= "") {
+            // copy all values to the Persisted Twin
+            set ..PersistedTwin.TimeStart = ..TimeStart
+            set ..PersistedTwin.TimeEnd = ..TimeEnd
+            set ..PersistedTwin.Action = ..Action
+            set ..PersistedTwin.Package = ..Package
+            set ..PersistedTwin.CommandString = ..CommandString
+            set ..PersistedTwin.UserName = ..UserName
+            set ..PersistedTwin.Version = ..Version
+            set ..PersistedTwin.SourceName = ..SourceName
+            set ..PersistedTwin.SourceMoniker = ..SourceMoniker
+            set ..PersistedTwin.SourceDetails = ..SourceDetails
+            set ..PersistedTwin.Success = ..Success
+            set ..PersistedTwin.Committed = ..Committed
+            set ..PersistedTwin.Phases = ..Phases
+            // Mark as finalized and record should be locked
+            set ..PersistedTwin.Finalized = 1
+        }
+        // Ensure the persisted twin is saved
+        set sc = ..%Save()
 
-    // Delete this temp entry as it's no longer needed
-    set sc = $$$ADDSC(sc, ..%DeleteId(..%Id()))
+        // Delete this temp entry as it's no longer needed
+        set sc = $$$ADDSC(sc, ..%DeleteId(..%Id()))
+    }
     quit sc
 }
 

--- a/src/cls/IPM/General/HistoryTemp.cls
+++ b/src/cls/IPM/General/HistoryTemp.cls
@@ -25,12 +25,16 @@ ClassMethod Init(
     quit log
 }
 
-/// Persist this more permanently by saving to the PersistedTwin
-Method %OnClose() As %Status [ Private, ServerOnly = 1 ]
+/// Explicitly persist current state to the PersistedTwin
+/// Can be called before classes are deleted during self-uninstall
+Method PersistToTwin() As %Status
 {
     set sc = $$$OK
     if $$$comClassDefined("%IPM.General.History") {
         if (..PersistedTwin '= "") {
+            // Reload to get latest state
+            $$$ThrowOnError(..%Reload())
+
             // copy all values to the Persisted Twin
             set ..PersistedTwin.TimeStart = ..TimeStart
             set ..PersistedTwin.TimeEnd = ..TimeEnd
@@ -47,9 +51,21 @@ Method %OnClose() As %Status [ Private, ServerOnly = 1 ]
             set ..PersistedTwin.Phases = ..Phases
             // Mark as finalized and record should be locked
             set ..PersistedTwin.Finalized = 1
+            // Save the persisted twin
+            set sc = ..PersistedTwin.%Save()
+            set sc = ..%Save()
         }
-        // Ensure the persisted twin is saved
-        set sc = ..%Save()
+    }
+    quit sc
+}
+
+/// Persist this more permanently by saving to the PersistedTwin
+Method %OnClose() As %Status [ Private, ServerOnly = 1 ]
+{
+    set sc = $$$OK
+    if $$$comClassDefined("%IPM.General.History") {
+        // Persist to twin if not already done
+        set sc = ..PersistToTwin()
 
         // Delete this temp entry as it's no longer needed
         set sc = $$$ADDSC(sc, ..%DeleteId(..%Id()))

--- a/src/cls/IPM/General/HistoryTemp.cls
+++ b/src/cls/IPM/General/HistoryTemp.cls
@@ -51,8 +51,6 @@ Method PersistToTwin() As %Status
             set ..PersistedTwin.Phases = ..Phases
             // Mark as finalized and record should be locked
             set ..PersistedTwin.Finalized = 1
-            // Save the persisted twin
-            set sc = ..PersistedTwin.%Save()
             set sc = ..%Save()
         }
     }

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -290,26 +290,6 @@ Method CheckBeforeClean(
                 set pSkip = 1
                 quit
             }
-            // Special check for IPM self-uninstall: block if other modules are installed
-            if (..Module.Name = $$$IPMModuleName) {
-                // Check if other modules are installed
-                set tStmt = ##class(%SQL.Statement).%New()
-                set tSC = tStmt.%Prepare("SELECT COUNT(*) As ModCount FROM %IPM_Storage.ModuleItem WHERE Name != ?")
-                $$$ThrowOnError(tSC)
-                set tRS = tStmt.%Execute($$$IPMModuleName)
-                if tRS.%Next() {
-                    set tCount = tRS.ModCount
-                    if (tCount > 0) {
-                        write !,"Cannot uninstall IPM: ",tCount," module(s) still installed."
-                        write !,"Run 'uninstall -all' first, or use 'uninstall zpm -force' to bypass this check."
-                        write !,"Warning: Using -force will orphan installed modules."
-                        set pSkip = 1
-                        // Unmark the self-uninstall flag since uninstall won't proceed
-                        set $$$IPMSelfUninstallFlag = 0
-                        quit
-                    }
-                }
-            }
         }
     } catch e {
         set tSC = e.AsStatus()

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -487,9 +487,12 @@ Method %Clean(ByRef pParams) As %Status
         }
 
         if (tLevel > 0) && '$get(pParams("Clean","Nested"),0) {
-            set tSC = ##class(%IPM.StudioDocument.Module).Delete(..Module.Name_".ZPM")
-            if $$$ISERR(tSC) {
-                quit
+            // Check if StudioDocument.Module class still exists before trying to delete
+            if $$$comClassDefined("%IPM.StudioDocument.Module") {
+                set tSC = ##class(%IPM.StudioDocument.Module).Delete(..Module.Name_".ZPM")
+                if $$$ISERR(tSC) {
+                    quit
+                }
             }
         }
     } catch e {

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -262,6 +262,7 @@ Method CheckBeforeClean(
         set tVerbose = $get(pParams("Verbose"))
         set tLevel = $get(pParams("Clean","Level"),0)
         set tRecurse = $get(pParams("Clean","Recurse"),1)
+        set tForce = $get(pParams("Clean","Force"),0)
 
         if (..Module.GlobalScope && '$get(pParams("Clean","GlobalScope"))) {
             do ..Log("Clean SKIPPED - module has global scope.")
@@ -269,7 +270,7 @@ Method CheckBeforeClean(
             quit
         }
 
-        if '$get(pParams("Clean","Force")) {
+        if 'tForce {
             // Check to see if anything depends on this module and return an error status if it does.
             set tSC = ##class(%IPM.Utils.Module).GetDependentsList(.tList,,..Module.Name)
             if $$$ISERR(tSC) {
@@ -288,6 +289,26 @@ Method CheckBeforeClean(
                 do ..Log("Clean SKIPPED - required by " _ $listlength(tModList) _ " other module" _ $case($listlength(tModList),1:"",:"s") _ ". (" _ $listtostring(tModList,"; ") _ ")")
                 set pSkip = 1
                 quit
+            }
+            // Special check for IPM self-uninstall: block if other modules are installed
+            if (..Module.Name = $$$IPMModuleName) {
+                // Check if other modules are installed
+                set tStmt = ##class(%SQL.Statement).%New()
+                set tSC = tStmt.%Prepare("SELECT COUNT(*) As ModCount FROM %IPM_Storage.ModuleItem WHERE Name != ?")
+                $$$ThrowOnError(tSC)
+                set tRS = tStmt.%Execute($$$IPMModuleName)
+                if tRS.%Next() {
+                    set tCount = tRS.ModCount
+                    if (tCount > 0) {
+                        write !,"Cannot uninstall IPM: ",tCount," module(s) still installed."
+                        write !,"Run 'uninstall -all' first, or use 'uninstall zpm -force' to bypass this check."
+                        write !,"Warning: Using -force will orphan installed modules."
+                        set pSkip = 1
+                        // Unmark the self-uninstall flag since uninstall won't proceed
+                        set $$$IPMSelfUninstallFlag = 0
+                        quit
+                    }
+                }
             }
         }
     } catch e {

--- a/src/cls/IPM/Lifecycle/Module.cls
+++ b/src/cls/IPM/Lifecycle/Module.cls
@@ -26,70 +26,67 @@ Method %Clean(ByRef pParams) As %Status
 
         // Special handling for IPM self-uninstall: clean up operational globals
         if (..Module.Name = $$$IPMModuleName) {
-            set tVerbose = $get(pParams("Verbose"))
+            set verbose = $get(pParams("Verbose"))
 
-            // Check if modules were orphaned (user used -force)
-            // IPM is always at index 1, so start checking at index 2
-            set tOrphanedModules = ""
-            set tIndex = 1
-            for {
-                set tIndex = $order(^IPM.Storage.ModuleD(tIndex))
-                quit:tIndex=""
-                set tOrphanedModules = tOrphanedModules _ $listbuild(tIndex)
-            }
+            // Check if user wants full cleanup
+            set fullCleanup = $get(pParams("Clean","FullCleanup"), 0)
 
-            if $listlength(tOrphanedModules) > 0 {
-                // Modules were orphaned - warn user but still clean up
-                write !,"Warning: ",$listlength(tOrphanedModules)," module(s) orphaned:"
+            if fullCleanup {
+                // Full cleanup: delete ALL module records and operational globals
+                write !,"Performing full cleanup of IPM operational globals..."
 
-                // List orphaned modules with versions
-                set tPtr = 0
-                while $listnext(tOrphanedModules, tPtr, tIndex) {
-                    try {
-                        set tModData = ^IPM.Storage.ModuleD(tIndex)
-                        set tModName = $listget(tModData, 2)
-                        set tVersion = $listget(tModData, 4)
-                        write !,"  - ",tModName," (",tVersion,")"
-                    } catch {
-                        write !,"  - (unknown module at index ",tIndex,")"
-                    }
+                kill ^IPM.Storage.ModuleD          // Delete ALL module records (including orphans)
+                kill ^IPM.Storage.ModuleI
+                kill ^IPM.Storage.InvokeReferenceC
+                kill ^IPM.Storage.ResourceReferenceC
+                kill ^IPM.Storage.ResourceReferenceI
+                kill ^IPM.Storage.SystemRequirementsD
+                kill ^IPM.Repo.DefinitionD
+                kill ^IPM.Repo.DefinitionI
+                kill ^IPM.Repo.Filesystem.CacheD
+                kill ^IPM.General.SettingsD
+                kill ^IPM.UpdateStep.AnyMemberD
+                kill ^IPM.UpdateStep.PrimaryOnlyD
+                kill ^IPM.StudioDoc.ModuleStreamD
+                kill ^IPM.StudioDoc.ModuleStreamI
+                kill ^IPM.StudioDoc.ModuleStreamS
+                kill ^IPM.StudioDoc.LocalMsgStreamD
+                kill ^IRIS.Temp.HistoryTempD
+                kill ^IRIS.Temp.IPM.LoadedResourceD
+
+                // Note: Preserve ^IPM.General.HistoryD for audit trail
+                // Note: Preserve ^IPM.settings in %SYS for user preferences
+
+                write:verbose !,"Full cleanup complete: All module records deleted."
+            } else {
+                // Check if modules were orphaned (user used -force)
+                // IPM is always at index 1, so start checking at index 2
+                set tOrphanedModules = ""
+                set tIndex = 1
+                for {
+                    set tIndex = $order(^IPM.Storage.ModuleD(tIndex))
+                    quit:tIndex=""
+                    set tOrphanedModules = tOrphanedModules _ $listbuild(tIndex)
                 }
 
-                write !,"Module classes remain but are no longer managed by IPM."
-                write !,"Recovery options:"
-                write !,"  1. Delete orphaned classes: Do $system.OBJ.DeletePackage([package])"
-                write !,"  2. Reinstall IPM, then reinstall modules from registry"
-            }
+                if $listlength(tOrphanedModules) > 0 {
+                    // Modules were orphaned - warn user but still clean up
+                    write !,"Warning: ",$listlength(tOrphanedModules)," module(s) orphaned:"
 
-            // Always clean up operational globals (whether orphaned or not)
-            if tVerbose {
-                write !,"Cleaning up IPM operational globals..."
-            }
-
-            kill ^IPM.Storage.ModuleD          // Delete ALL module records (including orphans)
-            kill ^IPM.Storage.ModuleI
-            kill ^IPM.Storage.InvokeReferenceC
-            kill ^IPM.Storage.ResourceReferenceC
-            kill ^IPM.Storage.ResourceReferenceI
-            kill ^IPM.Storage.SystemRequirementsD
-            kill ^IPM.Repo.DefinitionD
-            kill ^IPM.Repo.DefinitionI
-            kill ^IPM.Repo.Filesystem.CacheD
-            kill ^IPM.General.SettingsD
-            kill ^IPM.UpdateStep.AnyMemberD
-            kill ^IPM.UpdateStep.PrimaryOnlyD
-            kill ^IPM.StudioDoc.ModuleStreamD
-            kill ^IPM.StudioDoc.ModuleStreamI
-            kill ^IPM.StudioDoc.ModuleStreamS
-            kill ^IPM.StudioDoc.LocalMsgStreamD
-            kill ^IRIS.Temp.HistoryTempD
-            kill ^IRIS.Temp.IPM.LoadedResourceD
-
-            // Note: Preserve ^IPM.General.HistoryD for audit trail
-            // Note: Preserve ^IPM.settings in %SYS for user preferences
-
-            if tVerbose {
-                write !,"IPM operational globals cleaned up (history and settings preserved)."
+                    // List orphaned modules with versions
+                    set tPtr = 0
+                    while $listnext(tOrphanedModules, tPtr, tIndex) {
+                        try {
+                            set tModData = ^IPM.Storage.ModuleD(tIndex)
+                            set tModName = $listget(tModData, 2)
+                            set tVersion = $listget(tModData, 4)
+                            write !,"  - ",tModName," (",tVersion,")"
+                        } catch {
+                            write !,"  - (unknown module at index ",tIndex,")"
+                        }
+                    }
+                    write !,"Reinstalling IPM will automatically re-adopt these modules."
+                }
             }
         }
     } catch e {

--- a/src/cls/IPM/Lifecycle/Module.cls
+++ b/src/cls/IPM/Lifecycle/Module.cls
@@ -23,6 +23,75 @@ Method %Clean(ByRef pParams) As %Status
         if $$$ISERR(tSC) {
             quit
         }
+
+        // Special handling for IPM self-uninstall: clean up operational globals
+        if (..Module.Name = $$$IPMModuleName) {
+            set tVerbose = $get(pParams("Verbose"))
+
+            // Check if modules were orphaned (user used -force)
+            // IPM is always at index 1, so start checking at index 2
+            set tOrphanedModules = ""
+            set tIndex = 1
+            for {
+                set tIndex = $order(^IPM.Storage.ModuleD(tIndex))
+                quit:tIndex=""
+                set tOrphanedModules = tOrphanedModules _ $listbuild(tIndex)
+            }
+
+            if $listlength(tOrphanedModules) > 0 {
+                // Modules were orphaned - warn user but still clean up
+                write !,"Warning: ",$listlength(tOrphanedModules)," module(s) orphaned:"
+
+                // List orphaned modules with versions
+                set tPtr = 0
+                while $listnext(tOrphanedModules, tPtr, tIndex) {
+                    try {
+                        set tModData = ^IPM.Storage.ModuleD(tIndex)
+                        set tModName = $listget(tModData, 2)
+                        set tVersion = $listget(tModData, 4)
+                        write !,"  - ",tModName," (",tVersion,")"
+                    } catch {
+                        write !,"  - (unknown module at index ",tIndex,")"
+                    }
+                }
+
+                write !,"Module classes remain but are no longer managed by IPM."
+                write !,"Recovery options:"
+                write !,"  1. Delete orphaned classes: Do $system.OBJ.DeletePackage([package])"
+                write !,"  2. Reinstall IPM, then reinstall modules from registry"
+            }
+
+            // Always clean up operational globals (whether orphaned or not)
+            if tVerbose {
+                write !,"Cleaning up IPM operational globals..."
+            }
+
+            kill ^IPM.Storage.ModuleD          // Delete ALL module records (including orphans)
+            kill ^IPM.Storage.ModuleI
+            kill ^IPM.Storage.InvokeReferenceC
+            kill ^IPM.Storage.ResourceReferenceC
+            kill ^IPM.Storage.ResourceReferenceI
+            kill ^IPM.Storage.SystemRequirementsD
+            kill ^IPM.Repo.DefinitionD
+            kill ^IPM.Repo.DefinitionI
+            kill ^IPM.Repo.Filesystem.CacheD
+            kill ^IPM.General.SettingsD
+            kill ^IPM.UpdateStep.AnyMemberD
+            kill ^IPM.UpdateStep.PrimaryOnlyD
+            kill ^IPM.StudioDoc.ModuleStreamD
+            kill ^IPM.StudioDoc.ModuleStreamI
+            kill ^IPM.StudioDoc.ModuleStreamS
+            kill ^IPM.StudioDoc.LocalMsgStreamD
+            kill ^IRIS.Temp.HistoryTempD
+            kill ^IRIS.Temp.IPM.LoadedResourceD
+
+            // Note: Preserve ^IPM.General.HistoryD for audit trail
+            // Note: Preserve ^IPM.settings in %SYS for user preferences
+
+            if tVerbose {
+                write !,"IPM operational globals cleaned up (history and settings preserved)."
+            }
+        }
     } catch e {
         set tSC = e.AsStatus()
     }

--- a/src/cls/IPM/Lifecycle/Module.cls
+++ b/src/cls/IPM/Lifecycle/Module.cls
@@ -28,12 +28,9 @@ Method %Clean(ByRef pParams) As %Status
         if (..Module.Name = $$$IPMModuleName) {
             set verbose = $get(pParams("Verbose"))
 
-            // Check if user wants full cleanup
-            set fullCleanup = $get(pParams("Clean","FullCleanup"), 0)
-
-            if fullCleanup {
-                // Full cleanup: delete ALL module records and operational globals
-                write !,"Performing full cleanup of IPM operational globals..."
+            // Check if user wants full cleanup (delete ALL module records and operational globals)
+            if $get(pParams("Clean","FullCleanup"), 0) {
+                write:verbose !,"Performing cleanup of IPM globals..."
 
                 kill ^IPM.Storage.ModuleD          // Delete ALL module records (including orphans)
                 kill ^IPM.Storage.ModuleI
@@ -57,32 +54,32 @@ Method %Clean(ByRef pParams) As %Status
                 // Note: Preserve ^IPM.General.HistoryD for audit trail
                 // Note: Preserve ^IPM.settings in %SYS for user preferences
 
-                write:verbose !,"Full cleanup complete: All module records deleted."
+                write:verbose !,"Cleanup complete."
             } else {
-                // Check if modules were orphaned (user used -force)
+                // Check if modules were orphaned
                 // IPM is always at index 1, so start checking at index 2
-                set tOrphanedModules = ""
-                set tIndex = 1
+                set orphanedModules = ""
+                set index = 1
                 for {
-                    set tIndex = $order(^IPM.Storage.ModuleD(tIndex))
-                    quit:tIndex=""
-                    set tOrphanedModules = tOrphanedModules _ $listbuild(tIndex)
+                    set index = $order(^IPM.Storage.ModuleD(index))
+                    quit:index=""
+                    set orphanedModules = orphanedModules _ $listbuild(index)
                 }
 
-                if $listlength(tOrphanedModules) > 0 {
+                if $listlength(orphanedModules) > 0 {
                     // Modules were orphaned - warn user but still clean up
-                    write !,"Warning: ",$listlength(tOrphanedModules)," module(s) orphaned:"
+                    write !,"Warning: ",$listlength(orphanedModules)," module(s) orphaned:"
 
                     // List orphaned modules with versions
-                    set tPtr = 0
-                    while $listnext(tOrphanedModules, tPtr, tIndex) {
+                    set ptr = 0
+                    while $listnext(orphanedModules, ptr, index) {
                         try {
-                            set tModData = ^IPM.Storage.ModuleD(tIndex)
-                            set tModName = $listget(tModData, 2)
-                            set tVersion = $listget(tModData, 4)
-                            write !,"  - ",tModName," (",tVersion,")"
+                            set modData = ^IPM.Storage.ModuleD(index)
+                            set modName = $listget(modData, 2)
+                            set version = $listget(modData, 4)
+                            write !,"  - ",modName," (",version,")"
                         } catch {
-                            write !,"  - (unknown module at index ",tIndex,")"
+                            write !,"  - (unknown module at index ",index,")"
                         }
                     }
                     write !,"Reinstalling IPM will automatically re-adopt these modules."

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2559,6 +2559,38 @@ ClassMethod Uninstall(ByRef pCommandInfo) [ Internal ]
         }
         if (tModuleName = $$$IPMModuleName) {
             $$$ThrowOnError(..CheckModuleNamespace())
+
+            // Check if other modules are installed
+            set tHasModules = 0
+            set rs = ##class(%SQL.Statement).%ExecDirect(,
+                "SELECT Name, VersionString FROM %IPM_Storage.ModuleItem WHERE Name != ?",
+                $$$IPMModuleName)
+            if rs.%Next() {
+                set tHasModules = 1
+
+                // Show list of installed modules
+                write !,"The following modules are currently installed:"
+                write !,"  - ",rs.Name," (",rs.VersionString,")"
+                while rs.%Next() {
+                    write !,"  - ",rs.Name," (",rs.VersionString,")"
+                }
+                write !
+
+                if 'tForce {
+                    // Dialog: Ask about full cleanup (downgrade scenario)
+                    write !,"Do you want to fully remove all modules and IPM metadata (except history)?"
+                    write !,"This is required for downgrading IPM. [y/N]: "
+                    read fullCleanupResponse
+                    set tParams("Clean","FullCleanup") = $case($zconvert(fullCleanupResponse,"L"),"y":1,"yes":1,:0)
+                }
+            }
+
+            if tParams("Clean","FullCleanup") {
+                // User chose full cleanup - uninstall all modules
+                write !,"Performing full cleanup: uninstalling all modules..."
+                $$$ThrowOnError(##class(%IPM.Utils.Module).UninstallAll(tForce,.tParams))
+            }
+
             // Set flag to indicate self-uninstall - will be checked by Interactive() loop
             set $$$IPMSelfUninstallFlag = 1
         }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1090,6 +1090,14 @@ ClassMethod ShellInternal(
             }
             do ..DisplayError(pException.AsStatus())
         }
+
+        // Check if IPM has uninstalled itself - exit gracefully if so
+        if $get($$$IPMSelfUninstallFlag, 0) {
+            write !,!,$$$FormattedLine($$$Yellow, "IPM has been uninstalled from this namespace. Exiting shell...")
+            write !
+            return
+        }
+
         set tCommand = ""
         if tOneCommand {
             quit
@@ -2551,6 +2559,8 @@ ClassMethod Uninstall(ByRef pCommandInfo) [ Internal ]
         }
         if (tModuleName = $$$IPMModuleName) {
             $$$ThrowOnError(..CheckModuleNamespace())
+            // Set flag to indicate self-uninstall - will be checked by Interactive() loop
+            set $$$IPMSelfUninstallFlag = 1
         }
         set tRecurse = $$$HasModifier(pCommandInfo,"recurse") // Recursively uninstall unneeded dependencies
         $$$ThrowOnError(##class(%IPM.Storage.Module).Uninstall(tModuleName,tForce,tRecurse,.tParams))

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -3259,10 +3259,11 @@ ZPM(pArgs...)
     // TODO: Needs to support enabling IPM from here, also need to decide what level of customization to provide
     set quitOnError = $get(pArgs(2))
     set haltOnComplete = $get(pArgs(3))
-    write !, "IPM is not enabled in this namespace."
+    set currentNs = $namespace
     set rs = ##class(%SQL.Statement).%ExecDirect(, "SELECT Nsp FROM %SYS.Namespace_List()")
     if rs.%SQLCODE '= 0 {
-        write !, "Error getting namespace name. SQLCODE =", rs.%SQLCODE
+        write !, "Error getting namespace list. SQLCODE =", rs.%SQLCODE
+        write !, "IPM is not enabled in namespace ", currentNs, "."
     } else {
         new $namespace
         set found = 0
@@ -3270,17 +3271,17 @@ ZPM(pArgs...)
             set $namespace = $zstrip(rs.%Get("Nsp"), "<>WC")
             // Some I4H containers come with %IPM.Main but the "version" command doesn't work ?!
             if $system.CLS.IsMthd("%IPM.Main", "Shell") && ($namespace '= "HSLIB") && ($namespace '= "HSSYS") {
-                write !, "Change namespace to one of the following to run the ""zpm"" command"
+                write !, "IPM is not enabled in namespace ", currentNs, ". Switch to one of the following namespaces to use IPM:"
                 do ##class(%IPM.Main).Shell("version")
-                write !, "If you want to map IPM globally, switch to one of the namespaces above and run: zpm ""enable -map -globally""."
-                write !, "If you want to reset repository and map IPM globally along with repository settings, switch to one of the namespaces above and run: zpm ""enable -community""."
+                write !, "To map IPM globally, switch to one of the namespaces above and run: zpm ""enable -map -globally""."
+                write !, "To reset repository and map IPM globally with repository settings, run: zpm ""enable -community""."
                 set found = 1
                 quit
             }
         }
         // Shouldn't happen since %ZLANGC00.mac and %ZLANGF00.mac are present
         if 'found {
-            write !, "No namespace found with IPM enabled."
+            write !, "IPM is not installed. No namespace found with IPM enabled."
         }
     }
 

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1092,9 +1092,8 @@ ClassMethod ShellInternal(
         }
 
         // Check if IPM has uninstalled itself - exit gracefully if so
-        if $get($$$IPMSelfUninstallFlag, 0) {
-            write !,!,$$$FormattedLine($$$Yellow, "IPM has been uninstalled from this namespace. Exiting shell...")
-            write !
+        if $get(^||%IPM.SelfUninstallFlag, 0) {
+            write !,!,$$$FormattedLine($$$Yellow, "IPM has been uninstalled from this namespace. Exiting shell..."),!
             return
         }
 
@@ -2561,12 +2560,12 @@ ClassMethod Uninstall(ByRef pCommandInfo) [ Internal ]
             $$$ThrowOnError(..CheckModuleNamespace())
 
             // Check if other modules are installed
-            set tHasModules = 0
+            set hasModules = 0
             set rs = ##class(%SQL.Statement).%ExecDirect(,
                 "SELECT Name, VersionString FROM %IPM_Storage.ModuleItem WHERE Name != ?",
                 $$$IPMModuleName)
             if rs.%Next() {
-                set tHasModules = 1
+                set hasModules = 1
 
                 // Show list of installed modules
                 write !,"The following modules are currently installed:"
@@ -2578,21 +2577,21 @@ ClassMethod Uninstall(ByRef pCommandInfo) [ Internal ]
 
                 if 'tForce {
                     // Dialog: Ask about full cleanup (downgrade scenario)
-                    write !,"Do you want to fully remove all modules and IPM metadata (except history)?"
+                    write !,"Do you want to fully remove all modules and IPM metadata (except history log)?"
                     write !,"This is required for downgrading IPM. [y/N]: "
                     read fullCleanupResponse
                     set tParams("Clean","FullCleanup") = $case($zconvert(fullCleanupResponse,"L"),"y":1,"yes":1,:0)
                 }
             }
 
-            if tParams("Clean","FullCleanup") {
+            if $get(tParams("Clean","FullCleanup")) {
                 // User chose full cleanup - uninstall all modules
                 write !,"Performing full cleanup: uninstalling all modules..."
                 $$$ThrowOnError(##class(%IPM.Utils.Module).UninstallAll(tForce,.tParams))
             }
 
             // Set flag to indicate self-uninstall - will be checked by Interactive() loop
-            set $$$IPMSelfUninstallFlag = 1
+            set ^||%IPM.SelfUninstallFlag = 1
         }
         set tRecurse = $$$HasModifier(pCommandInfo,"recurse") // Recursively uninstall unneeded dependencies
         $$$ThrowOnError(##class(%IPM.Storage.Module).Uninstall(tModuleName,tForce,tRecurse,.tParams))

--- a/src/cls/IPM/ResourceProcessor/PythonWheel.cls
+++ b/src/cls/IPM/ResourceProcessor/PythonWheel.cls
@@ -18,6 +18,14 @@ Method OnPhase(
 	ByRef pParams,
 	Output pResourceHandled As %Boolean = 0) As %Status
 {
+    if (pPhase = "Clean") {
+        // Mark as handled to prevent fallback to generic cleanup
+        // which tries to delete wheels as Studio documents
+        // TODO: actually cleanup the python wheel. This is non-trivial because we don't want to delete the wheel if it's shared with other modules
+        set pResourceHandled = 1
+        quit $$$OK
+    }
+
     if (pPhase '= "Initialize") {
         set pResourceHandled = 0
         quit $$$OK

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -624,11 +624,31 @@ ClassMethod ExecutePhases(
                     // Lifecycle before / (phase) / after
                     new $$$DeployedProjectInstalled
                     $$$ThrowOnError(tLifecycle.OnBeforePhase(tOnePhase,.pParams))
+
+                    // Self-uninstall: Finalize history BEFORE Clean deletes IPM's own classes
+                    set tIsSelfUninstall = (tOnePhase = "Clean") && (tModule.Name = $$$IPMModuleName)
+                    if tIsSelfUninstall && $isobject(pLog) {
+                        // Log the Clean phase completion and finalize NOW, before classes are deleted
+                        do pLog.FinalizePhase(tOnePhase, $$$OK)
+                        set tSC = pLog.Finalize($$$OK, 0)
+                        $$$ThrowOnError(tSC)
+                        // Explicitly persist to twin while History classes still exist
+                        $$$ThrowOnError(pLog.PersistToTwin())
+                        // Delete the temp record immediately to prevent %OnClose() from trying to reload it later
+                        $$$ThrowOnError(pLog.%DeleteId(pLog.%Id()))
+                        // Clear the log object reference so it's not used again
+                        set pLog = ""
+                    }
+
                     $$$ThrowOnError($method(tLifecycle,"%"_tOnePhase,.pParams))
 
                     // Self-uninstall: After Clean deletes IPM's own classes, skip all post-phase callbacks
-                    // All the callback code has been deleted, so attempting to call it would fail
-                    if (tOnePhase = "Clean") && (tModule.Name = $$$IPMModuleName) {
+                    if tIsSelfUninstall {
+                        // Print success message before skipping
+                        write !,"["_$namespace_"|"_tModule.DisplayName_"]",$char(9),tOnePhase," SUCCESS"
+                        if tTiming {
+                            write " ("_($zhorolog-tStart)_" s)"
+                        }
                         // Skip all post-phase processing - classes have been deleted
                         continue
                     }
@@ -725,7 +745,14 @@ ClassMethod Uninstall(
         set tSC = e.AsStatus()
     }
 	set devMode = $get(pParams("DeveloperMode", 0))
-	set tSC = $$$ADDSC(tSC, log.Finalize(tSC, devMode))
+	// Only finalize if log wasn't already finalized and deleted (e.g., during self-uninstall)
+	if $isobject(log) {
+		try {
+			set tSC = $$$ADDSC(tSC, log.Finalize(tSC, devMode))
+		} catch {
+			// Skip if log was already deleted during self-uninstall
+		}
+	}
     quit tSC
 }
 

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -625,6 +625,14 @@ ClassMethod ExecutePhases(
                     new $$$DeployedProjectInstalled
                     $$$ThrowOnError(tLifecycle.OnBeforePhase(tOnePhase,.pParams))
                     $$$ThrowOnError($method(tLifecycle,"%"_tOnePhase,.pParams))
+
+                    // Self-uninstall: After Clean deletes IPM's own classes, skip all post-phase callbacks
+                    // All the callback code has been deleted, so attempting to call it would fail
+                    if (tOnePhase = "Clean") && (tModule.Name = $$$IPMModuleName) {
+                        // Skip all post-phase processing - classes have been deleted
+                        continue
+                    }
+
                     $$$ThrowOnError(tLifecycle.OnAfterPhase(tOnePhase,.pParams))
                 }
 

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -625,10 +625,10 @@ ClassMethod ExecutePhases(
                     new $$$DeployedProjectInstalled
                     $$$ThrowOnError(tLifecycle.OnBeforePhase(tOnePhase,.pParams))
 
-                    // Self-uninstall: Finalize history BEFORE Clean deletes IPM's own classes
-                    set tIsSelfUninstall = (tOnePhase = "Clean") && (tModule.Name = $$$IPMModuleName)
-                    if tIsSelfUninstall && $isobject(pLog) {
-                        // Log the Clean phase completion and finalize NOW, before classes are deleted
+                    // Self-uninstall: Finalize history before Clean phase deletes IPM's own classes
+                    set isSelfUninstall = (tOnePhase = "Clean") && (tModule.Name = $$$IPMModuleName)
+                    if isSelfUninstall && $isobject(pLog) {
+                        // Log the Clean phase completion and finalize now
                         do pLog.FinalizePhase(tOnePhase, $$$OK)
                         set tSC = pLog.Finalize($$$OK, 0)
                         $$$ThrowOnError(tSC)
@@ -643,7 +643,7 @@ ClassMethod ExecutePhases(
                     $$$ThrowOnError($method(tLifecycle,"%"_tOnePhase,.pParams))
 
                     // Self-uninstall: After Clean deletes IPM's own classes, skip all post-phase callbacks
-                    if tIsSelfUninstall {
+                    if isSelfUninstall {
                         // Print success message before skipping
                         write !,"["_$namespace_"|"_tModule.DisplayName_"]",$char(9),tOnePhase," SUCCESS"
                         if tTiming {
@@ -659,12 +659,12 @@ ClassMethod ExecutePhases(
                 #; Call Invoke Methods After Phase
                 set tKey = ""
                 for {
-                set tInvoke = tModule.Invokes.GetNext(.tKey)
-                if (tKey = "") || '$isobject(tInvoke) {
-                    quit // '$IsObject can happen reasonably after namespace changes
-                }
-                set tSC = tInvoke.OnAfterPhase(tOnePhase,.pParams)
-                quit:$$$ISERR(tSC)
+                    set tInvoke = tModule.Invokes.GetNext(.tKey)
+                    if (tKey = "") || '$isobject(tInvoke) {
+                        quit // '$IsObject can happen reasonably after namespace changes
+                    }
+                    set tSC = tInvoke.OnAfterPhase(tOnePhase,.pParams)
+                    quit:$$$ISERR(tSC)
                 }
                 quit:$$$ISERR(tSC)
 

--- a/src/inc/IPM/Common.inc
+++ b/src/inc/IPM/Common.inc
@@ -90,10 +90,6 @@ ROUTINE %IPM.Common [Type=INC]
 #;            %IPMDeployedProjectInstalled("/path/to/second/Deployed.xml") = ""
 #Define DeployedProjectInstalled %IPMDeployedProjectInstalled
 
-#; Variable to indicate IPM has uninstalled itself
-#; Set during zpm uninstall, checked by Interactive() shell loop
-#define IPMSelfUninstallFlag %IPMSelfUninstallFlag
-
 #Define DeployedProjectIndex "%Export","DeployedProject"
 
 #; Locking for module update framework

--- a/src/inc/IPM/Common.inc
+++ b/src/inc/IPM/Common.inc
@@ -90,6 +90,10 @@ ROUTINE %IPM.Common [Type=INC]
 #;            %IPMDeployedProjectInstalled("/path/to/second/Deployed.xml") = ""
 #Define DeployedProjectInstalled %IPMDeployedProjectInstalled
 
+#; Variable to indicate IPM has uninstalled itself
+#; Set during zpm uninstall, checked by Interactive() shell loop
+#define IPMSelfUninstallFlag %IPMSelfUninstallFlag
+
 #Define DeployedProjectIndex "%Export","DeployedProject"
 
 #; Locking for module update framework

--- a/src/inc/IPM/Formatting.inc
+++ b/src/inc/IPM/Formatting.inc
@@ -1,7 +1,8 @@
 ROUTINE %IPM.Formatting [Type=INC]
 #; Contains utility macros for formatting lines printed to Terminal
 
-#define ColorScheme $Case(##class(%IPM.Repo.UniversalSettings).GetValue("ColorScheme"),"none":0,:1)
+#define ColorScheme $Select(##class(%Dictionary.CompiledClass).%ExistsId("%IPM.Repo.UniversalSettings"):##class(%IPM.Repo.UniversalSettings).GetValue("ColorScheme")'="none",1:0)
+
 /// Returns a line with given formatting, clearing the formatting at the end of the line
 #define FormattedLine(%formatCode, %line) $Select($$$ColorScheme:$$$ControlSequence(%formatCode)_%line_$$$ControlSequence($$$ResetAll),1:%line)
 #define pad(%width, %text) $Justify("", %width - $Length(%text))


### PR DESCRIPTION
## Description
Fixes #1057 

- IPM will cleanly uninstall itself (no errors and exits the zpm shell)
- If any modules are left over, it will ask the user if they want to remove all modules and globals (so IPM can be downgraded)
    - If yes, then uninstalls all modules and kills all globals except history and user settings
    - If no, then just uninstalls IPM (and a reinstall will unorphan the modules)
    - User prompt can be skipped with `-force`

Example:
```
zpm:USER>uninstall zpm

The following modules are currently installed:
  - vscode-per-namespace-settings (1.0.0)
  - testcoverage (4.1.2)

Do you want to fully remove all modules and IPM metadata (except history log)?
This is required for downgrading IPM. [y/N]:
[USER|ZPM]      Clean START
[USER|ZPM]      Unconfigure START
[USER|ZPM]      Unconfigure SUCCESS
Warning: 2 module(s) orphaned:
  - vscode-per-namespace-settings (1.0.0)
  - testcoverage (4.1.2)
Reinstalling IPM will automatically re-adopt these modules.
[USER|ZPM]      Clean SUCCESS

IPM has been uninstalled from this namespace. Exiting shell...
```

## Testing
Tested locally with and without other modules present and with and without fully removing IPM metadata. Did not create integration tests because I can't figure out a way of uninstalling/reinstalling IPM without fully breaking it in the middle of tests.

## Checklist
<!-- You can select a checkbox by changing "[ ]" to "[x]" -->
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] Changelog entry added.
- [x] Unit (`zpm test -only`) and integration tests (`zpm verify -only`) pass.
- [x] Style matches the style guide in the [contributing guide](https://github.com/intersystems/ipm/blob/main/CONTRIBUTING.md#style-guide).
- [x] Documentation has been/will be updated
  - Source controlled docs, e.g. README.md, should be included in this PR and Wiki changes should be made after this PR is merged (add an extra issue for this if needed)
- [x] Pull request correctly renders in the "Preview" tab.
