### PR TITLE
Add system requirement setting for %SYS namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - #1117: Add `sync` command for incremental loading of changed files in dev-mode modules. Detects modified files since last sync using SHA-1 hash and recompiles only what is stale. Supports `-delete` for processing removed files and `-test` for running changed test-phase unit tests.
+- #106: A module can now specify `<SystemRequirements SYSNamespace="true"/>` to prevent installation in non-%SYS namespaces.
 
 ### Fixed
 - Performance: Studio project creation on package load in dev mode is now 80% faster.

--- a/src/cls/IPM/Storage/SystemRequirements.cls
+++ b/src/cls/IPM/Storage/SystemRequirements.cls
@@ -27,6 +27,8 @@ Property IPMVersion As %String(MAXLEN = 256, XMLPROJECTION = "ATTRIBUTE");
 
 Property PythonVersion As %String(MAXLEN = 256, XMLPROJECTION = "ATTRIBUTE");
 
+Property SYSNamespace As %Boolean(XMLPROJECTION = "ATTRIBUTE");
+
 Method CheckRequirements() As %Status
 {
     set tSC = $$$OK
@@ -35,6 +37,7 @@ Method CheckRequirements() As %Status
     set tSC = $system.Status.AppendStatus(tSC,..CheckHealth())
     set tSC = $system.Status.AppendStatus(tSC,..CheckIPMVersion())
     set tSC = $system.Status.AppendStatus(tSC,..CheckPythonVersion())
+    set tSC = $system.Status.AppendStatus(tSC,..CheckSYSNamespace())
     return tSC
 }
 
@@ -127,6 +130,14 @@ ClassMethod IsInteroperabilityEnabled() As %Boolean
   return ##class(%EnsembleMgr).IsEnsembleNamespace($namespace) && ##class(%EnsembleMgr).validateNamespace($namespace, 1)
 }
 
+Method CheckSYSNamespace() As %Status
+{
+    if ..SYSNamespace && ($namespace'="%SYS") {
+        return $$$ERROR($$$GeneralError, "The module requires the %SYS namespace. Current namespace is "_$namespace)
+    }
+    return $$$OK
+}
+
 Storage Default
 {
 <Data name="SystemRequirementsDefaultData">
@@ -153,6 +164,9 @@ Storage Default
 </Value>
 <Value name="8">
 <Value>PythonVersion</Value>
+</Value>
+<Value name="9">
+<Value>SYSNamespace</Value>
 </Value>
 </Data>
 <DataLocation>^IPM.Storage.SystemRequirementsD</DataLocation>

--- a/tests/integration_tests/Test/PM/Integration/SystemRequirements.cls
+++ b/tests/integration_tests/Test/PM/Integration/SystemRequirements.cls
@@ -1,0 +1,40 @@
+Class Test.PM.Integration.SystemRequirements Extends Test.PM.Integration.Base
+{
+
+Method OnBeforeAllTests() As %Status
+{
+    set sc = ##class(%IPM.Main).Shell("enable -map -globally")
+    do $$$AssertStatusOK(sc, "IPM mapped to all namespaces globally.")
+    return $$$OK
+}
+
+Method OnAfterAllTests() As %Status
+{
+    new $namespace
+    set $namespace = "%SYS"
+    do ##class(%IPM.Main).Shell("uninstall sys-ns-module")
+    set sc = ##class(%IPM.Main).Shell("unmap -g")
+    do $$$AssertStatusOK(sc, "IPM unmapped globally.")
+    return $$$OK
+}
+
+Method TestSYSNamespaceRequirement() As %Status
+{
+    if $namespace = "%SYS" { return $$$OK }
+    set sourceDir = ..GetModuleDir("sys-ns-module")
+
+    // Try loading in current namespace; should fail with %SYS requirement error
+    set sc = ##class(%IPM.Main).Shell("load " _ sourceDir)
+    do $$$AssertStatusNotOK(sc, "sys-ns-module load fails in non-%SYS namespace as expected.")
+    do $$$AssertTrue($system.Status.GetErrorText(sc) [ "requires the %SYS namespace", "Error cites %SYS namespace requirement.")
+
+    // Try loading in %SYS namespace; should succeed
+    new $namespace
+    set $namespace = "%SYS"
+    set sc = ##class(%IPM.Main).Shell("load " _ sourceDir)
+    do $$$AssertStatusOK(sc, "sys-ns-module loads in %SYS namespace.")
+    do $$$AssertEquals(##class(SysNS.Module).Hello(), "Hello from SysNS.Module", "SysNS.Module.Hello() runs and returns expected value.")
+    return $$$OK
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/sys-ns-module/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/sys-ns-module/module.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="IRIS" version="26">
+  <Document name="sys-ns-module.ZPM">
+    <Module>
+      <Name>sys-ns-module</Name>
+      <Version>1.0.0</Version>
+      <Packaging>module</Packaging>
+      <SystemRequirements SYSNamespace="true"/>
+      <SourcesRoot>src</SourcesRoot>
+      <Resource Name="SysNS.PKG"/>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/sys-ns-module/src/SysNS/module.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/sys-ns-module/src/SysNS/module.cls
@@ -1,0 +1,9 @@
+Class SysNS.Module
+{
+
+ClassMethod Hello() As %String
+{
+    return "Hello from SysNS.Module"
+}
+
+}


### PR DESCRIPTION
## Description
- Closes #106 
- module.xml can now specify `<SystemRequirements SYSNamespace="true"/>` to prevent installation of the module in a non-%SYS namespace

Example module.xml used in the integration test:
```
<?xml version="1.0" encoding="UTF-8"?>
<Export generator="IRIS" version="26">
  <Document name="sys-ns-module.ZPM">
    <Module>
      <Name>sys-ns-module</Name>
      <Version>1.0.0</Version>
      <Packaging>module</Packaging>
      <SystemRequirements SYSNamespace="true"/>
      <SourcesRoot>src</SourcesRoot>
      <Resource Name="SysNS.PKG"/>
    </Module>
  </Document>
</Export>
```

Example of trying to install in not-%SYS:
```
zpm:USER>load /home/irisowner/zpm/tests/integration_tests/Test/PM/Integration/_data/sys-ns-module

ERROR! The module requires the %SYS namespace. Current namespace is USER
```

## Testing
New integration tests at Test.PM.Integration.SystemRequirements

## Checklist
<!-- You can select a checkbox by changing "[ ]" to "[x]" -->
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] Changelog entry added.
- [x] Unit (`zpm test -only`) and integration tests (`zpm verify -only`) pass.
- [x] Style matches the style guide in the [contributing guide](https://github.com/intersystems/ipm/blob/main/CONTRIBUTING.md#style-guide).
- [x] Documentation has been/will be updated
  - Source controlled docs, e.g. README.md, should be included in this PR and Wiki changes should be made after this PR is merged (add an extra issue for this if needed)
- [x] Pull request correctly renders in the "Preview" tab.
