### PR TITLE
Fix SystemRequirement IPM version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #1119: The update command should check version requirements using post-update values instead of what's currently installed
 - #1097: The Test resource processor now supports nested tests
 - #1116: Fix behavior inconsistencies between install and uninstall for package name casing.
+- #1114: Fix issue with SystemRequirements being confused by multiple namespaces with different version of IPM installed
 
 ### Security
 - urllib Python wheel updated to 2.7.0

--- a/src/cls/IPM/Storage/SystemRequirements.cls
+++ b/src/cls/IPM/Storage/SystemRequirements.cls
@@ -84,8 +84,12 @@ Method CheckIPMVersion() As %Status
     if ..IPMVersion = "" {
         return $$$OK
     }
-    do ##class(%IPM.Main).GetVersion($$$IPMModuleName,.out)
-    set tVersion = ##class(%IPM.General.SemanticVersion).FromString($listget(out($$$IPMModuleName), 2))
+    set tVersionString = ""
+    set tRS = ##class(%SQL.Statement).%ExecDirect(, "SELECT VersionString FROM %IPM_Storage.ModuleItem WHERE Name = ?", $$$IPMModuleName)
+    if tRS.%Next() {
+        set tVersionString = tRS.%Get("VersionString")
+    }
+    set tVersion = ##class(%IPM.General.SemanticVersion).FromString(tVersionString)
     $$$ThrowOnError(##class(%IPM.General.SemanticVersionExpression).FromString(..IPMVersion,.tExpression))
     if tVersion.Satisfies(tExpression) {
         return $$$OK


### PR DESCRIPTION
## Description
- Fixes #1114 
- Bug is that %IPM.Main:GetVersion() doesn't properly support modules that exist as different versions in different namespaces
- Change the IPM SystemRequirement check to directly query in the current namespace

## Testing
Fairly tricky to design an integration test, so just tested manually.

## Checklist
<!-- You can select a checkbox by changing "[ ]" to "[x]" -->
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] Changelog entry added.
- [x] Unit (`zpm test -only`) and integration tests (`zpm verify -only`) pass.
- [x] Style matches the style guide in the [contributing guide](https://github.com/intersystems/ipm/blob/main/CONTRIBUTING.md#style-guide).
- [x] Documentation has been/will be updated
  - Source controlled docs, e.g. README.md, should be included in this PR and Wiki changes should be made after this PR is merged (add an extra issue for this if needed)
- [x] Pull request correctly renders in the "Preview" tab.
