### PR TITLE
Fix downstream regression on ResolveChildren() output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ semver Intersection would incorrectly pass if an exact version is compared again
 no overlap.
 - #1077: Fixed error handling of dependency resolution to correctly report what the offending
 modules are.
+- #1187: Remove extra path entries in output of %IPM.Storage.ResourceReference:ResolveChildren() that broke unguarded downstream callers.
 
 ## [0.10.7] - 2026-05-29
 

--- a/src/cls/IPM/ResourceProcessor/Test.cls
+++ b/src/cls/IPM/ResourceProcessor/Test.cls
@@ -288,8 +288,7 @@ Method OnResolveChildren(ByRef pResourceArray) As %Status
         set tResourceInfo("UnitTest") = 1
         set tResource = $case(..Package '= "", 1: ..Package, : ..Class)_..Extension
         // GetChildren has Output semantics — it kills its output array before populating it.
-        // Using tClassArray (not pResourceArray directly) preserves any existing entries
-        // in pResourceArray (e.g., the "/tests/" path entry added before this call).
+        // Use tClassArray as the intermediate to avoid killing any existing entries in pResourceArray.
         kill tClassArray
         $$$ThrowOnError(##class(%IPM.Storage.ResourceReference).GetChildren(tResource,tModuleName,1,.tResourceInfo,.tClassArray))
         $$$ThrowOnError(..EmbeddedProcessor.OnResolveChildren(.tClassArray))

--- a/src/cls/IPM/Storage/Module.cls
+++ b/src/cls/IPM/Storage/Module.cls
@@ -1371,6 +1371,11 @@ Method GetResolvedReferences(
             kill tempArray("Scope")
             if ..HasScope(pPhases, resourceScope) && ..HasScope(pPhases, attrScope) {
                 merge pReferenceArray(..Name) = tempArray
+                // ResolveChildren does not emit path entries for document enumeration. Re-add here
+                // because ExportSingleModule needs the path entry to trigger its directory-copy branch.
+                if $extract(tResource.Name) = "/" {
+                    set pReferenceArray(..Name, tResource.Name) = ..Name
+                }
             }
             if $$$ISERR(tSC) {
                 quit

--- a/src/cls/IPM/Storage/ResourceReference.cls
+++ b/src/cls/IPM/Storage/ResourceReference.cls
@@ -193,7 +193,7 @@ ClassMethod GetChildren(
                 quit
             }
         } else {
-            if pResourceName '= "" {
+            if (pResourceName '= "") && ($extract(pResourceName) '= "/") {
                 merge pResourceArray(pResourceName) = pResourceInfoArray
             }
 

--- a/tests/integration_tests/Test/PM/Integration/IncludeTests.cls
+++ b/tests/integration_tests/Test/PM/Integration/IncludeTests.cls
@@ -107,4 +107,41 @@ Method TestIncludeTestsModuleXml()
   }
 }
 
+// Regression test: ResolveChildren must not return path entries (names starting with /)
+// as top-level keys. Path resources have no Studio document representation; returning them
+// as document names can crash callers.
+Method TestResolveChildrenNoPathEntries()
+{
+    set status = $$$OK
+    try {
+        set testRoot = ##class(%File).NormalizeDirectory($get(^UnitTestRoot))
+        set moduleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(testRoot)_"/_data/test-output-format/")
+        set status = ##class(%IPM.Main).Shell("load "_moduleDir)
+        do $$$AssertStatusOK(status,"Loaded test-output-format module successfully.")
+
+        set module = ##class(%IPM.Storage.Module).NameOpen("test-output-format",,.status)
+        do $$$AssertStatusOK(status,"Opened test-output-format module.")
+
+        set foundPathEntry = 0
+        set key = ""
+        for {
+            set tResource = module.Resources.GetNext(.key)
+            quit:(key = "")
+            kill tChildren
+            do $$$AssertStatusOK(tResource.ResolveChildren(.tChildren),"ResolveChildren succeeded for "_tResource.Name)
+            set childKey = ""
+            for {
+                set childKey = $order(tChildren(childKey))
+                quit:(childKey = "")
+                if ($extract(childKey) = "/") {
+                    set foundPathEntry = 1
+                }
+            }
+        }
+        do $$$AssertNotTrue(foundPathEntry,"ResolveChildren output contains no path entries.")
+    } catch e {
+        do $$$AssertStatusOK(e.AsStatus(),"An exception occurred.")
+    }
+}
+
 }

--- a/tests/integration_tests/Test/PM/Integration/IncludeTests.cls
+++ b/tests/integration_tests/Test/PM/Integration/IncludeTests.cls
@@ -122,7 +122,6 @@ Method TestResolveChildrenNoPathEntries()
         set module = ##class(%IPM.Storage.Module).NameOpen("test-output-format",,.status)
         do $$$AssertStatusOK(status,"Opened test-output-format module.")
 
-        set foundPathEntry = 0
         set key = ""
         for {
             set tResource = module.Resources.GetNext(.key)
@@ -133,12 +132,11 @@ Method TestResolveChildrenNoPathEntries()
             for {
                 set childKey = $order(tChildren(childKey))
                 quit:(childKey = "")
-                if ($extract(childKey) = "/") {
-                    set foundPathEntry = 1
+                if $extract(childKey) = "/" {
+                    do $$$AssertTrue(0,"Path entry '"_childKey_"' found in ResolveChildren output for "_tResource.Name)
                 }
             }
         }
-        do $$$AssertNotTrue(foundPathEntry,"ResolveChildren output contains no path entries.")
     } catch e {
         do $$$AssertStatusOK(e.AsStatus(),"An exception occurred.")
     }


### PR DESCRIPTION
## Description
- Fixes #1187 
- Changes ResolveChildren to only have one responsibility: listing the actual resources and not the path
- The path is used by ExportSingleModule, which calls into GetResolvedReferences, which now has the path entry injected there (output has not changed)
- The p4 extension directly calls into ResolveChildren and does not want paths

## Testing
Added an integration test.
Update: was able to reproduce the bug by creating the exact same environment as the reporter. Recreated the crash on IPM 0.10.7, loaded this 0.10.8+snapshot fix, and was able to install healthshare.hp.atr in dev mode without issues.

Keeping this old section for extra context:

> Was ultimately unable to reproduce the original bug but manually confirmed the changes to ResolveChildren() output as follows:
> 
> With isc.json installed (the original offending module) and then calling `set mod = ##class(%IPM.Storage.Module).NameOpen("isc.json") set key="" for { set res=mod.Resources.GetNext(.key) quit:key=""  kill tc  do res.ResolveChildren(.tc) zwrite tc }`, 0.10.7 adds a few entries not present in 0.10.6:
> ```
> [...]
> tc("/internal/testing/unit_tests/")="isc.json"
> tc("/internal/testing/unit_tests/","Deploy")=""
> tc("/internal/testing/unit_tests/","Generated")=""
> tc("/internal/testing/unit_tests/","Preload")=""
> tc("/internal/testing/unit_tests/","Processor")=21@%IPM.ResourceProcessor.Test  ; <OREF,refs=2>
> tc("/internal/testing/unit_tests/","Scope")=""
> ```
> 
> These cause the crash because `##class(%Studio.SourceControl.Interface).ExternalName()` is called on each child resource/top level key, e.g. `"/internal/testing/unit_tests/"`. Somewhere along the call chain/name normalization, this gets converted to `""`, which results in a `<SUBSCRIPT>` error from trying to access `^Sources("")`. By removing these entries from the output, the crash should be avoided even if this were not able to be empirically proven.