### PR TITLE
Fix installer crash on particular environments with existing IPM code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - #1207: Zero-byte files are now supported in IPM modules
+- #1209: Fix IPM installer failing on certain environments with (partially) installed older IPM versions
 
 ## [0.10.8] - 2026-07-08
 

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -456,22 +456,29 @@ ClassMethod CleanupOldMappings() As %Status
 
         // These mappings were suggested as a temporary workaround for IRIS 2023.x,
         // but whose underlying issues have been resolved in 2024.1 and later.
-        set status = ##class(%IPM.Utils.Module).RemoveGlobalMapping($namespace,"oddStudioDocument:(BEGIN):(""%ZP"")","IRISLIB")
-        if $$$ISERR(status) {
-            set sc = $$$ADDSC(sc, status)
-        }
-        set status = ##class(%IPM.Utils.Module).RemoveGlobalMapping($namespace,"oddStudioDocument:(""%ZP""):(""A"")","IRISSYS")
-        if $$$ISERR(status) {
-            set sc = $$$ADDSC(sc, status)
-        }
-        set status = ##class(%IPM.Utils.Module).RemoveGlobalMapping($namespace,"oddStudioDocument:(""Ens""):(""Ent"")","ENSLIB")
-        if $$$ISERR(status) {
-            set sc = $$$ADDSC(sc, status)
-        }
-        set status = ##class(%IPM.Utils.Module).RemoveGlobalMapping($namespace,"oddStudioDocument",namespace)
-        if $$$ISERR(status) {
-            // this mapping deletion will fail if there are still sub-mappings present
-            // so we can ignore errors here
+        // %IPM.Utils.Module ships in the src payload imported later in this manifest, so
+        // on some upgrade paths the class/method may not yet exist when this runs. Tolerate
+        // that with a try/catch rather than reordering, since cleanup must precede the import.
+        try {
+            set status = ##class(%IPM.Utils.Module).RemoveGlobalMapping($namespace,"oddStudioDocument:(BEGIN):(""%ZP"")","IRISLIB")
+            if $$$ISERR(status) {
+                set sc = $$$ADDSC(sc, status)
+            }
+            set status = ##class(%IPM.Utils.Module).RemoveGlobalMapping($namespace,"oddStudioDocument:(""%ZP""):(""A"")","IRISSYS")
+            if $$$ISERR(status) {
+                set sc = $$$ADDSC(sc, status)
+            }
+            set status = ##class(%IPM.Utils.Module).RemoveGlobalMapping($namespace,"oddStudioDocument:(""Ens""):(""Ent"")","ENSLIB")
+            if $$$ISERR(status) {
+                set sc = $$$ADDSC(sc, status)
+            }
+            set status = ##class(%IPM.Utils.Module).RemoveGlobalMapping($namespace,"oddStudioDocument",namespace)
+            if $$$ISERR(status) {
+                // this mapping deletion will fail if there are still sub-mappings present
+                // so we can ignore errors here
+            }
+        } catch e {
+            // %IPM.Utils.Module (or RemoveGlobalMapping) not available yet on this upgrade path; skip
         }
     }
 

--- a/preload/cls/IPM/Installer.cls
+++ b/preload/cls/IPM/Installer.cls
@@ -479,6 +479,7 @@ ClassMethod CleanupOldMappings() As %Status
             }
         } catch e {
             // %IPM.Utils.Module (or RemoveGlobalMapping) not available yet on this upgrade path; skip
+            write !,"WARNING: CleanupOldMappings caught exception in ",namespace,": ",e.DisplayString()
         }
     }
 


### PR DESCRIPTION
## Description
- Fixes #1209 

## Testing
Manually tested by running these steps:

1. Install IPM
2. Package snapshot
  a. `zpm "package zpm -only -p /tmp/zpm-0.10.9"`
  b. `w ##class(IPM.Installer).MakeFile("/tmp/zpm-0.10.9.tgz","/tmp/zpm-0.10.9.xml")`
3. Break the existing IPM installation
  a.  `set m = ##class(%IPM.Storage.Module).NameOpen("zpm")`
  b. `do ##class(%IPM.Storage.Module).%DeleteId(m.%Id())`
  c.  `do $system.OBJ.Delete("%IPM.Utils.Module","d")`
4. Reinstall IPM with `do $system.OBJ.Load("/tmp/zpm-0.10.9.xml","ck")`

(To reproduce the crash, replace step 4 with installing 0.10.8)

## Checklist
<!-- You can select a checkbox by changing "[ ]" to "[x]" -->
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] Changelog entry added.
- [x] Unit (`zpm test -only`) and integration tests (`zpm verify -only`) pass.
- [x] Style matches the style guide in the [contributing guide](https://github.com/intersystems/ipm/blob/main/CONTRIBUTING.md#style-guide).
- [x] Documentation has been/will be updated
  - Source controlled docs, e.g. README.md, should be included in this PR and Wiki changes should be made after this PR is merged (add an extra issue for this if needed)
- [x] Pull request correctly renders in the "Preview" tab.
