### PR TITLE
Remove upper bound Python version checker and update container images to 2026.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #1114: Fix issue with SystemRequirements being confused by multiple namespaces with different version of IPM installed
 - #1128: Fixed an issue where an update can fail if a resource is moved from one module to another
 - #430: Updating shared transitive dependencies with lock-step version requirements now works instead of erroring out
+- #1179: IPM will no longer erroneously complain about Python 3.13+ on compatible versions of IRIS. The lower bound check (3.10+) remains, but the upper bound is left to the user. There is a compatibility matrix in the README.
 
 ### Security
 - urllib Python wheel updated to 2.7.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=containers.intersystems.com/intersystems/iris-community:2025.1
+ARG BASE=containers.intersystems.com/intersystems/iris-community:2026.1
 
 FROM ${BASE}
 

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -173,9 +173,6 @@ ClassMethod ValidatePythonRuntime() As %Boolean
         if (+version < 3.10) {
             write !!,"WARNING: Python version "_version_" is not supported. IPM requires Python 3.10 or higher.",!
             return 0
-        } elseif (+version > 3.12) {
-            write !!,"WARNING: Python version "_version_" is not yet supported. IPM cannot use Python 3.13 or higher due to IRIS incompatibilities.",!
-            return 0
         }
     } catch e {
         return 0

--- a/tests/sandbox/Dockerfile
+++ b/tests/sandbox/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=containers.intersystems.com/intersystems/iris-community:2025.1
+ARG BASE=containers.intersystems.com/intersystems/iris-community:2026.1
 FROM ${BASE}
 ARG IPM_VERSION=zpm-0.7.2.xml
 

--- a/tests/sandbox/durable-sys/docker-compose.yml
+++ b/tests/sandbox/durable-sys/docker-compose.yml
@@ -1,14 +1,14 @@
 services:
   irishealth:
     init: true
-    image: irepo.intersystems.com/intersystems/irishealth:2025.1
+    image: irepo.intersystems.com/intersystems/irishealth:2026.1
     hostname: irishealth
-    ports: 
+    ports:
       - 1972
-    command: 
+    command:
       - --check-caps false
       - --key /irishealth-shared/iris.key
-    volumes: 
+    volumes:
       - type: bind
         source: ./irishealth/shared
         target: /irishealth-shared
@@ -23,21 +23,21 @@ services:
           cpus: '2.00'
           memory: 8gb
 
-# web gateway container
+  # web gateway container
   webgateway:
     init: true
-    image: irepo.intersystems.com/intersystems/webgateway:2025.1
+    image: irepo.intersystems.com/intersystems/webgateway:2026.1
     hostname: webgateway
     ports:
-    - 80
+      - 80
     environment:
-    - ISC_DATA_DIRECTORY=/webgateway-shared/durable
-    - ISC_CSP_CONF_FILE=/webgateway-shared/CSP.conf
-    - ISC_CSP_INI_FILE=/webgateway-shared/CSP.ini
+      - ISC_DATA_DIRECTORY=/webgateway-shared/durable
+      - ISC_CSP_CONF_FILE=/webgateway-shared/CSP.conf
+      - ISC_CSP_INI_FILE=/webgateway-shared/CSP.ini
     volumes:
-    - ./webgateway/shared:/webgateway-shared
+      - ./webgateway/shared:/webgateway-shared
     depends_on:
-    - irishealth
+      - irishealth
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Description
- Resolves #1179 
- Resolves #1174 
- The upper bound check on the Python version has been removed since this is dynamically dependent on IRIS version and more trouble than worth
  - Users can check the compatibility table in the README.md
