### PR TITLE
Fix issue where IPM would get stuck in secret mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ no overlap.
 modules are.
 - #1187: Remove extra path entries in output of %IPM.Storage.ResourceReference:ResolveChildren() that broke unguarded downstream callers.
 - #1191: Fixed issue where configured Python version would not be used automatically during calls to pip
+- #1198: Fixed bug where using `-password-stdin` would leave the IPM terminal in secret mode
 
 ## [0.10.7] - 2026-05-29
 

--- a/src/cls/IPM/Repo/Definition.cls
+++ b/src/cls/IPM/Repo/Definition.cls
@@ -186,10 +186,19 @@ ClassMethod Configure(
 
         if $data(pModifiers("password-stdin")) {
             // prompt for password using secret input terminal mode
-            open $io:(:"S")
-            read "Password: ", pwd
-            close $io
-            set pModifiers("password") = pwd
+            set ioDevice = $io
+            set readSC = $$$OK
+            try {
+                open ioDevice:(:"S")
+                read "Password: ", pwd
+                write !
+                set pModifiers("password") = pwd
+            } catch ex {
+                set readSC = ex.AsStatus()
+            }
+            // Restore normal echo mode — must happen even on Ctrl+C or error
+            open ioDevice:(:"")
+            $$$ThrowOnError(readSC)
         } elseif $data(pModifiers("password")) {
             write !, $$$FormattedLine($$$Yellow, "WARNING: Using --password via the CLI is insecure. Use --password-stdin.")
         }


### PR DESCRIPTION
## Description
- Fixes #1198 by wrapping the io device code in try-catch block so echo is always restored.

## Testing
Manually tested by ctrl+c'ing out of the secret mode password input and verified the terminal returned to echo mode.

## Checklist
<!-- You can select a checkbox by changing "[ ]" to "[x]" -->
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] Changelog entry added.
- [x] Unit (`zpm test -only`) and integration tests (`zpm verify -only`) pass.
- [x] Style matches the style guide in the [contributing guide](https://github.com/intersystems/ipm/blob/main/CONTRIBUTING.md#style-guide).
- [x] Documentation has been/will be updated
  - Source controlled docs, e.g. README.md, should be included in this PR and Wiki changes should be made after this PR is merged (add an extra issue for this if needed)
- [x] Pull request correctly renders in the "Preview" tab.
