### PR TITLE
Fix pre-release version parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - #1207: Zero-byte files are now supported in IPM modules
 - #1209: Fix IPM installer failing on certain environments with (partially) installed older IPM versions
+- #1212: Fix improper parsing of module versions with dashes in the pre-release string
 
 ## [0.10.8] - 2026-07-08
 

--- a/src/cls/IPM/General/SemanticVersionExpression/Comparator.cls
+++ b/src/cls/IPM/General/SemanticVersionExpression/Comparator.cls
@@ -58,7 +58,7 @@ ClassMethod FromString(
     set pComparator.Minor = $piece(pExpr,".",2)
     set tEnd = $piece(pExpr,".",3,*)
     set pComparator.Patch = $piece($piece(tEnd,"-"),"+") // Before -prerelease and/or +build
-    set pComparator.Prerelease = $piece($piece(tEnd,"-",2),"+") // After - and possibly before +build
+    set pComparator.Prerelease = $piece($piece(tEnd,"-",2,*),"+") // After - and possibly before +build
     set pComparator.Build = $piece(tEnd,"+",2)
 
     set tSC = pComparator.%ValidateObject()

--- a/tests/unit_tests/Test/PM/Unit/SemVer/Expressions.cls
+++ b/tests/unit_tests/Test/PM/Unit/SemVer/Expressions.cls
@@ -58,6 +58,18 @@ Method TestPrerelease()
     do ..AssertNotSatisfied("1.0.0-1.m1","1.0.0")
     do ..AssertNotSatisfied("=1.0.0-1.m1","1.0.0")
 
+    // Prerelease identifiers containing hyphens must not be truncated at the second hyphen
+    do ..AssertSatisfied("1.0.0-alpha-1","1.0.0-alpha-1")
+    do ..AssertSatisfied("=1.0.0-alpha-1","1.0.0-alpha-1")
+    do ..AssertNotSatisfied("=1.0.0-alpha-1","1.0.0-alpha-2")
+    do ..AssertNotSatisfied("=1.0.0-alpha-1","1.0.0-alpha")
+    do ..AssertNotSatisfied("=1.0.0-alpha-1","1.0.0")
+    // Multiple hyphens and dot-separated segments with hyphens
+    do ..AssertSatisfied("=1.0.0-alpha-beta-gamma","1.0.0-alpha-beta-gamma")
+    do ..AssertNotSatisfied("=1.0.0-alpha-beta-gamma","1.0.0-alpha-beta")
+    do ..AssertSatisfied("=1.0.0-rc.1-final","1.0.0-rc.1-final")
+    do ..AssertNotSatisfied("=1.0.0-rc.1-final","1.0.0-rc.1")
+
     // Issue #557: snapshots/prereleases shouldn't be considered as a lower version number
     // Even though 1.5.0-beta.1 is technically within the 1.x range, it's a prerelease and should not be considered satisfiable.
     // Similarly 1.1.5-beta.1 does not satisify 1.1.x. See https://github.com/npm/node-semver?tab=readme-ov-file#prerelease-tags


### PR DESCRIPTION
## Description
- Fixes #1212
- Fixes pre-release string parsing to allow dashes

## Testing
Added unit test cases containing multiple dashes to Test.PM.Unit.SemVer.Expressions

## Checklist
<!-- You can select a checkbox by changing "[ ]" to "[x]" -->
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] Changelog entry added.
- [x] Unit (`zpm test -only`) and integration tests (`zpm verify -only`) pass.
- [x] Style matches the style guide in the [contributing guide](https://github.com/intersystems/ipm/blob/main/CONTRIBUTING.md#style-guide).
- [x] Documentation has been/will be updated
  - Source controlled docs, e.g. README.md, should be included in this PR and Wiki changes should be made after this PR is merged (add an extra issue for this if needed)
- [x] Pull request correctly renders in the "Preview" tab.
