### PR TITLE
list parsing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #1079: Add semantic sorting and shortcuts to list-installed
 
 ### Fixed
+- #1175: Fix issue parsing version for packages with both deployed and non-deployed versions
 - #964: Fix poor error handling on some install failures due to incorrect error message variable in embedded SQL
 - #1130: Fix issue with ORAS repositories pointing to some OCI registries that require authentication (e.g. ghcr.io) not accepting credentials properly. `repo -list` now shows an `Authenticated?` status for ORAS repos with credentials configured.
 - #1001: The `unmap` and `enable` commands will now only activate CPF merge once after all namespaces have been configured instead after every namespace

--- a/src/cls/IPM/Repo/Oras/PackageService.cls
+++ b/src/cls/IPM/Repo/Oras/PackageService.cls
@@ -192,7 +192,9 @@ ClassMethod AggregatePlatformVersions(
     set ptr = 0
     while $listnext(tagsList, ptr, tag) {
         // aggregate
-        set $listbuild(version, platformVersion) = $listfromstring(tag, $$$OrasTagPlatformSeparator)
+        set parsed = $listfromstring(tag, $$$OrasTagPlatformSeparator)
+        set version = $listget(parsed, 1)
+        set platformVersion = $listget(parsed, 2, "")  // Default to empty string if no platform
         set value = $get(aggregatedPlatformVersion(version))
         set aggregatedPlatformVersion(version) = value _ $listbuild(platformVersion)
     }


### PR DESCRIPTION
## Description
Closes #1175 
### Problem

When parsing ORAS tags, $listbuild(version, platformVersion) = $listfromstring(tag, "\__") doesn't reset variables when a tag has no "__" separator. This causes the platformVersion variable to retain values from previous loop iterations, incorrectly assigning platform versions to non-deployed packages.

### Solution
Changed to use $listget() with explicit defaults:


set parsed = \$ listfromstring(tag, \$$$OrasTagPlatformSeparator)
set version = \$listget(parsed, 1)
set platformVersion = $listget(parsed, 2, "")  // Default to empty string
This ensures platformVersion is always set correctly, preventing IPM from appending platform suffixes like __2026.1 to tags that don't have them.

### Impact
Fixes installation failures when ORAS registries contain a mix of deployed (with __platform) and non-deployed tags for the same package.

## Testing
Tested install of a deployed and non-deployed version of the package

## Checklist
<!-- You can select a checkbox by changing "[ ]" to "[x]" -->
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [X] Changelog entry added.
- [X] Unit (`zpm test -only`) and integration tests (`zpm verify -only`) pass.
- [X] Style matches the style guide in the [contributing guide](https://github.com/intersystems/ipm/blob/main/CONTRIBUTING.md#style-guide).
- [X] Documentation has been/will be updated
  - Source controlled docs, e.g. README.md, should be included in this PR and Wiki changes should be made after this PR is merged (add an extra issue for this if needed)
- [X] Pull request correctly renders in the "Preview" tab.
