### PR TITLE
More efficient test loading and add option to include tests in packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #973: Enables CORS and JWT configuration for WebApplications in module.xml
 - #1110: Add `iriscli` and `ipm` container utility scripts that are auto-installed to `~/.local/bin/` and `~/bin/` so they work both inside and outside of containers (Unix/Linux only)
 - #971: Adds structured test output formats (JSON, YAML, Toon). Use `-f <format>` for a one-shot override or `config set TestReportFormat <format>` for a persistent default. Without either, legacy output is shown. Also adds `-output-file` for writing results to a file (including JUnit XML via `.xml` extension) and improves `-quiet` to suppress build noise.
+- #870: When running tests for just a single suite or class, will only load and compile the relevant classes instead of all the tests
+- #843: Optionally include tests when packaging using either the `-include-tests` flag or `<IncludeTests>1</IncludeTests>` in module.xml
 
 ### Fixed
 - #964: Fix poor error handling on some install failures due to incorrect error message variable in embedded SQL

--- a/src/cls/IPM/Lifecycle/Base.cls
+++ b/src/cls/IPM/Lifecycle/Base.cls
@@ -1163,7 +1163,16 @@ Method %Export(
         }
 
         set tExportDependencies = $get(pParams("ExportDependencies"), ..#EXPORTDEPENDENCIES)
-        set tSC = ..Module.GetResolvedReferences(.tResourceArray, tExportDependencies,..PhaseList,.pDependencyGraph)
+        set phaseList = ..PhaseList
+        if $get(pParams("IncludeTests"), ..Module.IncludeTests) {
+            if '$listfind(phaseList, "Test") {
+                set phaseList = phaseList_$listbuild("Test")
+            }
+            if '$listfind(phaseList, "Verify") {
+                set phaseList = phaseList_$listbuild("Verify")
+            }
+        }
+        set tSC = ..Module.GetResolvedReferences(.tResourceArray, tExportDependencies, phaseList, .pDependencyGraph)
         if $$$ISERR(tSC) {
             quit
         }
@@ -1201,7 +1210,7 @@ Method %Export(
                 set tModule = ##class(%IPM.Storage.Module).NameOpen(tModuleName)
                 do ..ExportPythonDependencies(tModule, .pParams)
                 // Recalculate resource array to pick up any python dependencies added during export
-                $$$ThrowOnError(..Module.GetResolvedReferences(.tResourceArray,tExportDependencies,..PhaseList,.pDependencyGraph))
+                $$$ThrowOnError(..Module.GetResolvedReferences(.tResourceArray,tExportDependencies,phaseList,.pDependencyGraph))
             }
             kill tSingleModuleArray
             merge tSingleModuleArray = tResourceArray(tModuleName)

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -126,6 +126,7 @@ This command is an alias for `module-action module-name package`
 <modifier name="path" aliases="p" dataAlias="Path" value="true" description="the specified path to export package." />
 <modifier name="export-deps" value="true" valueList="0,1" dataAlias="ExportDependencies" description="If specified, controls whether dependencies are exported. If omitted, defaults to the value of the #EXPORTDEPENDENCIES in lifecycle class. This modifier is only used in &quot;Package&quot; and &quot;Publish&quot; lifecycles." />
 <modifier name="export-python-deps" dataAlias="ExportPythonDependencies" dataValue="1" description="If specified, exports Python dependencies. If omitted, defaults to false." />
+<modifier name="include-tests" dataAlias="IncludeTests" dataValue="1" description="If specified, includes test-scoped resources in the package." />
 </command>
 
 <command name="verify" dataPrefix="D">
@@ -143,6 +144,7 @@ This command is an alias for `module-action module-name publish`
 <modifier name="repo" aliases="r" dataAlias="PublishTo" description="Namespace-unique name of repository for the module to publish to (if deployment is enabled)" />
 <modifier name="use-external-name" aliases="use-ext" dataAlias="UseExternalName" dataValue="1" description="Publish the package under the &lt;ExternalName&gt; of the package. If ExternalName is unspecified or illegal, an error will be thrown."/>
 <modifier name="export-python-deps" dataAlias="ExportPythonDependencies" dataValue="1" description="If specified, exports Python dependencies. If omitted, defaults to false." />
+<modifier name="include-tests" dataAlias="IncludeTests" dataValue="1" description="If specified, includes test-scoped resources in the package." />
 </command>
 
 <command name="update" dataPrefix="D">

--- a/src/cls/IPM/ResourceProcessor/Test.cls
+++ b/src/cls/IPM/ResourceProcessor/Test.cls
@@ -118,14 +118,35 @@ Method OnPhase(
 
             // Ensure unit tests and related classes are loaded.
             set tUnitTestDir = ##class(%File).NormalizeDirectory(..ResourceReference.Module.Root_..ResourceReference.Name)
-            set tSC = ##class(%IPM.Test.Manager).LoadTestDirectory(tUnitTestDir,tVerbose, ,..Format)
-            $$$ThrowOnError(tSC)
+            set fileExt = $case(..Format, "XML":"xml", :"cls")
+
+            if $data(pParams("UnitTest","Case"), earlyCase)#2 {
+                // Convert dotted package prefix to directory path, e.g. Test.PM.Unit -> Test/PM/Unit
+                set caseDir = $replace($piece(earlyCase,".",1,*-1),".","/")
+                set caseFilePath = ##class(%File).NormalizeFilename(tUnitTestDir_caseDir_"/"_$piece(earlyCase,".",*)_"."_fileExt)
+                // Fall back to full directory if the specific file isn't on disk
+                // (e.g., the class lives in a different resource's directory).
+                if ##class(%File).Exists(caseFilePath) {
+                    $$$ThrowOnError($system.OBJ.Load(caseFilePath, "k"_$select(tVerbose:"/display",1:"/nodisplay")))
+                } else {
+                    $$$ThrowOnError(##class(%IPM.Test.Manager).LoadTestDirectory(tUnitTestDir, tVerbose, , ..Format))
+                }
+            } elseif $data(pParams("UnitTest","Suite"), earlySuite)#2 {
+                set suiteDir = ##class(%File).NormalizeDirectory(tUnitTestDir_$replace(earlySuite,".","\"))
+                $$$ThrowOnError(##class(%IPM.Test.Manager).LoadTestDirectory(suiteDir, tVerbose, , ..Format))
+            } else {
+                $$$ThrowOnError(##class(%IPM.Test.Manager).LoadTestDirectory(tUnitTestDir, tVerbose, , ..Format))
+            }
 
             set tCompileFlags = "ck"_$select(tVerbose:"d",1:"-d")
             set tDoDelete = 1
             set tTestSpec = ""
             if (..Package '= "") {
-                $$$ThrowOnError($system.OBJ.CompilePackage(..Package, tCompileFlags))
+                if $data(pParams("UnitTest","Case"), tTestCase)#2 {
+                    $$$ThrowOnError($system.OBJ.Compile(tTestCase, tCompileFlags))
+                } else {
+                    $$$ThrowOnError($system.OBJ.CompilePackage(..Package, tCompileFlags))
+                }
 
                 // See if package contains any classes.
                 // If it does, we won't delete the classes after running the test.
@@ -276,9 +297,16 @@ Method OnResolveChildren(ByRef pResourceArray) As %Status
         set tResourceInfo("Processor") = $this
         set tResourceInfo("UnitTest") = 1
         set tResource = $case(..Package '= "", 1: ..Package, : ..Class)_..Extension
-        $$$ThrowOnError(##class(%IPM.Storage.ResourceReference).GetChildren(tResource,tModuleName,1,.tResourceInfo,.pResourceArray))
-        $$$ThrowOnError(..EmbeddedProcessor.OnResolveChildren(.pResourceArray))
-        merge pResourceArray = tResourceInfo
+        // GetChildren has Output semantics — it kills its output array before populating it.
+        // Using tClassArray (not pResourceArray directly) preserves any existing entries
+        // in pResourceArray (e.g., the "/tests/" path entry added before this call).
+        kill tClassArray
+        $$$ThrowOnError(##class(%IPM.Storage.ResourceReference).GetChildren(tResource,tModuleName,1,.tResourceInfo,.tClassArray))
+        $$$ThrowOnError(..EmbeddedProcessor.OnResolveChildren(.tClassArray))
+        merge pResourceArray = tClassArray
+        // pResourceArray("Scope") is read by GetResolvedReferences for the HasScope check.
+        // tResourceInfo("Scope") above stamps each child class node — different consumers.
+        set pResourceArray("Scope") = ..Phase
     } catch e {
         set tSC = e.AsStatus()
     }
@@ -327,6 +355,12 @@ Method OnExportItem(
 	ByRef pParams,
 	Output pItemHandled As %Boolean = 0) As %Status
 {
+    // Path resources (Name="/tests/...") are handled by directory-copy in ExportSingleModule,
+    // not by ExportUDL. Returning here with pItemHandled=0 lets ExportSingleModule fall through
+    // to that branch. Delegating to EmbeddedProcessor would attempt ExportUDL("/tests/"), which fails.
+    if ($extract(pItemName) = "/") {
+        quit $$$OK
+    }
     quit ..EmbeddedProcessor.OnExportItem(pFullExportPath, pItemName, .pItemParams, .pParams, .pItemHandled)
 }
 

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -85,6 +85,8 @@ Property AfterInstallMessage As %String(MAXLEN = "", XMLPROJECTION = "Element");
 
 Property Deployed As %Boolean(XMLPROJECTION = "Element");
 
+Property IncludeTests As %Boolean(XMLPROJECTION = "Element");
+
 Property UpdatePackage As %Dictionary.Classname;
 
 /// Iterates through all of a module's update step classes and tries to either execute or seed those steps.
@@ -1352,6 +1354,8 @@ Method GetResolvedReferences(
             set tSC = tResource.ResolveChildren(.tempArray)
             set resourceScope = tResource.Scope
             set attrScope = $get(tempArray("Scope"))
+            // Kill before merge so "Scope" doesn't leak into pReferenceArray as a resource name.
+            kill tempArray("Scope")
             if ..HasScope(pPhases, resourceScope) && ..HasScope(pPhases, attrScope) {
                 merge pReferenceArray(..Name) = tempArray
             }
@@ -1955,6 +1959,9 @@ Storage Default
 </Value>
 <Value name="29">
 <Value>UpdatePackage</Value>
+</Value>
+<Value name="30">
+<Value>IncludeTests</Value>
 </Value>
 </Data>
 <DataLocation>^IPM.Storage.ModuleD</DataLocation>

--- a/tests/integration_tests/Test/PM/Integration/IncludeTests.cls
+++ b/tests/integration_tests/Test/PM/Integration/IncludeTests.cls
@@ -1,0 +1,110 @@
+Class Test.PM.Integration.IncludeTests Extends %UnitTest.TestCase
+{
+
+Method OnAfterAllTests() As %Status
+{
+  do ##class(%IPM.Main).Shell("uninstall test-output-format")
+  return $$$OK
+}
+
+Method TestExcludeTestsByDefault()
+{
+  set status = $$$OK
+  try {
+    set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
+    set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/test-output-format/")
+    set status = ##class(%IPM.Main).Shell("load "_moduleDir)
+    do $$$AssertStatusOK(status,"Loaded test-output-format module successfully.")
+
+    set tempDir = ##class(%Library.File).TempFilename()_"dir"
+    set status = ##class(%IPM.Main).Shell("test-output-format package -only -DPath="_tempDir)
+    do $$$AssertStatusOK(status,"Packaged test-output-format without -include-tests successfully.")
+
+    set outFile = ##class(%Library.File).TempFilename()
+    set outDir = ##class(%Library.File).NormalizeDirectory(##class(%Library.File).TempFilename()_"dir-out")
+    do ##class(%Library.File).CreateDirectoryChain(outDir)
+    do $$$AssertEquals($zf(-100,"/STDOUT="""_outFile_"""/STDERR="""_outFile_"""","tar","-xvf",tempDir_".tgz","-C",outDir),0)
+
+    do $$$AssertTrue(##class(%File).Exists(outDir_"module.xml"),"module.xml is present in package.")
+    do $$$AssertNotTrue(##class(%File).DirectoryExists(outDir_"tests"),"tests/ directory is absent from package by default.")
+  } catch e {
+    do $$$AssertStatusOK(e.AsStatus(),"An exception occurred.")
+  }
+}
+
+Method TestIncludeTestsFlag()
+{
+  set status = $$$OK
+  try {
+    set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
+    set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/test-output-format/")
+    set status = ##class(%IPM.Main).Shell("load "_moduleDir)
+    do $$$AssertStatusOK(status,"Loaded test-output-format module successfully.")
+
+    set tempDir = ##class(%Library.File).TempFilename()_"dir"
+    set status = ##class(%IPM.Main).Shell("test-output-format package -only -include-tests -DPath="_tempDir)
+    do $$$AssertStatusOK(status,"Packaged test-output-format with -include-tests successfully.")
+
+    set outFile = ##class(%Library.File).TempFilename()
+    set outDir = ##class(%Library.File).NormalizeDirectory(##class(%Library.File).TempFilename()_"dir-out")
+    do ##class(%Library.File).CreateDirectoryChain(outDir)
+    do $$$AssertEquals($zf(-100,"/STDOUT="""_outFile_"""/STDERR="""_outFile_"""","tar","-xvf",tempDir_".tgz","-C",outDir),0)
+
+    do $$$AssertTrue(##class(%File).Exists(outDir_"module.xml"),"module.xml is present in package.")
+    do $$$AssertTrue(##class(%File).Exists(outDir_"tests/Test/Output/Format/AfterAllReturn.cls"),"Test file is present in package with -include-tests.")
+  } catch e {
+    do $$$AssertStatusOK(e.AsStatus(),"An exception occurred.")
+  }
+}
+
+Method TestIncludeTestsModuleXml()
+{
+  set status = $$$OK
+  try {
+    set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
+    set sourceDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/test-output-format/")
+
+    // Copy to temp dir so we can modify module.xml without altering the shared test fixture.
+    set tempModuleDir = ##class(%Library.File).NormalizeDirectory(##class(%Library.File).TempFilename()_"dir-src")
+    do ##class(%Library.File).CreateDirectoryChain(tempModuleDir)
+    if '##class(%Library.File).CopyDir(sourceDir, tempModuleDir, 1) {
+      do $$$AssertTrue(0,"Failed to copy test-output-format to temp directory.")
+      quit
+    }
+
+    // Inject <IncludeTests>1</IncludeTests> into the module.xml copy.
+    set moduleXmlPath = tempModuleDir_"module.xml"
+    set readStream = ##class(%Stream.FileCharacter).%New()
+    $$$ThrowOnError(readStream.LinkToFile(moduleXmlPath))
+    set xmlContent = ""
+    while 'readStream.AtEnd {
+      set xmlContent = xmlContent _ readStream.ReadLine() _ $char(10)
+    }
+    set xmlContent = $replace(xmlContent, "</Module>", "  <IncludeTests>1</IncludeTests>"_$char(10)_"    </Module>")
+    set readStream = ""
+
+    set writeStream = ##class(%Stream.FileCharacter).%New()
+    $$$ThrowOnError(writeStream.LinkToFile(moduleXmlPath))
+    $$$ThrowOnError(writeStream.Write(xmlContent))
+    $$$ThrowOnError(writeStream.%Save())
+
+    set status = ##class(%IPM.Main).Shell("load "_tempModuleDir)
+    do $$$AssertStatusOK(status,"Loaded test-output-format module with IncludeTests from module.xml.")
+
+    set tempDir = ##class(%Library.File).TempFilename()_"dir"
+    set status = ##class(%IPM.Main).Shell("test-output-format package -only -DPath="_tempDir)
+    do $$$AssertStatusOK(status,"Packaged test-output-format (IncludeTests from module.xml) successfully.")
+
+    set outFile = ##class(%Library.File).TempFilename()
+    set outDir = ##class(%Library.File).NormalizeDirectory(##class(%Library.File).TempFilename()_"dir-out")
+    do ##class(%Library.File).CreateDirectoryChain(outDir)
+    do $$$AssertEquals($zf(-100,"/STDOUT="""_outFile_"""/STDERR="""_outFile_"""","tar","-xvf",tempDir_".tgz","-C",outDir),0)
+
+    do $$$AssertTrue(##class(%File).Exists(outDir_"module.xml"),"module.xml is present in package.")
+    do $$$AssertTrue(##class(%File).Exists(outDir_"tests/Test/Output/Format/AfterAllReturn.cls"),"Test file is present when IncludeTests set in module.xml.")
+  } catch e {
+    do $$$AssertStatusOK(e.AsStatus(),"An exception occurred.")
+  }
+}
+
+}


### PR DESCRIPTION
## Description
- Resolves #870 
- Resolves #843 
- When running tests, if you specify a suite or class using the -D flags, instead of loading and compiling all tests, will just load and compile the relevant tests.
- Added option to include tests in package/publish either with a CLI `-include-tests` flag or adding a `<IncludeTests>1</IncludeTests>` element in module.xml

## Testing
Added a new integration test.
Ran the tests both with and without the -D flags

## Checklist
<!-- You can select a checkbox by changing "[ ]" to "[x]" -->
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] Changelog entry added.
- [x] Unit (`zpm test -only`) and integration tests (`zpm verify -only`) pass.
- [x] Style matches the style guide in the [contributing guide](https://github.com/intersystems/ipm/blob/main/CONTRIBUTING.md#style-guide).
- [x] Documentation has been/will be updated
  - Source controlled docs, e.g. README.md, should be included in this PR and Wiki changes should be made after this PR is merged (add an extra issue for this if needed)
- [x] Pull request correctly renders in the "Preview" tab.
