### PR TITLE
Add warning when using -password instead of -password-stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - requests Python wheel updated to 2.33.0
+- #1138: Warn when using `-password` instead of `-password-stdin`.
 
 ## [0.10.6] - 2026-02-24
 

--- a/src/cls/IPM/Repo/Definition.cls
+++ b/src/cls/IPM/Repo/Definition.cls
@@ -1,4 +1,4 @@
-Include (%syPrompt, %IPM.Common)
+Include (%syPrompt, %IPM.Common, %IPM.Formatting)
 
 Class %IPM.Repo.Definition Extends (%Persistent, %ZEN.DataModel.Adaptor, %IPM.CLI.Commands, %JSON.Adaptor) [ Abstract ]
 {
@@ -190,6 +190,8 @@ ClassMethod Configure(
             read "Password: ", pwd
             close $io
             set pModifiers("password") = pwd
+        } elseif $data(pModifiers("password")) {
+            write !, $$$FormattedLine($$$Yellow, "WARNING: Using --password via the CLI is insecure. Use --password-stdin.")
         }
 
         $$$ThrowOnError(..OnConfigure(tInstance,pInteractive,.pModifiers,.pData))


### PR DESCRIPTION
## Description
- Fixes #1138 
- Adds a simple warning line `WARNING: Using --password via the CLI is insecure. Use --password-stdin.`

## Testing
Manually tested it.
