### PR TITLE
Support omitting dependency versions in module.xml; will default to *

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.7] - Unreleased
 
 ### Added
+- #408: Modules can now list dependencies without specifying version; will be assumed to be "*"
 - #992: Implement automatic history purge logic
 - #973: Enables CORS and JWT configuration for WebApplications in module.xml
 - #1110: Add `iriscli` and `ipm` container utility scripts that are auto-installed to `~/.local/bin/` and `~/bin/` so they work both inside and outside of containers (Unix/Linux only)

--- a/src/cls/IPM/Storage/ModuleReference.cls
+++ b/src/cls/IPM/Storage/ModuleReference.cls
@@ -10,9 +10,9 @@ Parameter NAMESPACE As STRING = "http://www.intersystems.com/PackageManager";
 Property Name As %String(MAXLEN = 255) [ Required ];
 
 /// Does not need code generation for comparison because <property>VersionString</property> comparison is good enough
-Property Version As %IPM.General.SemanticVersionExpression(ForceCodeGenerate = 0, XMLPROJECTION = "NONE") [ Required ];
+Property Version As %IPM.General.SemanticVersionExpression(ForceCodeGenerate = 0, XMLPROJECTION = "NONE");
 
-Property VersionString As %String(MAXLEN = 100, XMLNAME = "Version") [ Required ];
+Property VersionString As %String(MAXLEN = 100, XMLNAME = "Version") [ InitialExpression = "*" ];
 
 /// Restrict the scope in which this reference is relevant. Default is "all scopes"
 Property Scope As %String(VALUELIST = ",test,verify", XMLPROJECTION = "ATTRIBUTE");
@@ -21,6 +21,7 @@ Property DisplayName As %String(MAXLEN = 255) [ Internal ];
 
 Method VersionStringSet(tValue) As %Status
 {
+    set tValue = $select(tValue = "": "*", 1: tValue)
     set i%VersionString = tValue
     set tSC = ##class(%IPM.General.SemanticVersionExpression).FromString(tValue,.tExpression)
     if $$$ISOK(tSC) {

--- a/tests/integration_tests/Test/PM/Integration/DepNoVersion.cls
+++ b/tests/integration_tests/Test/PM/Integration/DepNoVersion.cls
@@ -1,0 +1,31 @@
+Class Test.PM.Integration.DepNoVersion Extends Test.PM.Integration.Base
+{
+
+Parameter ModuleFolder = "dep-no-version";
+
+/// Verify that a dependency declared without a Version attribute loads successfully
+/// and is treated as matching any version (*).
+Method TestLoadDependencyWithNoVersion() As %Status
+{
+    set moduleDir = ..GetModuleDir(..#ModuleFolder)
+    set sc = ##class(%IPM.Main).Shell("load -v " _ moduleDir)
+    do $$$AssertStatusOK(sc, "Load module with version-less dependency")
+
+    set module = ##class(%IPM.Storage.Module).NameOpen("dep-no-version", sc)
+    do $$$AssertStatusOK(sc, "Opened module")
+    if '$$$AssertTrue($isobject(module), "Module object valid") {
+        quit $$$OK
+    }
+
+    set dep = module.Dependencies.GetAt(1)
+    do $$$AssertEquals(dep.VersionString, "*", "Missing version defaults to *")
+    do $$$AssertTrue(dep.Version.IsSatisfiedBy(##class(%IPM.General.SemanticVersion).FromString("1.0.0")), "* satisfies 1.0.0")
+    do $$$AssertTrue(dep.Version.IsSatisfiedBy(##class(%IPM.General.SemanticVersion).FromString("99.99.99")), "* satisfies any version")
+
+    do $$$AssertStatusOK(##class(%IPM.Main).Shell("uninstall dep-no-version-dep"), "Uninstalled dep-no-version-dep")
+    do $$$AssertStatusOK(##class(%IPM.Main).Shell("uninstall dep-no-version"), "Uninstalled dep-no-version")
+
+    quit $$$OK
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/dep-no-version/.modules/dep-no-version-dep/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/dep-no-version/.modules/dep-no-version-dep/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="dep-no-version-dep.ZPM">
+    <Module>
+      <Name>dep-no-version-dep</Name>
+      <Version>1.0.0</Version>
+      <Packaging>module</Packaging>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/dep-no-version/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/dep-no-version/module.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="dep-no-version.ZPM">
+    <Module>
+      <Name>dep-no-version</Name>
+      <Version>1.0.0</Version>
+      <Packaging>module</Packaging>
+      <Dependencies>
+        <ModuleReference>
+          <Name>dep-no-version-dep</Name>
+        </ModuleReference>
+      </Dependencies>
+    </Module>
+  </Document>
+</Export>


### PR DESCRIPTION
## Description
- Resolves #408
- Removed the "requires" tag on version and versionstring
- Added default of "*"  

## Testing
New integration test: Test.PM.Integration.DepNoVersion

## Checklist
<!-- You can select a checkbox by changing "[ ]" to "[x]" -->
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] Changelog entry added.
- [x] Unit (`zpm test -only`) and integration tests (`zpm verify -only`) pass.
- [x] Style matches the style guide in the [contributing guide](https://github.com/intersystems/ipm/blob/main/CONTRIBUTING.md#style-guide).
- [x] Documentation has been/will be updated
  - Source controlled docs, e.g. README.md, should be included in this PR and Wiki changes should be made after this PR is merged (add an extra issue for this if needed)
- [x] Pull request correctly renders in the "Preview" tab.
