### PR TITLE
The `load` command also unpacks to the standard directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - #408: Modules can now list dependencies without specifying version; will be assumed to be "*"
+- #945: The `load` command will unpack the tarball (or copy the non-tarball source) into the standard unpacking directory `$System.Util.DataDirectory()/ipm/<packagename>/<version>/` just like the install command
 - #992: Implement automatic history purge logic
 - #973: Enables CORS and JWT configuration for WebApplications in module.xml
 - #1110: Add `iriscli` and `ipm` container utility scripts that are auto-installed to `~/.local/bin/` and `~/bin/` so they work both inside and outside of containers (Unix/Linux only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - #408: Modules can now list dependencies without specifying version; will be assumed to be "*"
-- #945: The `load` command will unpack the tarball (or copy the non-tarball source) into the standard unpacking directory `$System.Util.DataDirectory()/ipm/<packagename>/<version>/` just like the install command
+- #945: When loading from a tarball, the `load` command now unpacks into the configured module root (defaults to `$System.Util.DataDirectory()/ipm/`) under `<packagename>/<version>/` instead of a temporary directory, matching the behavior of the `install` command. Directory loads are unaffected and continue to load in-place.
 - #992: Implement automatic history purge logic
 - #973: Enables CORS and JWT configuration for WebApplications in module.xml
 - #1110: Add `iriscli` and `ipm` container utility scripts that are auto-installed to `~/.local/bin/` and `~/bin/` so they work both inside and outside of containers (Unix/Linux only)

--- a/src/cls/IPM/General/Archive.cls
+++ b/src/cls/IPM/General/Archive.cls
@@ -53,9 +53,8 @@ ClassMethod Extract(
             quit
         }
         if '##class(%File).DirectoryExists(pTargetDirectory) {
-            set tResult = ##class(%File).CreateDirectoryChain(pTargetDirectory,.tReturn)
-            if 'tResult {
-                set tSC = $$$ERROR($$$GeneralError,$$$FormatText("Error creating directory chain %1: %2",pTargetDirectory,tReturn))
+            set tSC = ##class(%IPM.Utils.File).CreateDirectoryChain(pTargetDirectory)
+            if $$$ISERR(tSC) {
                 quit
             }
         }

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -1153,11 +1153,8 @@ Method %Export(
         }
 
         if '##class(%File).DirectoryExists(pTargetDirectory) {
-            kill %objlasterror
-            set tCreated = ##class(%File).CreateDirectoryChain(pTargetDirectory,.tReturnValue)
-            if 'tCreated {
-                set tLastErr = $get(%objlasterror)
-                set tSC = $$$EMBEDSC($$$ERROR($$$GeneralError,$$$FormatText("Error creating directory %1: %2",pTargetDirectory,tReturnValue)),tLastErr)
+            set tSC = ##class(%IPM.Utils.File).CreateDirectoryChain(pTargetDirectory)
+            if $$$ISERR(tSC) {
                 quit
             }
         }
@@ -1965,12 +1962,7 @@ Method ExportSingleModule(
             set tSC = $$$OK
             set tDirectory = ##class(%File).GetDirectory(tExportPath,1)
             if '##class(%File).DirectoryExists(tDirectory) {
-                set tGood = ##class(%File).CreateDirectoryChain(tDirectory,.tReturn)
-                if 'tGood {
-                    set tLastErr = $get(%objlasterror)
-                    set tSC = $$$EMBEDSC($$$ERROR($$$GeneralError,$$$FormatText("Error creating directory '%1': %2",tDirectory,tReturn)),tLastErr)
-                    $$$ThrowOnError(tSC)
-                }
+                $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(tDirectory))
                 write:pVerbose !,"Created ",tDirectory
             }
             if ##class(%File).DirectoryExists(tSourcePath) {
@@ -1990,7 +1982,7 @@ Method ExportSingleModule(
             }
         } elseif (tExt = "CLS") || (tExt = "DFI") || (tExt = "PRJ") || ($zconvert($extract(tFullPath,$length(tFullPath)-2,*),"l")="xml") || (##class(%RoutineMgr).UserType(tFullResourceName)) {
             if '##class(%File).Exists(tFullPath) {
-                do ##class(%File).CreateDirectoryChain(##class(%File).GetDirectory(tFullPath))
+                $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(##class(%File).GetDirectory(tFullPath)))
             }
             set tSC = $$Export^%occXMLExport(tFullPath,"-d /diffexport/createdirs",tFullResourceName)
             $$$ThrowOnError(tSC)

--- a/src/cls/IPM/Lifecycle/Module.cls
+++ b/src/cls/IPM/Lifecycle/Module.cls
@@ -148,8 +148,8 @@ Method %Package(ByRef pParams) As %Status
             // create temporary subdirectory to prevent clashes
             set randomDir = $translate($system.Encryption.Base64Encode($system.Encryption.GenCryptRand(6)),"+/=")
             set tExportSubDirectory = ##class(%Library.File).NormalizeDirectory(tExportDirectory) _ randomDir _ "/"
-            if '##class(%File).CreateDirectoryChain(tExportSubDirectory,.tReturn) {
-                set tSC = $$$ERROR($$$GeneralError,$$$FormatText("Error creating directory chain %1: %2",tExportSubDirectory,tReturn))
+            set tSC = ##class(%IPM.Utils.File).CreateDirectoryChain(tExportSubDirectory)
+            if $$$ISERR(tSC) {
                 quit
             }
         }

--- a/src/cls/IPM/Lifecycle/StudioProject/XDataArchive.cls
+++ b/src/cls/IPM/Lifecycle/StudioProject/XDataArchive.cls
@@ -156,7 +156,7 @@ ClassMethod CreateDirectoryChain(pName As %String) As %Status
 {
     set tSC = $$$OK
     if '##class(%Library.File).CreateDirectoryChain(pName,.tReturn) {
-        set tSC = $$$ERROR($$$GeneralError,$$$FormatText("Error creating directory chain %1: %2",pName,$zutil(209,tReturn)))
+        set tSC = $$$ERROR($$$GeneralError,$$$FormatText("Error creating directory chain %1: %2",pName,$zutil(209,$select(tReturn<0:-tReturn,1:tReturn))))
     }
     quit tSC
 }

--- a/src/cls/IPM/Lifecycle/StudioProject/XDataArchive.cls
+++ b/src/cls/IPM/Lifecycle/StudioProject/XDataArchive.cls
@@ -151,7 +151,9 @@ Method GetDirectoryContentsRecursive(
     quit tSC
 }
 
-/// Copied from %IPM.Utils.File to support use in classes cloned from this one
+/// Copied from %IPM.Utils.File to support use in classes cloned from this one.
+/// Cannot delegate to %IPM.Utils.File because subclasses generated via XData self-cloning
+/// are deployed as standalone classes without a dependency on the rest of the IPM codebase.
 ClassMethod CreateDirectoryChain(pName As %String) As %Status
 {
     set tSC = $$$OK

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2394,24 +2394,28 @@ ClassMethod LoadInternal(
         }
     }
 
-    // When loading a module from a local folder, there might be a <mod root>/.modules/ folder containining dependencies.
+    // When loading a module from a local folder, there might be a <mod root>/.modules/ folder containing dependencies.
     // It's easier to configure a temporary repository than to handle this case in the dependency resolution code.
     set tTargetDirectory = $get(tTargetDirectory, tDirectoryName)
 
-    // Copy source to the standard module location (DataDirectory/ipm/<name>/<version>/) unless in developer mode,
-    // where the developer works on files in-place.
-    if '$get(tParams("DeveloperMode"), 0) {
+    // For tarball and URL sources, copy the extracted content to <ModuleRoot>/<name>/<version>/
+    // and clean up the temp extraction directory. Directory loads are left in-place so that
+    // live-edit workflows (mounted volumes, bootstrap) continue to work without re-loading.
+    if $get(tTempExtractionRoot) '= "" {
         set tModuleObj = ##class(%IPM.Utils.Module).GetModuleObjectFromPath(tTargetDirectory, .tFound)
+        if 'tFound {
+            $$$ThrowStatus($$$ERROR($$$GeneralError,"No Module element found in module.xml at "_tTargetDirectory))
+        }
         set tFinalDirectory = ##class(%Library.File).NormalizeDirectory(
             ##class(%IPM.Repo.UniversalSettings).GetModuleRoot() _ tModuleObj.Name _ "/" _ tModuleObj.VersionString)
         if ##class(%File).DirectoryExists(tFinalDirectory) {
             $$$ThrowOnError(##class(%IPM.Utils.File).RemoveDirectoryTree(tFinalDirectory))
         }
         $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(tFinalDirectory))
+        // Destination was just created empty above, so pDeleteFirst=0 is intentional.
+        // If CopyDir fails partway through, tFinalDirectory may be left in a partial state.
         $$$ThrowOnError(##class(%IPM.Utils.File).CopyDir(tTargetDirectory, tFinalDirectory, 0))
-        if $get(tTempExtractionRoot) '= "" {
-            $$$ThrowOnError(##class(%IPM.Utils.File).RemoveDirectoryTree(tTempExtractionRoot))
-        }
+        $$$ThrowOnError(##class(%IPM.Utils.File).RemoveDirectoryTree(tTempExtractionRoot))
         set tTargetDirectory = tFinalDirectory
     }
 

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2364,7 +2364,8 @@ ClassMethod LoadInternal(
     }
     set extension = $$$lcase($piece(tDirectoryName,".",*))
     if ##class(%File).Exists(tDirectoryName) && ((extension="tgz") || (extension="tar.gz")) {
-        set tTargetDirectory = $$$FileTempDirSys
+        set tTempExtractionRoot = $$$FileTempDirSys
+        set tTargetDirectory = tTempExtractionRoot
         if $get(pCommandInfo("data", "Verbose")) {
             write !,"Extracting archive to ",tTargetDirectory
         }
@@ -2401,13 +2402,16 @@ ClassMethod LoadInternal(
     // where the developer works on files in-place.
     if '$get(tParams("DeveloperMode"), 0) {
         set tModuleObj = ##class(%IPM.Utils.Module).GetModuleObjectFromPath(tTargetDirectory, .tFound)
-        if 'tFound {
-            $$$ThrowStatus($$$ERROR($$$GeneralError, "No module.xml found in " _ tTargetDirectory))
-        }
         set tFinalDirectory = ##class(%Library.File).NormalizeDirectory(
             ##class(%SYSTEM.Util).DataDirectory() _ "ipm/" _ tModuleObj.Name _ "/" _ tModuleObj.VersionString)
+        if ##class(%File).DirectoryExists(tFinalDirectory) {
+            $$$ThrowOnError(##class(%IPM.Utils.File).RemoveDirectoryTree(tFinalDirectory))
+        }
         $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(tFinalDirectory))
-        $$$ThrowOnError(##class(%IPM.Utils.File).CopyDir(tTargetDirectory, tFinalDirectory))
+        $$$ThrowOnError(##class(%IPM.Utils.File).CopyDir(tTargetDirectory, tFinalDirectory, 0))
+        if $get(tTempExtractionRoot) '= "" {
+            $$$ThrowOnError(##class(%IPM.Utils.File).RemoveDirectoryTree(tTempExtractionRoot))
+        }
         set tTargetDirectory = tFinalDirectory
     }
 

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2403,7 +2403,7 @@ ClassMethod LoadInternal(
     if '$get(tParams("DeveloperMode"), 0) {
         set tModuleObj = ##class(%IPM.Utils.Module).GetModuleObjectFromPath(tTargetDirectory, .tFound)
         set tFinalDirectory = ##class(%Library.File).NormalizeDirectory(
-            ##class(%SYSTEM.Util).DataDirectory() _ "ipm/" _ tModuleObj.Name _ "/" _ tModuleObj.VersionString)
+            ##class(%IPM.Repo.UniversalSettings).GetModuleRoot() _ tModuleObj.Name _ "/" _ tModuleObj.VersionString)
         if ##class(%File).DirectoryExists(tFinalDirectory) {
             $$$ThrowOnError(##class(%IPM.Utils.File).RemoveDirectoryTree(tFinalDirectory))
         }

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -2288,7 +2288,7 @@ ClassMethod LoadFromRepo(
 {
     set slash=$select($zversion(1)=3:"/",1:"\")
     set TempDir = ##class(%File).GetDirectory(##class(%File).GetDirectory($zutil(86))_"mgr"_slash_"Temp"_slash_$translate($ztimestamp,".,")_slash)
-    $$$ThrowOnError(##class(%File).CreateDirectoryChain(TempDir))
+    $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(TempDir))
     set:$extract(tDirectoryName,*)="/" tDirectoryName=$extract(tDirectoryName,1,*-1)
     set RepoName=$piece($piece($piece(tDirectoryName,"/",*),".git")," ")
     set tCmd="cd "_TempDir_" && git clone "_tDirectoryName
@@ -2396,6 +2396,21 @@ ClassMethod LoadInternal(
     // When loading a module from a local folder, there might be a <mod root>/.modules/ folder containining dependencies.
     // It's easier to configure a temporary repository than to handle this case in the dependency resolution code.
     set tTargetDirectory = $get(tTargetDirectory, tDirectoryName)
+
+    // Copy source to the standard module location (DataDirectory/ipm/<name>/<version>/) unless in developer mode,
+    // where the developer works on files in-place.
+    if '$get(tParams("DeveloperMode"), 0) {
+        set tModuleObj = ##class(%IPM.Utils.Module).GetModuleObjectFromPath(tTargetDirectory, .tFound)
+        if 'tFound {
+            $$$ThrowStatus($$$ERROR($$$GeneralError, "No module.xml found in " _ tTargetDirectory))
+        }
+        set tFinalDirectory = ##class(%Library.File).NormalizeDirectory(
+            ##class(%SYSTEM.Util).DataDirectory() _ "ipm/" _ tModuleObj.Name _ "/" _ tModuleObj.VersionString)
+        $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(tFinalDirectory))
+        $$$ThrowOnError(##class(%IPM.Utils.File).CopyDir(tTargetDirectory, tFinalDirectory))
+        set tTargetDirectory = tFinalDirectory
+    }
+
     set dotModules = ##class(%File).NormalizeDirectory(".modules", tTargetDirectory)
     set tmpRepoMgr = ##class(%IPM.General.TempLocalRepoManager).%New(dotModules, 1)
     set tSC = ##class(%IPM.Utils.Module).LoadNewModule(tTargetDirectory, .tParams, , pLog)

--- a/src/cls/IPM/Repo/Oras/PublishService.cls
+++ b/src/cls/IPM/Repo/Oras/PublishService.cls
@@ -18,10 +18,7 @@ Method PublishModule(pModule As %IPM.Repo.Remote.ModuleInfo) As %Status
         set tempDirectory = ##class(%File).NormalizeDirectory(tDir _ "/" _ repo _ "/" _ tag _ "/")
 
         #; Create temp directory
-        set tCreated = ##class(%File).CreateDirectoryChain(tempDirectory,.tReturnValue)
-        if 'tCreated {
-            $$$ThrowStatus($$$ERROR($$$GeneralError, $$$FormatText("Error creating directory %1: %2", tempDirectory, tReturnValue)))
-        }
+        $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(tempDirectory))
 
         #; Create tgz file in temp directory
         set tFileBinStream = ##class(%Stream.FileBinary).%New()

--- a/src/cls/IPM/ResourceProcessor/ArtifactoryTarball.cls
+++ b/src/cls/IPM/ResourceProcessor/ArtifactoryTarball.cls
@@ -267,9 +267,7 @@ ClassMethod RetrieveArtifact(
 
     // Create directory if it doesn't exist
     if '##class(%File).DirectoryExists(downloadDirectory) {
-        if '##class(%File).CreateDirectoryChain(downloadDirectory) {
-            $$$ThrowStatus($$$ERROR($$$GeneralError, "Unable to create destination directory: "_downloadDirectory))
-        }
+        $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(downloadDirectory))
     }
 
     set localPath = ##class(%File).NormalizeFilename(artifactName, downloadDirectory)

--- a/src/cls/IPM/ResourceProcessor/FileCopy.cls
+++ b/src/cls/IPM/ResourceProcessor/FileCopy.cls
@@ -158,8 +158,8 @@ Method DoCopy(
         do ..NormalizeNames(.tSource, .tTarget, .tTargetDir, .copyAsFile)
 
         if '##class(%File).DirectoryExists(tTargetDir) {
-            if '##class(%File).CreateDirectoryChain(tTargetDir,.tReturn) {
-                set tSC = $$$ERROR($$$GeneralError,$$$FormatText("Error creating directory %1: %2",tTargetDir,$zutil(209,tReturn)))
+            set tSC = ##class(%IPM.Utils.File).CreateDirectoryChain(tTargetDir)
+            if $$$ISERR(tSC) {
                 quit
             }
         }

--- a/src/cls/IPM/ResourceProcessor/PythonWheel.cls
+++ b/src/cls/IPM/ResourceProcessor/PythonWheel.cls
@@ -94,8 +94,9 @@ Method OnExportItem(
         return $$$ERROR($$$GeneralError, "File """_dir_""" exists and is not a directory. Failed to export item: "_..Name)
     }
     if '##class(%File).DirectoryExists(dir) {
-        if '##class(%File).CreateDirectoryChain(dir, .return) {
-            return $$$ERROR($$$GeneralError, "Failed to create directory "_dir_", OS returned code: "_-return)
+        set sc = ##class(%IPM.Utils.File).CreateDirectoryChain(dir)
+        if $$$ISERR(sc) {
+            return sc
         }
     }
     if verbose {

--- a/src/cls/IPM/ResourceProcessor/Test.cls
+++ b/src/cls/IPM/ResourceProcessor/Test.cls
@@ -241,7 +241,7 @@ Method OnPhase(
                 }
                 set outputDir = ##class(%File).GetDirectory(outputFile)
                 if outputDir '= "" {
-                    $$$ThrowOnError(##class(%File).CreateDirectoryChain(outputDir))
+                    $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(outputDir))
                 }
                 set tSC = $classmethod(outputClass,"ToFile",outputFile)
                 $$$ThrowOnError(tSC)

--- a/src/cls/IPM/ResourceProcessor/Test.cls
+++ b/src/cls/IPM/ResourceProcessor/Test.cls
@@ -118,19 +118,9 @@ Method OnPhase(
 
             // Ensure unit tests and related classes are loaded.
             set tUnitTestDir = ##class(%File).NormalizeDirectory(..ResourceReference.Module.Root_..ResourceReference.Name)
-            set fileExt = $case(..Format, "XML":"xml", :"cls")
-
             if $data(pParams("UnitTest","Case"), earlyCase)#2 {
-                // Convert dotted package prefix to directory path, e.g. Test.PM.Unit -> Test/PM/Unit
-                set caseDir = $replace($piece(earlyCase,".",1,*-1),".","/")
-                set caseFilePath = ##class(%File).NormalizeFilename(tUnitTestDir_caseDir_"/"_$piece(earlyCase,".",*)_"."_fileExt)
-                // Fall back to full directory if the specific file isn't on disk
-                // (e.g., the class lives in a different resource's directory).
-                if ##class(%File).Exists(caseFilePath) {
-                    $$$ThrowOnError($system.OBJ.Load(caseFilePath, "k"_$select(tVerbose:"/display",1:"/nodisplay")))
-                } else {
-                    $$$ThrowOnError(##class(%IPM.Test.Manager).LoadTestDirectory(tUnitTestDir, tVerbose, , ..Format))
-                }
+                // Load the full directory so base classes are available before compiling the target case.
+                $$$ThrowOnError(##class(%IPM.Test.Manager).LoadTestDirectory(tUnitTestDir, tVerbose, , ..Format))
             } elseif $data(pParams("UnitTest","Suite"), earlySuite)#2 {
                 set suiteDir = ##class(%File).NormalizeDirectory(tUnitTestDir_$replace(earlySuite,".","\"))
                 $$$ThrowOnError(##class(%IPM.Test.Manager).LoadTestDirectory(suiteDir, tVerbose, , ..Format))

--- a/src/cls/IPM/Utils/FileBinaryTar.cls
+++ b/src/cls/IPM/Utils/FileBinaryTar.cls
@@ -155,7 +155,7 @@ Method ExtractTo(pDest As %String) As %Status
     if ..name'="" {
         if ..typeflag=5 {
             set fullPath = ##class(%File).NormalizeDirectory(..name, pDest)
-            set sc = ##class(%File).CreateDirectoryChain(fullPath)
+            set sc = ##class(%IPM.Utils.File).CreateDirectoryChain(fullPath)
             if $$$ISERR(sc) {
                 return sc
             }
@@ -164,8 +164,9 @@ Method ExtractTo(pDest As %String) As %Status
             set path = pDest_..name
             set directory = ##class(%File).GetDirectory(path)
             if '##class(%File).DirectoryExists(directory) {
-                if '##class(%File).CreateDirectoryChain(directory, .ret) {
-                    return $$$ERROR($$$GeneralError, $$$FormatText("Error creating directory chain %1: %2", directory, ret))
+                set sc = ##class(%IPM.Utils.File).CreateDirectoryChain(directory)
+                if $$$ISERR(sc) {
+                    return sc
                 }
             }
             #; no idea, why it's needed, but IRIS.DAT filename not allowed

--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -234,9 +234,8 @@ ClassMethod LoadModuleFromArchive(
                 quit
             }
         }
-        set tCreated = ##class(%File).CreateDirectoryChain(tTargetDirectory,.tReturnValue)
-        if 'tCreated {
-            set tSC = $$$ERROR($$$GeneralError,$$$FormatText("Error creating directory %1: %2",tTargetDirectory,tReturnValue))
+        set tSC = ##class(%IPM.Utils.File).CreateDirectoryChain(tTargetDirectory)
+        if $$$ISERR(tSC) {
             quit
         }
         set tTargetDirectory = ##class(%File).NormalizeFilenameWithSpaces(tTargetDirectory)

--- a/tests/integration_tests/Test/PM/Integration/FileBinaryTar.cls
+++ b/tests/integration_tests/Test/PM/Integration/FileBinaryTar.cls
@@ -5,36 +5,88 @@ Class Test.PM.Integration.FileBinaryTar Extends %UnitTest.TestCase
 
 Method TestPackageAndExtract()
 {
-  Set tSC = $$$OK
-  Try {
-    Set tTestRoot = ##class(%File).NormalizeDirectory($Get(^UnitTestRoot))
+  set sc = $$$OK
+  try {
+    set tTestRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
 
-    Set tModuleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(tTestRoot)_"/_data/simple-module/")
-    Set tSC = ##class(%IPM.Main).Shell("load "_tModuleDir)
-    Do $$$AssertStatusOK(tSC,"Loaded SimpleModule module successfully.")
+    set tModuleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(tTestRoot)_"/_data/simple-module/")
+    set sc = ##class(%IPM.Main).Shell("load "_tModuleDir)
+    do $$$AssertStatusOK(sc,"Loaded SimpleModule module successfully.")
 
-    Set tempDir = ##class(%Library.File).TempFilename()_"dir"
-    Set tSC = ##class(%IPM.Main).Shell("simplemodule package -only -DPath="_tempDir)
-    Do $$$AssertStatusOK(tSC,"Packaged SimpleModule successfully.")
+    set tempDir = ##class(%Library.File).TempFilename()_"dir"
+    set sc = ##class(%IPM.Main).Shell("simplemodule package -only -DPath="_tempDir)
+    do $$$AssertStatusOK(sc,"Packaged SimpleModule successfully.")
 
-    Set outFile = ##class(%Library.File).TempFilename()
-    Set outDir = ##class(%Library.File).NormalizeDirectory(##class(%Library.File).TempFilename()_"dir-out")
-    Do ##class(%Library.File).CreateDirectoryChain(outDir)
-    Do $$$AssertEquals($zf(-100,"/STDOUT="""_outFile_"""/STDERR="""_outFile_"""","tar","-xvf",tempDir_".tgz","-C",outDir),0)
+    set outFile = ##class(%Library.File).TempFilename()
+    set outDir = ##class(%Library.File).NormalizeDirectory(##class(%Library.File).TempFilename()_"dir-out")
+    do ##class(%Library.File).CreateDirectoryChain(outDir)
+    do $$$AssertEquals($zf(-100,"/STDOUT="""_outFile_"""/STDERR="""_outFile_"""","tar","-xvf",tempDir_".tgz","-C",outDir),0)
 
-    Do $$$AssertNotTrue(##class(%File).DirectoryExists(outDir_"src/cls/Test/Test"))
-    Do $$$AssertNotTrue(##class(%File).DirectoryExists(outDir_"src/src"))
-    Do $$$AssertNotTrue(##class(%File).DirectoryExists(outDir_"simplemodule"))
-    Do $$$AssertTrue(##class(%File).Exists(outDir_"src/cls/Test/Test.cls"))
-    Do $$$AssertTrue(##class(%File).Exists(outDir_"module.xml"))
+    do $$$AssertNotTrue(##class(%File).DirectoryExists(outDir_"src/cls/Test/Test"))
+    do $$$AssertNotTrue(##class(%File).DirectoryExists(outDir_"src/src"))
+    do $$$AssertNotTrue(##class(%File).DirectoryExists(outDir_"simplemodule"))
+    do $$$AssertTrue(##class(%File).Exists(outDir_"src/cls/Test/Test.cls"))
+    do $$$AssertTrue(##class(%File).Exists(outDir_"module.xml"))
 
-    Set tSC = ##class(%IPM.Main).Shell("load "_tempDir_".tgz")
-    Do $$$AssertStatusOK(tSC,"Loaded SimpleModule module successfully from .tgz file.")
+    set sc = ##class(%IPM.Main).Shell("load "_tempDir_".tgz")
+    do $$$AssertStatusOK(sc,"Loaded SimpleModule module successfully from .tgz file.")
 
-    Set tSC = ##class(%IPM.Main).Shell("load "_outDir)
-    Do $$$AssertStatusOK(tSC,"Loaded SimpleModule module successfully from package directory.")
-  } Catch e {
-    Do $$$AssertStatusOK(e.AsStatus(),"An exception occurred.")
+    set sc = ##class(%IPM.Main).Shell("load "_outDir)
+    do $$$AssertStatusOK(sc,"Loaded SimpleModule module successfully from package directory.")
+  } catch e {
+    do $$$AssertStatusOK(e.AsStatus(),"An exception occurred.")
+  }
+}
+
+Method TestLoadDestinationDirectory()
+{
+  set sc = $$$OK
+  try {
+    set tTestRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
+    set tModuleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(tTestRoot)_"/_data/simple-module/")
+
+    // Load from directory — files should land in DataDirectory/ipm/<name>/<version>/
+    set sc = ##class(%IPM.Main).Shell("load "_tModuleDir)
+    do $$$AssertStatusOK(sc,"Loaded SimpleModule from directory.")
+    set tModule = ##class(%IPM.Storage.Module).NameOpen("simplemodule",,.sc)
+    do $$$AssertStatusOK(sc,"Opened module after directory load.")
+    set tExpectedDir = ##class(%Library.File).NormalizeDirectory(
+      ##class(%SYSTEM.Util).DataDirectory()_"ipm/"_tModule.Name_"/"_tModule.VersionString)
+    do $$$AssertTrue(##class(%File).DirectoryExists(tExpectedDir),"Module directory exists at standard path after load from directory.")
+    do $$$AssertTrue(##class(%File).Exists(tExpectedDir_"module.xml"),"module.xml present at standard path after load from directory.")
+    set sc = ##class(%IPM.Main).Shell("uninstall simplemodule")
+    do $$$AssertStatusOK(sc,"Uninstalled SimpleModule.")
+
+    // Load from tarball — files should also land in DataDirectory/ipm/<name>/<version>/
+    set tempDir = ##class(%Library.File).TempFilename()_"dir"
+    set sc = ##class(%IPM.Main).Shell("load "_tModuleDir)
+    do $$$AssertStatusOK(sc,"Loaded SimpleModule from directory to enable packaging.")
+    set sc = ##class(%IPM.Main).Shell("simplemodule package -only -DPath="_tempDir)
+    do $$$AssertStatusOK(sc,"Packaged SimpleModule.")
+    set sc = ##class(%IPM.Main).Shell("uninstall simplemodule")
+    do $$$AssertStatusOK(sc,"Uninstalled SimpleModule before tarball load.")
+    set sc = ##class(%IPM.Main).Shell("load "_tempDir_".tgz")
+    do $$$AssertStatusOK(sc,"Loaded SimpleModule from tarball.")
+    set tModule = ##class(%IPM.Storage.Module).NameOpen("simplemodule",,.sc)
+    do $$$AssertStatusOK(sc,"Opened module after tarball load.")
+    set tExpectedDir = ##class(%Library.File).NormalizeDirectory(
+      ##class(%SYSTEM.Util).DataDirectory()_"ipm/"_tModule.Name_"/"_tModule.VersionString)
+    do $$$AssertTrue(##class(%File).DirectoryExists(tExpectedDir),"Module directory exists at standard path after load from tarball.")
+    set sc = ##class(%IPM.Main).Shell("uninstall simplemodule")
+    do $$$AssertStatusOK(sc,"Uninstalled SimpleModule.")
+
+    // Load -dev from directory — module Root should point to the original path, not DataDirectory
+    $$$ThrowOnError(##class(%IPM.Utils.File).RemoveDirectoryTree(tExpectedDir))
+    set sc = ##class(%IPM.Main).Shell("load -dev "_tModuleDir)
+    do $$$AssertStatusOK(sc,"Loaded SimpleModule in dev mode.")
+    set tModule = ##class(%IPM.Storage.Module).NameOpen("simplemodule",,.sc)
+    do $$$AssertStatusOK(sc,"Opened module after dev mode load.")
+    do $$$AssertEquals(tModule.Root, tModuleDir, "Module Root points to original directory in dev mode.")
+    do $$$AssertNotTrue(##class(%File).DirectoryExists(tExpectedDir),"Module NOT copied to standard path in dev mode.")
+    set sc = ##class(%IPM.Main).Shell("uninstall simplemodule")
+    do $$$AssertStatusOK(sc,"Uninstalled SimpleModule.")
+  } catch e {
+    do $$$AssertStatusOK(e.AsStatus(),"An exception occurred.")
   }
 }
 

--- a/tests/integration_tests/Test/PM/Integration/FileBinaryTar.cls
+++ b/tests/integration_tests/Test/PM/Integration/FileBinaryTar.cls
@@ -56,6 +56,7 @@ Method TestLoadDestinationDirectory()
     do $$$AssertTrue(##class(%File).Exists(tExpectedDir_"module.xml"),"module.xml present at standard path after load from directory.")
     set sc = ##class(%IPM.Main).Shell("uninstall simplemodule")
     do $$$AssertStatusOK(sc,"Uninstalled SimpleModule.")
+    $$$ThrowOnError(##class(%IPM.Utils.File).RemoveDirectoryTree(tExpectedDir))
 
     // Load from tarball — files should also land in DataDirectory/ipm/<name>/<version>/
     set tempDir = ##class(%Library.File).TempFilename()_"dir"

--- a/tests/integration_tests/Test/PM/Integration/FileBinaryTar.cls
+++ b/tests/integration_tests/Test/PM/Integration/FileBinaryTar.cls
@@ -45,20 +45,16 @@ Method TestLoadDestinationDirectory()
     set tTestRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
     set tModuleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(tTestRoot)_"/_data/simple-module/")
 
-    // Load from directory — files should land in DataDirectory/ipm/<name>/<version>/
+    // Load from directory — module stays in-place, Root points to the source directory.
     set sc = ##class(%IPM.Main).Shell("load "_tModuleDir)
     do $$$AssertStatusOK(sc,"Loaded SimpleModule from directory.")
     set tModule = ##class(%IPM.Storage.Module).NameOpen("simplemodule",,.sc)
     do $$$AssertStatusOK(sc,"Opened module after directory load.")
-    set tExpectedDir = ##class(%Library.File).NormalizeDirectory(
-      ##class(%SYSTEM.Util).DataDirectory()_"ipm/"_tModule.Name_"/"_tModule.VersionString)
-    do $$$AssertTrue(##class(%File).DirectoryExists(tExpectedDir),"Module directory exists at standard path after load from directory.")
-    do $$$AssertTrue(##class(%File).Exists(tExpectedDir_"module.xml"),"module.xml present at standard path after load from directory.")
+    do $$$AssertEquals(tModule.Root, tModuleDir, "Module Root points to source directory after load from directory.")
     set sc = ##class(%IPM.Main).Shell("uninstall simplemodule")
     do $$$AssertStatusOK(sc,"Uninstalled SimpleModule.")
-    $$$ThrowOnError(##class(%IPM.Utils.File).RemoveDirectoryTree(tExpectedDir))
 
-    // Load from tarball — files should also land in DataDirectory/ipm/<name>/<version>/
+    // Load from tarball — files should land in <ModuleRoot>/<name>/<version>/
     set tempDir = ##class(%Library.File).TempFilename()_"dir"
     set sc = ##class(%IPM.Main).Shell("load "_tModuleDir)
     do $$$AssertStatusOK(sc,"Loaded SimpleModule from directory to enable packaging.")
@@ -71,19 +67,18 @@ Method TestLoadDestinationDirectory()
     set tModule = ##class(%IPM.Storage.Module).NameOpen("simplemodule",,.sc)
     do $$$AssertStatusOK(sc,"Opened module after tarball load.")
     set tExpectedDir = ##class(%Library.File).NormalizeDirectory(
-      ##class(%SYSTEM.Util).DataDirectory()_"ipm/"_tModule.Name_"/"_tModule.VersionString)
+      ##class(%IPM.Repo.UniversalSettings).GetModuleRoot()_tModule.Name_"/"_tModule.VersionString)
     do $$$AssertTrue(##class(%File).DirectoryExists(tExpectedDir),"Module directory exists at standard path after load from tarball.")
+    do $$$AssertEquals(tModule.Root, tExpectedDir, "Module Root points to module root path after load from tarball.")
     set sc = ##class(%IPM.Main).Shell("uninstall simplemodule")
     do $$$AssertStatusOK(sc,"Uninstalled SimpleModule.")
 
-    // Load -dev from directory — module Root should point to the original path, not DataDirectory
-    $$$ThrowOnError(##class(%IPM.Utils.File).RemoveDirectoryTree(tExpectedDir))
+    // Load -dev from directory — module stays in-place, Root points to the source directory.
     set sc = ##class(%IPM.Main).Shell("load -dev "_tModuleDir)
     do $$$AssertStatusOK(sc,"Loaded SimpleModule in dev mode.")
     set tModule = ##class(%IPM.Storage.Module).NameOpen("simplemodule",,.sc)
     do $$$AssertStatusOK(sc,"Opened module after dev mode load.")
-    do $$$AssertEquals(tModule.Root, tModuleDir, "Module Root points to original directory in dev mode.")
-    do $$$AssertNotTrue(##class(%File).DirectoryExists(tExpectedDir),"Module NOT copied to standard path in dev mode.")
+    do $$$AssertEquals(tModule.Root, tModuleDir, "Module Root points to source directory in dev mode.")
     set sc = ##class(%IPM.Main).Shell("uninstall simplemodule")
     do $$$AssertStatusOK(sc,"Uninstalled SimpleModule.")
   } catch e {

--- a/tests/integration_tests/Test/PM/Integration/History.cls
+++ b/tests/integration_tests/Test/PM/Integration/History.cls
@@ -619,7 +619,7 @@ Method TestFailingPhases()
         // Check history log entry is good
         do $$$AssertTrue(rs.%Get("ID") '= "")
         do $$$AssertEquals(rs.%Get("Action"),"load")
-        do $$$AssertEquals(rs.%Get("Package"),"invoke")
+        do $$$AssertEquals(rs.%Get("Package"),"invoke-non-status-return-check-status")
         do $$$AssertEquals(rs.%Get("Version_Major"),"0")
         do $$$AssertEquals(rs.%Get("Version_Minor"),"0")
         do $$$AssertEquals(rs.%Get("Version_Patch"),"1")

--- a/tests/integration_tests/Test/PM/Integration/Invoke.cls
+++ b/tests/integration_tests/Test/PM/Integration/Invoke.cls
@@ -9,7 +9,7 @@ Method TestInvokeCheckStatus()
     do $$$AssertStatusOK(sc,"Loaded module successfully")
 
     // Uninstall module
-    set sc = ##class(%IPM.Main).Shell("uninstall -verbose invoke")
+    set sc = ##class(%IPM.Main).Shell("uninstall -verbose invoke-success")
     do $$$AssertStatusOK(sc,"Uninstalled module successfully")
 
     // These invokes should fail
@@ -42,7 +42,7 @@ Method TestInvokeIpmDirExpression()
         // Verify the path is correct
         set receivedPath = $get(^IRIS.Temp.Test.IpmDir)
         set expectedPath = ##class(%Library.File).NormalizeDirectory(
-            $system.Util.DataDirectory() _ "ipm/invoke-ipmdir-test/1.0.0/")
+            ##class(%IPM.Repo.UniversalSettings).GetModuleRoot() _ "invoke-ipmdir-test/1.0.0/")
         do $$$AssertEquals(receivedPath, expectedPath, "ipmDir expression correctly evaluated to: " _ expectedPath)
 
         // Clean up - uninstall module

--- a/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/NoStatusCheckStatus/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/NoStatusCheckStatus/module.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Export generator="Cache" version="25">
-  <Document name="invoke.ZPM">
+  <Document name="invoke-no-status-check-status.ZPM">
     <Module>
-      <Name>invoke</Name>
+      <Name>invoke-no-status-check-status</Name>
       <Version>0.0.1-snapshot</Version>
       <Packaging>module</Packaging>
       <SourcesRoot>../../src</SourcesRoot>

--- a/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/NonStatusReturnCheckStatus/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/NonStatusReturnCheckStatus/module.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Export generator="Cache" version="25">
-  <Document name="invoke.ZPM">
+  <Document name="invoke-non-status-return-check-status.ZPM">
     <Module>
-      <Name>invoke</Name>
+      <Name>invoke-non-status-return-check-status</Name>
       <Version>0.0.1-snapshot</Version>
       <Packaging>module</Packaging>
       <SourcesRoot>../../src</SourcesRoot>

--- a/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/NonStatusReturnNoCheckStatus/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/NonStatusReturnNoCheckStatus/module.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Export generator="Cache" version="25">
-  <Document name="invoke.ZPM">
+  <Document name="invoke-non-status-return-no-check-status.ZPM">
     <Module>
-      <Name>invoke</Name>
+      <Name>invoke-non-status-return-no-check-status</Name>
       <Version>0.0.1-snapshot</Version>
       <Packaging>module</Packaging>
       <SourcesRoot>../../src</SourcesRoot>

--- a/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/ReturnErrorCheckStatus/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/ReturnErrorCheckStatus/module.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Export generator="Cache" version="25">
-  <Document name="invoke.ZPM">
+  <Document name="invoke-return-error-check-status.ZPM">
     <Module>
-      <Name>invoke</Name>
+      <Name>invoke-return-error-check-status</Name>
       <Version>0.0.1-snapshot</Version>
       <Packaging>module</Packaging>
       <SourcesRoot>../../src</SourcesRoot>

--- a/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/ReturnErrorNoCheckStatus/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/ReturnErrorNoCheckStatus/module.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Export generator="Cache" version="25">
-  <Document name="invoke.ZPM">
+  <Document name="invoke-return-error-no-check-status.ZPM">
     <Module>
-      <Name>invoke</Name>
+      <Name>invoke-return-error-no-check-status</Name>
       <Version>0.0.1-snapshot</Version>
       <Packaging>module</Packaging>
       <SourcesRoot>../../src</SourcesRoot>

--- a/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/ReturnNonErrorCheckStatus/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/ReturnNonErrorCheckStatus/module.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Export generator="Cache" version="25">
-  <Document name="invoke.ZPM">
+  <Document name="invoke-return-non-error-check-status.ZPM">
     <Module>
-      <Name>invoke</Name>
+      <Name>invoke-return-non-error-check-status</Name>
       <Version>0.0.1-snapshot</Version>
       <Packaging>module</Packaging>
       <SourcesRoot>../../src</SourcesRoot>

--- a/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/StatusNotReturnedCheckStatus/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/StatusNotReturnedCheckStatus/module.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Export generator="Cache" version="25">
-  <Document name="invoke.ZPM">
+  <Document name="invoke-status-not-returned-check-status.ZPM">
     <Module>
-      <Name>invoke</Name>
+      <Name>invoke-status-not-returned-check-status</Name>
       <Version>0.0.1-snapshot</Version>
       <Packaging>module</Packaging>
       <SourcesRoot>../../src</SourcesRoot>

--- a/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/StatusNotReturnedNoCheckStatus/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/invoke/failure/StatusNotReturnedNoCheckStatus/module.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Export generator="Cache" version="25">
-  <Document name="invoke.ZPM">
+  <Document name="invoke-status-not-returned-no-check-status.ZPM">
     <Module>
-      <Name>invoke</Name>
+      <Name>invoke-status-not-returned-no-check-status</Name>
       <Version>0.0.1-snapshot</Version>
       <Packaging>module</Packaging>
       <SourcesRoot>../../src</SourcesRoot>

--- a/tests/integration_tests/Test/PM/Integration/_data/invoke/success/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/invoke/success/module.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Export generator="Cache" version="25">
-  <Document name="invoke.ZPM">
+  <Document name="invoke-success.ZPM">
     <Module>
-      <Name>invoke</Name>
+      <Name>invoke-success</Name>
       <Version>0.0.1-snapshot</Version>
       <Packaging>module</Packaging>
       <SourcesRoot>../src</SourcesRoot>


### PR DESCRIPTION
## Description
- Resolves #945 
- `load` will also unpack tarballs to the `${ipmdir}` directory that `install` uses
- Regular directories are unaffected and uncopied
- Also fixes a bunch of call sights that directly call into %File.Library.CreateDirectoryChain instead of the wrapper that properly handles the error codes, e.g. -13 = Permission denied

## Testing
Added new test to Test.PM.Integration.FileBinaryTar
Tested the error handling wrapper and got these very readable errors after changing permissions in the default module root:
```
zpm:USER>install isc.json

ERROR! Error creating directory chain /usr/irissys/ipm/isc.json/2.0.1/: <13> Permission denied

zpm:USER>load /home/irisowner/zpm/tests/integration_tests/Test/PM/Integration/_data/simplest-module/1.0.0 -verbose

ERROR! Error creating directory chain /usr/irissys/ipm/simplest-module/1.0.0/: <13> Permission denied
```

## Checklist
<!-- You can select a checkbox by changing "[ ]" to "[x]" -->
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] Changelog entry added.
- [x] Unit (`zpm test -only`) and integration tests (`zpm verify -only`) pass.
- [x] Style matches the style guide in the [contributing guide](https://github.com/intersystems/ipm/blob/main/CONTRIBUTING.md#style-guide).
- [x] Documentation has been/will be updated
  - Source controlled docs, e.g. README.md, should be included in this PR and Wiki changes should be made after this PR is merged (add an extra issue for this if needed)
- [x] Pull request correctly renders in the "Preview" tab.
