### PR TITLE
Add ability to tee IPM output to both terminal and a log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #1117: Add `sync` command for incremental loading of changed files in dev-mode modules. Detects modified files since last sync using SHA-1 hash and recompiles only what is stale. Supports `-delete` for processing removed files and `-test` for running changed test-phase unit tests.
 - #106: A module can now specify `<SystemRequirements SYSNamespace="true"/>` to prevent installation in non-%SYS namespaces.
+- #1213: Add a `-log-file` modifier to every command, writing a plain-text copy of session output to the given file while still showing it on the terminal. A bare filename resolves under the new `LogDirectory` setting. Set the new `AutoLog` setting to 1 to log every shell session automatically.
 
 ### Changed
 - Minimum supported Python version is now 3.9

--- a/src/cls/IPM/CLI/Commands.cls
+++ b/src/cls/IPM/CLI/Commands.cls
@@ -365,6 +365,13 @@ ClassMethod %GetOneCommandStructure(Output pCommandStructure) [ CodeMode = objec
                             }
                         }
                     }
+                    // Inject global log-file modifier into every command
+                    do %code.WriteLine(" Set pCommandStructure("_tName_",""modifiers"",""log-file"",""value"") = 1")
+                    do %code.WriteLine(" Set pCommandStructure("_tName_",""modifiers"",""log-file"",""required"") = 0")
+                    do %code.WriteLine(" Set pCommandStructure("_tName_",""modifiers"",""log-file"",""deprecated"") = 0")
+                    do %code.WriteLine(" Set pCommandStructure("_tName_",""modifiers"",""log-file"",""description"") = ""Write session output to this log file""")
+                    do %code.WriteLine(" Set pCommandStructure("_tName_",""modifiers"",""log-file"",""group"") = ""-""")
+                    do %code.WriteLine(" Set pCommandStructure("_tName_",""groups"",""-"",""modifiers"",$i(pCommandStructure("_tName_",""groups"",""-"",""modifiers""))) = ""log-file""")
                 }
             }
             do %code.WriteLine(" Set pCommandStructure(-1, ""maxLength"") = "_tMaxLengthCommand)

--- a/src/cls/IPM/ExtensionBase/CompositeMethodOverrides.cls
+++ b/src/cls/IPM/ExtensionBase/CompositeMethodOverrides.cls
@@ -1,3 +1,5 @@
+Include %IPM.Common
+
 /// This class contains inheritence hacks to override final methods in %Studio.* methods
 /// And provides utilities to work with extension classes and namespace-specific source control classes
 Class %IPM.ExtensionBase.CompositeMethodOverrides
@@ -180,6 +182,7 @@ Method GetMenuExtension(
             if (tSourceNamespace '= ..Namespace) {
                 set tMenuName = $piece(pMenuID,",")
                 try {
+                    $$$SuspendRedirection(redirect)
                     set $namespace = tSourceNamespace
                     if '$data(tCache.MenuMap(tSourceNamespace,tMenuName),tPresent) {
                         set tOtherNSExtension = ..GetCurrentNamespaceExtension()
@@ -198,7 +201,9 @@ Method GetMenuExtension(
                         }
                         $$$ThrowOnError(tSC)
                     } elseif (tPresent) {
-                        // Intentionally stays in tSourceNamespace
+                        // Intentionally stays in tSourceNamespace, which has an IPM source
+                        // control extension configured and so can resolve the redirect handler.
+                        $$$RestoreRedirection(redirect)
                         return ..GetCurrentNamespaceExtension()
                     }
                 } catch e {
@@ -206,6 +211,7 @@ Method GetMenuExtension(
                     write !,"Error checking Studio extension menu item in ",tSourceNamespace,": ",$system.Status.GetErrorText(tSC)
                 }
                 set $namespace = ..Namespace
+                $$$RestoreRedirection(redirect)
             }
         }
     }

--- a/src/cls/IPM/General/History.cls
+++ b/src/cls/IPM/General/History.cls
@@ -201,31 +201,40 @@ ClassMethod DeleteHistoryGlobally(
 	verbose As %Boolean = 0) As %Integer
 {
     set originalNS = $namespace
+    // Suspended for the whole walk: each namespace visited below may hold the %IPM package
+    // without the %IPM.* routine mapping the redirect handler needs.
     new $namespace
+    $$$SuspendRedirection(redirect)
     set $namespace = "%SYS"
-    set rs = ##class(%SQL.Statement).%ExecDirect(, "SELECT DISTINCT Nsp FROM %SYS.Namespace_List()")
-    $$$ThrowSQLIfError(rs.%SQLCODE, rs.%Message)
     set count = 0
-    while rs.%Next() {
-        set ns = rs.%Get("Nsp")
-        set $namespace = ns
-        if ##class(%Dictionary.ClassDefinition).%Exists($listbuild("%IPM.General.History")) {
-            // Use try/catch to handle permission errors in locked-down namespaces
-            try {
-                set subcount = ..DeleteHistory(.filter)
-                set count = count + subcount
-                if verbose {
-                    write !, "Deleted " _ subcount _ " record(s) from " _ ns, !
-                }
-            } catch ex {
-                // Ignore permission errors in locked namespaces
-                if verbose {
-                    write !, "Skipped " _ ns _ " (no permission): " _ ex.DisplayString(), !
+    try {
+        set rs = ##class(%SQL.Statement).%ExecDirect(, "SELECT DISTINCT Nsp FROM %SYS.Namespace_List()")
+        $$$ThrowSQLIfError(rs.%SQLCODE, rs.%Message)
+        while rs.%Next() {
+            set ns = rs.%Get("Nsp")
+            set $namespace = ns
+            if ##class(%Dictionary.ClassDefinition).%Exists($listbuild("%IPM.General.History")) {
+                // Use try/catch to handle permission errors in locked-down namespaces
+                try {
+                    set subcount = ..DeleteHistory(.filter)
+                    set count = count + subcount
+                    if verbose {
+                        write !, "Deleted " _ subcount _ " record(s) from " _ ns, !
+                    }
+                } catch ex {
+                    // Ignore permission errors in locked namespaces
+                    if verbose {
+                        write !, "Skipped " _ ns _ " (no permission): " _ ex.DisplayString(), !
+                    }
                 }
             }
         }
+    } catch outerEx {
+        $$$RestoreRedirection(redirect)
+        throw outerEx
     }
     set $namespace = originalNS
+    $$$RestoreRedirection(redirect)
     quit count
 }
 

--- a/src/cls/IPM/General/OutputLog.cls
+++ b/src/cls/IPM/General/OutputLog.cls
@@ -9,10 +9,12 @@ ClassMethod Start(path As %String, append As %Boolean = 1) As %Status [ Procedur
 {
     new sc,dir
     #dim sc As %Status = $$$OK
+    // Checked outside the try because the catch below tears down ^||%IPM.log, which on
+    // this path belongs to the tee that is already running.
+    if $data(^||%IPM.log("active")) {
+        quit $$$ERROR($$$GeneralError,"OutputLog already active")
+    }
     try {
-        if $data(^||%IPM.log("active")) {
-            $$$ThrowStatus($$$ERROR($$$GeneralError,"OutputLog already active"))
-        }
         set dir = ##class(%File).GetDirectory(path)
         if (dir '= "") && ('##class(%File).DirectoryExists(dir)) {
             $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(dir))
@@ -59,59 +61,83 @@ ClassMethod Start(path As %String, append As %Boolean = 1) As %Status [ Procedur
     }
     quit sc
 
-    // Echo s to the prior redirect chain (if any) or to the raw device.
-out(s) [rd] public {
-    new rd
-    if ^||%IPM.log("prior") '= "" {
+    // Echo s to the prior redirect chain (if any) or to the raw device. Every state read
+    // goes through $get and detach() covers the missing case: an error raised inside a
+    // redirect entry point is reported by writing, which re-enters here until <FRAMESTACK>.
+out(s) [rd,rt] public {
+    new rd,rt
+    set rt=$get(^||%IPM.log("routine"))
+    if rt="" { do detach(s) quit }
+    if $get(^||%IPM.log("prior")) '= "" {
         use $io::("^"_^||%IPM.log("prior"))
         do $zutil(82,12,1)
         write s
-        use $io::("^"_^||%IPM.log("routine"))
+        use $io::("^"_rt)
         do $zutil(82,12,1)
     } else {
         set rd=$zutil(82,12,0)
-        use ^||%IPM.log("device")
+        use $get(^||%IPM.log("device"))
         write s
-        use $io::("^"_^||%IPM.log("routine"))
+        use $io::("^"_rt)
         do $zutil(82,12,rd)
     }
   }
-rstr(sz,to) [rt] public {
-    new rt set vr="rt"
+    // Redirection still points here but the tee state is gone, so there is nothing left to
+    // forward through. Uninstall and write straight to the device.
+detach(s) public {
+    do $zutil(82,12,0)
+    use $io::("")
+    write s
+  }
+    // Reinstall this routine as the handler and restore rd. With the state gone there is
+    // no name to reinstall, so leave redirection off rather than `use $io::("^")`.
+reattach(rd) [rt] public {
+    new rt
+    set rt=$get(^||%IPM.log("routine"))
+    if rt="" {
+        do $zutil(82,12,0)
+        use $io::("")
+        quit
+    }
+    use $io::("^"_rt)
+    do $zutil(82,12,rd)
+  }
+rstr(sz,to) [rt,rd,vr] public {
+    new rt,rd,vr set vr="rt"
     set rd=$zutil(82,12,0)
-    use ^||%IPM.log("device")
+    use $get(^||%IPM.log("device"))
     set:$data(sz) vr=vr_"#"_sz set:$data(to) vr=vr_":"_to
     read @vr
     do:$data(to) $zutil(96,4,$test)
-    use $io::("^"_^||%IPM.log("routine"))
-    do $zutil(82,12,rd)
+    do reattach(rd)
     quit rt
   }
-rchr(to) [rc] public {
-    new rc set vr="rc#1"
+rchr(to) [rc,rd,vr] public {
+    new rc,rd,vr set vr="rc#1"
     set rd=$zutil(82,12,0)
-    use ^||%IPM.log("device")
+    use $get(^||%IPM.log("device"))
     set:$data(to) vr=vr_":"_to
     read @vr
-    use $io::("^"_^||%IPM.log("routine"))
-    do $zutil(82,12,rd)
+    do reattach(rd)
     quit rc
   }
     // Echo `write !` or `write #` so a terminal gets CR+LF and a prior redirect chain
     // gets its own wnl()/wff() entry point.
-outctl(c) [rd] public {
-    new rd
-    if ^||%IPM.log("prior") '= "" {
+outctl(c) [rd,rt] public {
+    new rd,rt
+    set rt=$get(^||%IPM.log("routine"))
+    if rt="" { do detach($select(c="!":$char(13,10),1:$char(12))) quit }
+    if $get(^||%IPM.log("prior")) '= "" {
         use $io::("^"_^||%IPM.log("prior"))
         do $zutil(82,12,1)
         if c="!" { write ! } else { write # }
-        use $io::("^"_^||%IPM.log("routine"))
+        use $io::("^"_rt)
         do $zutil(82,12,1)
     } else {
         set rd=$zutil(82,12,0)
-        use ^||%IPM.log("device")
+        use $get(^||%IPM.log("device"))
         if c="!" { write ! } else { write # }
-        use $io::("^"_^||%IPM.log("routine"))
+        use $io::("^"_rt)
         do $zutil(82,12,rd)
     }
   }
@@ -119,6 +145,8 @@ outctl(c) [rd] public {
     // $x is restored last because out() issues `use`, which zeroes it.
 buf(s) [clean] public {
     new clean
+    // Without this the nodes below would resurrect a half-populated tee after Stop().
+    if '$data(^||%IPM.log("active")) { quit }
     set clean=$replace(##class(%IPM.General.OutputLog).StripAnsi(s),$char(13),"")
     set ^||%IPM.log("buf")=$get(^||%IPM.log("buf"))_clean
     // A payload can carry its own newlines, so count only what follows the last one.
@@ -130,6 +158,7 @@ buf(s) [clean] public {
     set $x=^||%IPM.log("col")
   }
 flush(tail) public {
+    if '$data(^||%IPM.log("active")) { set $x=0 quit }
     set ^||%IPM.log("buf")=$get(^||%IPM.log("buf"))_tail
     do ##class(%IPM.General.OutputLog).FlushBuffer()
     set ^||%IPM.log("col")=0
@@ -205,7 +234,14 @@ ClassMethod FlushBuffer()
         // the tee degrades to terminal-only output.
         set ^||%IPM.log("path") = ""
     }
-    use principal::("^"_$get(^||%IPM.log("routine")))
+    set routine = $get(^||%IPM.log("routine"))
+    if routine = "" {
+        // No handler name left to reinstall, so leave redirection off instead of
+        // installing "^", which would fault on the next write.
+        use principal::("")
+        return
+    }
+    use principal::("^"_routine)
     do $zutil(82,12,redirect)
 }
 
@@ -275,6 +311,14 @@ ClassMethod Stop() As %Status
             return $$$OK
         }
         do ..FlushBuffer()
+        // Another handler was installed after this tee, so it sits on top of the chain and
+        // restoring our prior would drop it. Release the file and leave the chain alone;
+        // the entry points fall through to the device once the state is gone.
+        if $zutil(82,12), $zutil(96,12) '= $get(^||%IPM.log("routine")) {
+            if logPath '= "" { close logPath }
+            kill ^||%IPM.log
+            return $$$OK
+        }
         set prior = $get(^||%IPM.log("prior"))
         if prior '= "" {
             use $io::("^"_prior)

--- a/src/cls/IPM/General/OutputLog.cls
+++ b/src/cls/IPM/General/OutputLog.cls
@@ -7,7 +7,7 @@ Class %IPM.General.OutputLog
 /// When append is 1 (default), output is appended to an existing file.
 ClassMethod Start(path As %String, append As %Boolean = 1) As %Status [ ProcedureBlock = 0 ]
 {
-    new sc,dir,testStream
+    new sc,dir
     #dim sc As %Status = $$$OK
     try {
         if $data(^||%IPM.log("active")) {
@@ -17,20 +17,33 @@ ClassMethod Start(path As %String, append As %Boolean = 1) As %Status [ Procedur
         if (dir '= "") && ('##class(%File).DirectoryExists(dir)) {
             $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(dir))
         }
-        // Validate the path is writable and create the file on disk. testStream is
-        // new'd so the oref is freed when Start() returns — ppg nodes do not maintain
-        // object reference counts, so we never store orefs in ^||%IPM.log.
-        set testStream = ##class(%Stream.FileCharacter).%New()
-        $$$ThrowOnError(testStream.LinkToFile(path))
-        if append { $$$ThrowOnError(testStream.MoveToEnd()) }
-        $$$ThrowOnError(testStream.%Save())
+        // The open both validates writability and creates the file, and the device stays
+        // open for the life of the session so each line costs one append rather than a
+        // reopen. Sequential file devices are named by path, so nothing stored here is an
+        // oref: ppg nodes do not maintain object reference counts.
+        if append {
+            open path:("WAS"::32767:/IOTABLE="UTF8"):5
+        } else {
+            open path:("WNS"::32767:/IOTABLE="UTF8"):5
+        }
+        if '$test {
+            $$$ThrowStatus($$$ERROR($$$GeneralError,"Could not open log file "_path))
+        }
         set ^||%IPM.log("path") = path
         set ^||%IPM.log("device") = $io
         set ^||%IPM.log("routine") = $zname
         set ^||%IPM.log("buf") = ""
+        // Redirection does not maintain $X, so the tee tracks the printable column
+        // itself; wtab() needs it to honor `write ?n`.
+        set ^||%IPM.log("col") = 0
         if $zutil(82,12) {
             set ^||%IPM.log("prior") = $zutil(96,12)
         } else {
+            set ^||%IPM.log("prior") = ""
+        }
+        // A stale redirect pointing back here would make out() re-enter wstr() until
+        // <FRAMESTACK>; there is nothing to chain to in that case.
+        if ^||%IPM.log("prior") = $zname {
             set ^||%IPM.log("prior") = ""
         }
         use $io::("^"_$zname)
@@ -38,11 +51,17 @@ ClassMethod Start(path As %String, append As %Boolean = 1) As %Status [ Procedur
         set ^||%IPM.log("active") = 1
     } catch ex {
         set sc = ex.AsStatus()
+        // Nothing installed the redirect, so Stop() will not run; close the device here.
+        if $data(^||%IPM.log("path")) {
+            close ^||%IPM.log("path")
+            kill ^||%IPM.log
+        }
     }
     quit sc
 
-   #; Echo s to the prior redirect chain (if any) or to the raw device.
-out(s) public {
+    // Echo s to the prior redirect chain (if any) or to the raw device.
+out(s) [rd] public {
+    new rd
     if ^||%IPM.log("prior") '= "" {
         use $io::("^"_^||%IPM.log("prior"))
         do $zutil(82,12,1)
@@ -78,32 +97,116 @@ rchr(to) [rc] public {
     do $zutil(82,12,rd)
     quit rc
   }
-wchr(s) public { do out($char(s)) set ^||%IPM.log("buf")=$get(^||%IPM.log("buf"))_$char(s) }
-wff() public {
-    do out($char(12))
-    set %ipmLogPath=$get(^||%IPM.log("path"))
-    if %ipmLogPath '= "" {
-        set %ipmLogSt=##class(%Stream.FileCharacter).%New()
-        do %ipmLogSt.LinkToFile(%ipmLogPath) do %ipmLogSt.MoveToEnd()
-        do %ipmLogSt.Write($zstrip($get(^||%IPM.log("buf")),"*C")_$char(12))
-        do %ipmLogSt.%Save()
+    // Echo `write !` or `write #` so a terminal gets CR+LF and a prior redirect chain
+    // gets its own wnl()/wff() entry point.
+outctl(c) [rd] public {
+    new rd
+    if ^||%IPM.log("prior") '= "" {
+        use $io::("^"_^||%IPM.log("prior"))
+        do $zutil(82,12,1)
+        if c="!" { write ! } else { write # }
+        use $io::("^"_^||%IPM.log("routine"))
+        do $zutil(82,12,1)
+    } else {
+        set rd=$zutil(82,12,0)
+        use ^||%IPM.log("device")
+        if c="!" { write ! } else { write # }
+        use $io::("^"_^||%IPM.log("routine"))
+        do $zutil(82,12,rd)
     }
-    set ^||%IPM.log("buf")=""
   }
-wnl() public {
-    do out($char(10))
-    set %ipmLogPath=$get(^||%IPM.log("path"))
-    if %ipmLogPath '= "" {
-        set %ipmLogSt=##class(%Stream.FileCharacter).%New()
-        do %ipmLogSt.LinkToFile(%ipmLogPath) do %ipmLogSt.MoveToEnd()
-        do %ipmLogSt.Write($zstrip($get(^||%IPM.log("buf")),"*C"))
-        do %ipmLogSt.Write($char(10))
-        do %ipmLogSt.%Save()
+    // Buffer is kept ANSI-stripped so flushes and column tracking need no rescan.
+    // $x is restored last because out() issues `use`, which zeroes it.
+buf(s) [clean] public {
+    new clean
+    set clean=$replace(##class(%IPM.General.OutputLog).StripAnsi(s),$char(13),"")
+    set ^||%IPM.log("buf")=$get(^||%IPM.log("buf"))_clean
+    // A payload can carry its own newlines, so count only what follows the last one.
+    if clean[$char(10) {
+        set ^||%IPM.log("col")=$length($piece(clean,$char(10),$length(clean,$char(10))))
+    } else {
+        set ^||%IPM.log("col")=$get(^||%IPM.log("col"))+$length(clean)
     }
-    set ^||%IPM.log("buf")=""
+    set $x=^||%IPM.log("col")
   }
-wstr(s) public { do out(s) set ^||%IPM.log("buf")=$get(^||%IPM.log("buf"))_s }
-wtab(s) public { set p=$justify("",s-$x) do out(p) set ^||%IPM.log("buf")=$get(^||%IPM.log("buf"))_p }
+flush(tail) public {
+    set ^||%IPM.log("buf")=$get(^||%IPM.log("buf"))_tail
+    do ##class(%IPM.General.OutputLog).FlushBuffer()
+    set ^||%IPM.log("col")=0
+    set $x=0
+  }
+    // Control characters go to the device only, so the buffer cannot capture part of an
+    // escape sequence written one character at a time.
+wchr(s) public { do out($char(s)) do:s'<32 buf($char(s)) }
+wff() public { do outctl("#") do flush($char(12)) }
+wnl() public { do outctl("!") do flush($char(10)) }
+wstr(s) public { do out(s) do buf(s) }
+wtab(s) [col,pad] public {
+    new col,pad
+    set col=$get(^||%IPM.log("col"))
+    set pad=$justify("",$select(s>col:s-col,1:0))
+    do out(pad) do buf(pad)
+  }
+}
+
+/// Removes ANSI escape sequences, including the printable parameter and final bytes of
+/// a CSI sequence.
+ClassMethod StripAnsi(text As %String) As %String
+{
+    if text '[ $char(27) {
+        return text
+    }
+    set stripped = ""
+    set pos = 1
+    for {
+        // $find returns the position past the ESC, so the ESC itself is at afterEsc-1
+        set afterEsc = $find(text, $char(27), pos)
+        if 'afterEsc {
+            set stripped = stripped _ $extract(text, pos, *)
+            quit
+        }
+        set stripped = stripped _ $extract(text, pos, afterEsc - 2)
+        if $extract(text, afterEsc) = "[" {
+            // CSI parameter and intermediate bytes are 0x20-0x3F, final byte is 0x40-0x7E
+            set i = afterEsc + 1
+            while (i <= $length(text)) && ($ascii(text, i) < 64) {
+                set i = i + 1
+            }
+            set pos = i + 1
+        } else {
+            set pos = afterEsc + 1
+        }
+    }
+    return stripped
+}
+
+/// Appends pending output to the log file and clears the buffer.
+ClassMethod FlushBuffer()
+{
+    set buffer = $get(^||%IPM.log("buf"))
+    if buffer = "" {
+        return
+    }
+    set ^||%IPM.log("buf") = ""
+    set logPath = $get(^||%IPM.log("path"))
+    if logPath = "" {
+        return
+    }
+    // Redirection is process-wide, so it must be off while writing to the log device or
+    // the write is captured and recurses.
+    set principal = $io
+    set redirect = $zutil(82,12,0)
+    try {
+        use logPath
+        write buffer
+    } catch {
+        // This runs inside device redirection, where throwing would surface as a
+        // failure of whatever unrelated code was writing. Drop the path instead so
+        // the tee degrades to terminal-only output.
+        set ^||%IPM.log("path") = ""
+    }
+    use principal::("^"_$get(^||%IPM.log("routine")))
+    do $zutil(82,12,redirect)
 }
 
 /// Appends a delimiter line to the active log file marking the start of a command.
@@ -113,38 +216,65 @@ ClassMethod WriteCommandHeader(command As %String, namespace As %String)
     if '$data(^||%IPM.log("active")) {
         return
     }
-    set logPath = $get(^||%IPM.log("path"))
-    if logPath = "" { return }
     set h = $horolog
     set timestamp = $zdate(h,3)_" "_$ztime($piece(h,",",2))
-    set s = ##class(%Stream.FileCharacter).%New()
-    do s.LinkToFile(logPath)
-    do s.MoveToEnd()
-    do s.Write($char(10))
-    do s.WriteLine("--- ["_timestamp_"] ["_namespace_"] "_command_" ---")
-    do s.%Save()
+    // Appended to the buffer rather than written directly so the header cannot
+    // overtake output still pending from the previous command.
+    set header = $char(10)_"--- ["_timestamp_"] ["_namespace_"] "_command_" ---"_$char(10)
+    set ^||%IPM.log("buf") = $get(^||%IPM.log("buf"))_header
+    do ..FlushBuffer()
 }
 
-/// Stops the active tee, flushing and saving the log file.
+/// Starts a tee to this process's AutoLog file. The path is chosen on first use and
+/// reused (in append mode) for the rest of the process, so the many commands a single
+/// process may run - a test run drives dozens - all land in one transcript.
+ClassMethod StartAutoLog() As %Status
+{
+    if $get(^||%IPM.autolog("failed")) {
+        return $$$OK
+    }
+    set path = $get(^||%IPM.autolog("path"))
+    if path '= "" {
+        set sc = ..Start(path, 1)
+    } else {
+        set dir = ##class(%IPM.Repo.UniversalSettings).GetLogDirectory()
+        set h = $horolog
+        set stem = dir _ "ipm-" _ $zdate(h,3) _ "-" _ $translate($ztime($piece(h,",",2)), ":") _ "-" _ $job
+        set path = stem _ ".log"
+        set suffix = 0
+        while ##class(%File).Exists(path) {
+            set suffix = suffix + 1
+            set path = stem _ "-" _ suffix _ ".log"
+        }
+        set sc = ..Start(path, 0)
+    }
+    if $$$ISERR(sc) {
+        // Recorded so later commands in this process neither retry nor re-warn.
+        set ^||%IPM.autolog("failed") = 1
+        return sc
+    }
+    set ^||%IPM.autolog("path") = path
+    return $$$OK
+}
+
+/// Forgets the AutoLog path and any recorded failure, so the next StartAutoLog() picks
+/// a fresh file. Intended for tests; a real process keeps one AutoLog for its lifetime.
+ClassMethod ClearAutoLog() [ Internal ]
+{
+    kill ^||%IPM.autolog
+}
+
+/// Stops the active tee, flushing and closing the log file.
 /// Safe to call when no log is active.
 ClassMethod Stop() As %Status
 {
     set sc = $$$OK
+    set logPath = $get(^||%IPM.log("path"))
     try {
         if '$data(^||%IPM.log("active")) {
             return $$$OK
         }
-        set remaining = $get(^||%IPM.log("buf"))
-        if remaining '= "" {
-            set logPath = $get(^||%IPM.log("path"))
-            if logPath '= "" {
-                set s = ##class(%Stream.FileCharacter).%New()
-                do s.LinkToFile(logPath)
-                do s.MoveToEnd()
-                do s.Write($zstrip(remaining,"*C"))
-                set sc = s.%Save()
-            }
-        }
+        do ..FlushBuffer()
         set prior = $get(^||%IPM.log("prior"))
         if prior '= "" {
             use $io::("^"_prior)
@@ -157,6 +287,7 @@ ClassMethod Stop() As %Status
         do $zutil(82,12,0)
         use $io::("")
     }
+    if logPath '= "" { close logPath }
     kill ^||%IPM.log
     return sc
 }

--- a/src/cls/IPM/General/OutputLog.cls
+++ b/src/cls/IPM/General/OutputLog.cls
@@ -224,6 +224,9 @@ ClassMethod FlushBuffer()
     // Redirection is process-wide, so it must be off while writing to the log device or
     // the write is captured and recurses.
     set principal = $io
+    // The installed handler is not necessarily this tee: BeginCaptureOutput() and friends
+    // layer on top of it, and reinstalling ourselves would take their writes.
+    set handler = $select($zutil(82,12): $zutil(96,12), 1: "")
     set redirect = $zutil(82,12,0)
     try {
         use logPath
@@ -234,14 +237,11 @@ ClassMethod FlushBuffer()
         // the tee degrades to terminal-only output.
         set ^||%IPM.log("path") = ""
     }
-    set routine = $get(^||%IPM.log("routine"))
-    if routine = "" {
-        // No handler name left to reinstall, so leave redirection off instead of
-        // installing "^", which would fault on the next write.
+    if handler = "" {
         use principal::("")
         return
     }
-    use principal::("^"_routine)
+    use principal::("^"_handler)
     do $zutil(82,12,redirect)
 }
 
@@ -263,7 +263,7 @@ ClassMethod WriteCommandHeader(command As %String, namespace As %String)
 
 /// Starts a tee to this process's AutoLog file. The path is chosen on first use and
 /// reused (in append mode) for the rest of the process, so the many commands a single
-/// process may run - a test run drives dozens - all land in one transcript.
+/// process may run (a test run drives dozens) all land in one transcript.
 ClassMethod StartAutoLog() As %Status
 {
     if $get(^||%IPM.autolog("failed")) {
@@ -298,6 +298,27 @@ ClassMethod StartAutoLog() As %Status
 ClassMethod ClearAutoLog() [ Internal ]
 {
     kill ^||%IPM.autolog
+}
+
+/// Reinstalls this tee if it is active but interception has been switched off, which is
+/// what an excursion that suspended redirection and did not restore it leaves behind.
+/// Called at command boundaries so a missed $$$RestoreRedirection costs one command's output
+/// rather than the rest of the session. Must be called from a namespace with the %IPM.*
+/// routine mapping, since `use` names the handler routine.
+ClassMethod Resume()
+{
+    if '$data(^||%IPM.log("active")) {
+        return
+    }
+    if $zutil(82,12) {
+        return
+    }
+    set routine = $get(^||%IPM.log("routine"))
+    if routine = "" {
+        return
+    }
+    use $io::("^"_routine)
+    do $zutil(82,12,1)
 }
 
 /// Stops the active tee, flushing and closing the log file.

--- a/src/cls/IPM/General/OutputLog.cls
+++ b/src/cls/IPM/General/OutputLog.cls
@@ -1,0 +1,176 @@
+Include %IPM.Common
+
+Class %IPM.General.OutputLog
+{
+
+/// Starts tee-ing session output to the specified file.
+/// When append is 1 (default), output is appended to an existing file.
+ClassMethod Start(path As %String, append As %Boolean = 1) As %Status [ ProcedureBlock = 0 ]
+{
+    new sc,dir,testStream
+    #dim sc As %Status = $$$OK
+    try {
+        if $data(^||%IPM.log("active")) {
+            $$$ThrowStatus($$$ERROR($$$GeneralError,"OutputLog already active"))
+        }
+        set dir = ##class(%File).GetDirectory(path)
+        if (dir '= "") && ('##class(%File).DirectoryExists(dir)) {
+            $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(dir))
+        }
+        // Validate the path is writable and create the file on disk. testStream is
+        // new'd so the oref is freed when Start() returns — ppg nodes do not maintain
+        // object reference counts, so we never store orefs in ^||%IPM.log.
+        set testStream = ##class(%Stream.FileCharacter).%New()
+        $$$ThrowOnError(testStream.LinkToFile(path))
+        if append { $$$ThrowOnError(testStream.MoveToEnd()) }
+        $$$ThrowOnError(testStream.%Save())
+        set ^||%IPM.log("path") = path
+        set ^||%IPM.log("device") = $io
+        set ^||%IPM.log("routine") = $zname
+        set ^||%IPM.log("buf") = ""
+        if $zutil(82,12) {
+            set ^||%IPM.log("prior") = $zutil(96,12)
+        } else {
+            set ^||%IPM.log("prior") = ""
+        }
+        use $io::("^"_$zname)
+        do $zutil(82,12,1)
+        set ^||%IPM.log("active") = 1
+    } catch ex {
+        set sc = ex.AsStatus()
+    }
+    quit sc
+
+   #; Echo s to the prior redirect chain (if any) or to the raw device.
+out(s) public {
+    if ^||%IPM.log("prior") '= "" {
+        use $io::("^"_^||%IPM.log("prior"))
+        do $zutil(82,12,1)
+        write s
+        use $io::("^"_^||%IPM.log("routine"))
+        do $zutil(82,12,1)
+    } else {
+        set rd=$zutil(82,12,0)
+        use ^||%IPM.log("device")
+        write s
+        use $io::("^"_^||%IPM.log("routine"))
+        do $zutil(82,12,rd)
+    }
+  }
+rstr(sz,to) [rt] public {
+    new rt set vr="rt"
+    set rd=$zutil(82,12,0)
+    use ^||%IPM.log("device")
+    set:$data(sz) vr=vr_"#"_sz set:$data(to) vr=vr_":"_to
+    read @vr
+    do:$data(to) $zutil(96,4,$test)
+    use $io::("^"_^||%IPM.log("routine"))
+    do $zutil(82,12,rd)
+    quit rt
+  }
+rchr(to) [rc] public {
+    new rc set vr="rc#1"
+    set rd=$zutil(82,12,0)
+    use ^||%IPM.log("device")
+    set:$data(to) vr=vr_":"_to
+    read @vr
+    use $io::("^"_^||%IPM.log("routine"))
+    do $zutil(82,12,rd)
+    quit rc
+  }
+wchr(s) public { do out($char(s)) set ^||%IPM.log("buf")=$get(^||%IPM.log("buf"))_$char(s) }
+wff() public {
+    do out($char(12))
+    set %ipmLogPath=$get(^||%IPM.log("path"))
+    if %ipmLogPath '= "" {
+        set %ipmLogSt=##class(%Stream.FileCharacter).%New()
+        do %ipmLogSt.LinkToFile(%ipmLogPath) do %ipmLogSt.MoveToEnd()
+        do %ipmLogSt.Write($zstrip($get(^||%IPM.log("buf")),"*C")_$char(12))
+        do %ipmLogSt.%Save()
+    }
+    set ^||%IPM.log("buf")=""
+  }
+wnl() public {
+    do out($char(10))
+    set %ipmLogPath=$get(^||%IPM.log("path"))
+    if %ipmLogPath '= "" {
+        set %ipmLogSt=##class(%Stream.FileCharacter).%New()
+        do %ipmLogSt.LinkToFile(%ipmLogPath) do %ipmLogSt.MoveToEnd()
+        do %ipmLogSt.Write($zstrip($get(^||%IPM.log("buf")),"*C"))
+        do %ipmLogSt.Write($char(10))
+        do %ipmLogSt.%Save()
+    }
+    set ^||%IPM.log("buf")=""
+  }
+wstr(s) public { do out(s) set ^||%IPM.log("buf")=$get(^||%IPM.log("buf"))_s }
+wtab(s) public { set p=$justify("",s-$x) do out(p) set ^||%IPM.log("buf")=$get(^||%IPM.log("buf"))_p }
+}
+
+/// Appends a delimiter line to the active log file marking the start of a command.
+/// The header is file-only; it does not appear on the terminal.
+ClassMethod WriteCommandHeader(command As %String, namespace As %String)
+{
+    if '$data(^||%IPM.log("active")) {
+        return
+    }
+    set logPath = $get(^||%IPM.log("path"))
+    if logPath = "" { return }
+    set h = $horolog
+    set timestamp = $zdate(h,3)_" "_$ztime($piece(h,",",2))
+    set s = ##class(%Stream.FileCharacter).%New()
+    do s.LinkToFile(logPath)
+    do s.MoveToEnd()
+    do s.Write($char(10))
+    do s.WriteLine("--- ["_timestamp_"] ["_namespace_"] "_command_" ---")
+    do s.%Save()
+}
+
+/// Stops the active tee, flushing and saving the log file.
+/// Safe to call when no log is active.
+ClassMethod Stop() As %Status
+{
+    set sc = $$$OK
+    try {
+        if '$data(^||%IPM.log("active")) {
+            return $$$OK
+        }
+        set remaining = $get(^||%IPM.log("buf"))
+        if remaining '= "" {
+            set logPath = $get(^||%IPM.log("path"))
+            if logPath '= "" {
+                set s = ##class(%Stream.FileCharacter).%New()
+                do s.LinkToFile(logPath)
+                do s.MoveToEnd()
+                do s.Write($zstrip(remaining,"*C"))
+                set sc = s.%Save()
+            }
+        }
+        set prior = $get(^||%IPM.log("prior"))
+        if prior '= "" {
+            use $io::("^"_prior)
+        } else {
+            do $zutil(82,12,0)
+            use $io::("")
+        }
+    } catch ex {
+        set sc = ex.AsStatus()
+        do $zutil(82,12,0)
+        use $io::("")
+    }
+    kill ^||%IPM.log
+    return sc
+}
+
+/// Returns 1 if a log session is currently active, 0 otherwise.
+ClassMethod IsActive() As %Boolean
+{
+    return $data(^||%IPM.log("active")) > 0
+}
+
+/// Returns the path of the active log file, or "" if no log is active.
+ClassMethod GetActivePath() As %String
+{
+    return $get(^||%IPM.log("path"))
+}
+
+}

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1014,6 +1014,25 @@ ClassMethod ShellInternal(
     }
     set introMessageList = ..BuildIntroMessages(.outOfBoxMessage)
     set tInShell = 0
+
+    // Start AutoLog session if configured and no log already active
+    if '##class(%IPM.General.OutputLog).IsActive() && ##class(%IPM.Repo.UniversalSettings).GetAutoLog() {
+        set tAutoLogDir = ##class(%IPM.Repo.UniversalSettings).GetLogDirectory()
+        set h = $horolog
+        set tAutoLogTs = $zdate(h,3) _ "-" _ $translate($ztime($piece(h,",",2)),":")
+        set tAutoLogStem = "ipm-" _ tAutoLogTs _ "-" _ $job
+        set tAutoLogPath = tAutoLogDir _ tAutoLogStem _ ".log"
+        set tAutoLogSuffix = 0
+        while ##class(%File).Exists(tAutoLogPath) {
+            set tAutoLogSuffix = tAutoLogSuffix + 1
+            set tAutoLogPath = tAutoLogDir _ tAutoLogStem _ "-" _ tAutoLogSuffix _ ".log"
+        }
+        set tAutoLogSC = ##class(%IPM.General.OutputLog).Start(tAutoLogPath, 0)
+        if $$$ISERR(tAutoLogSC) {
+            write !,$$$FormattedLine($$$Yellow,"WARNING: AutoLog failed: "),$system.Status.GetOneStatusText(tAutoLogSC),!
+        }
+    }
+
     for {
         kill $$$DeprecationWarned
         try {
@@ -1049,7 +1068,23 @@ ClassMethod ShellInternal(
 			new $$$ZPMCommandToLog
 			set $$$ZPMCommandToLog = tCommand
 
+            // Handle -log-file modifier: start or redirect the session tee
+            set tLogFile = $get(tCommandInfo("modifiers","log-file"))
+            if tLogFile '= "" {
+                if ##class(%File).GetDirectory(tLogFile) = "" {
+                    set tLogFile = ##class(%IPM.Repo.UniversalSettings).GetLogDirectory() _ tLogFile
+                }
+                if tLogFile '= ##class(%IPM.General.OutputLog).GetActivePath() {
+                    do ##class(%IPM.General.OutputLog).Stop()
+                    $$$ThrowOnError(##class(%IPM.General.OutputLog).Start(tLogFile))
+                }
+            }
+            if ##class(%IPM.General.OutputLog).IsActive() {
+                do ##class(%IPM.General.OutputLog).WriteCommandHeader(tCommand, $namespace)
+            }
+
             if (tCommandInfo = "quit") {
+                do ##class(%IPM.General.OutputLog).Stop()
                 return
             } elseif (tCommandInfo = "help") {
                 do ..%Help(.tCommandInfo)
@@ -1117,6 +1152,7 @@ ClassMethod ShellInternal(
         } catch pException {
             if (pException.Code = $$$ERCTRLC) {
                 set pException = $$$NULLOREF
+                do ##class(%IPM.General.OutputLog).Stop()
                 return
             }
             do ..DisplayError(pException.AsStatus())
@@ -1125,6 +1161,7 @@ ClassMethod ShellInternal(
         // Check if IPM has uninstalled itself - exit gracefully if so
         if $get(^||%IPM.SelfUninstallFlag, 0) {
             write !,!,$$$FormattedLine($$$Yellow, "IPM has been uninstalled from this namespace. Exiting shell..."),!
+            do ##class(%IPM.General.OutputLog).Stop()
             return
         }
 
@@ -1134,6 +1171,7 @@ ClassMethod ShellInternal(
         }
         write !
     }
+    do ##class(%IPM.General.OutputLog).Stop()
 }
 
 /// Warn for deprecated parameters/modifiers

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1197,6 +1197,7 @@ ClassMethod RestoreLogAfterCommand(
 	commandLogPath As %String,
 	displacedLogPath As %String) [ Internal, Private ]
 {
+    do ##class(%IPM.General.OutputLog).Resume()
     if (commandLogPath = "") && (displacedLogPath = "") {
         return
     }
@@ -1245,9 +1246,14 @@ ClassMethod Namespace(ByRef pCommandInfo) [ Internal ]
             if '..IsIPMEnabled(name) {
                 write $$$FormattedLine($$$Red,"IPM is not enabled in the "_name_" namespace.")
             } else {
+                // IsIPMEnabled() vouched for the destination, so redirection is restored as
+                // soon as the switch lands and output from here on still reaches the log.
+                $$$SuspendRedirection(redirect)
                 set $namespace = name
+                $$$RestoreRedirection(redirect)
             }
         } catch ex {
+            $$$RestoreRedirection(redirect)
             $$$ThrowStatus($$$ERROR($$$GeneralError,"Failed to switch to namespace: " _ name))
         }
         quit
@@ -1274,8 +1280,13 @@ ClassMethod Namespace(ByRef pCommandInfo) [ Internal ]
                 write $$$FormattedLine($$$Red," IPM is not enabled for the selected "_selectedNamespace_" namespace."),!
                 continue
             }
+            $$$SuspendRedirection(redirect)
             set $namespace = selectedNamespace
+            $$$RestoreRedirection(redirect)
         } catch e {
+            // A failed switch leaves the caller's namespace in place, so the write below is
+            // safe once interception is back on.
+            $$$RestoreRedirection(redirect)
             write $$$FormattedLine($$$Red," "_e.AsSystemError()),!
             continue
         }
@@ -1601,7 +1612,8 @@ ClassMethod GenerateModuleXML(ByRef pCommandInfo) As %Status [ Internal ]
 ClassMethod GetDefaultCommandRegistry()
 {
     new $namespace
-    set $namespace="%SYS"
+    $$$SuspendRedirection(redirect)
+    set $namespace = "%SYS"
     set Status=##Class(Config.Startup).Get(.Properties)
     if Status {
         set ServerPort="http://"_$zutil(110)_":"_$get(Properties("WebServerPort"),52773)
@@ -1610,6 +1622,7 @@ ClassMethod GetDefaultCommandRegistry()
         write !,"Switch to the current registry:",!,"   repo -r -n registry -url "_ServerPort_"/registry/ -user ""_system"" -pass ""SYS""",!
 
     }
+    $$$RestoreRedirection(redirect)
 }
 
 /// Get Version Module
@@ -2175,9 +2188,14 @@ ClassMethod Repository(ByRef pCommandInfo) [ Internal ]
         set tSourceNamespace = $$$GetModifier(pCommandInfo,"copy-from")
         set tOldNamespace = $namespace
         new $namespace
+        // tSourceNamespace is an arbitrary namespace, so the suspension stays in force until
+        // the switch back below.
+        $$$SuspendRedirection(redirect)
         try {
             set $namespace = tSourceNamespace
         } catch e {
+            // The switch failed, so tOldNamespace is still current and the write is safe.
+            $$$RestoreRedirection(redirect)
             if (e.Name = "<NAMESPACE>") {
                 write !,"Invalid namespace: ",tSourceNamespace
                 return
@@ -2212,6 +2230,7 @@ ClassMethod Repository(ByRef pCommandInfo) [ Internal ]
         }
 
         set $namespace = tOldNamespace
+        $$$RestoreRedirection(redirect)
         for tIndex=1:1:$get(tRepositories) {
             // Deep clone in case there are ever other referenced objects that need to be carried across.
             // This is not relevant for any current repository types, but is most likely to be correct in
@@ -3548,7 +3567,13 @@ ZPM(pArgs...)
         write !, "Error getting namespace list. SQLCODE =", rs.%SQLCODE
         write !, "IPM is not enabled in namespace ", currentNs, "."
     } else {
+        // The loop leaves $namespace on whichever namespace it last visited, and that outlives
+        // the loop because `new $namespace` restores only at method exit, so every write from
+        // here to the end of the method needs redirection suspended. Spelled out rather than
+        // using $$$SuspendRedirection because this body is emitted into %ZLANGC00.mac, which
+        // compiles without IPM's include file.
         new $namespace
+        set redirect = $zutil(82,12,0)
         set found = 0
         while rs.%Next() {
             set $namespace = $zstrip(rs.%Get("Nsp"), "<>WC")
@@ -3576,6 +3601,7 @@ ZPM(pArgs...)
         write ! // Add a newline before halting
         halt
     }
+    do:$data(redirect) $zutil(82,12,redirect)
     // The $$$ERROR macro is not available for use in language extension
     return $system.Status.Error(5001, "IPM is not enabled in this namespace.")
  }
@@ -3665,13 +3691,14 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
         while $listnext(namespaces,pointer,namespace) {
             set namespace = $zstrip(namespace, "<>WC")
             set $namespace = namespace
-            if ..IPMInstalled() {
+            set installed = ..IPMInstalled()
+            set $namespace = initNamespace
+            if installed {
                 if 'quiet || preview {
                     write !,"Skipping IPM mapping of "_namespace_" - IPM already installed."
                 }
                 continue
             }
-            set $namespace = initNamespace
             if preview {
                 write !,"Would add IPM mappings to "_namespace
                 continue
@@ -3702,13 +3729,14 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
                 }
                 // If repository are already present, also skip repo mapping avoid override
                 set $namespace = namespace
-                if $data(^IPM.Repo.DefinitionD) \ 2 {
+                set reposPresent = $data(^IPM.Repo.DefinitionD) \ 2
+                set $namespace = initNamespace
+                if reposPresent {
                     if 'quiet || preview {
                         write !,"Skipping repository mapping of "_namespace_" - IPM repositories found."
                     }
                     continue
                 }
-                set $namespace = initNamespace
                 if preview {
                     write !,"Would add IPM repository mappings to "_namespace
                     continue
@@ -3903,6 +3931,9 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
             // Retrieve module installer manifest
             set manifest = packageService.GetModuleInstallerManifest(ipmRef)
             set currentNS = ""
+            // The namespaces below are the ones IPM is missing from, so nothing there can
+            // resolve the redirect handler, including the loader's own output.
+            $$$SuspendRedirection(redirect)
             while 1 {
                 set currentNS = $order(targetNamespaces(currentNS))
                 if currentNS = "" {
@@ -3916,6 +3947,8 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
                 do $system.OBJ.LoadStream(manifest, loadFlag)
                 write !, "IPM enabled for namespace "_currentNS
             }
+            set $namespace = initNamespace
+            $$$RestoreRedirection(redirect)
         } else {
             $$$ThrowOnError($$$ERROR($$$GeneralError,"Failed to get a valid registry server in order to download the IPM manifest."))
         }
@@ -3925,6 +3958,8 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
         set enabledNSList = ""
         set problematicList = ""
         set tOverallSC = $$$OK
+        // As above: IPM is absent from these namespaces until the load below succeeds.
+        $$$SuspendRedirection(redirect)
         while (currentNS '="") {
             set $namespace = currentNS
             if preview {
@@ -3941,6 +3976,8 @@ ClassMethod EnableIPM(ByRef pCommandInfo)
             set currentNS = $order(targetNamespaces(currentNS))
             set tOverallSC = $$$ADDSC(tOverallSC,tSC)
         }
+        set $namespace = initNamespace
+        $$$RestoreRedirection(redirect)
         if 'preview {
             write !, "IPM enabled for namespace(s) "_$listtostring(enabledNSList)
             if $$$ISERR(tOverallSC) {

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1032,6 +1032,10 @@ ClassMethod ShellInternal(
 
     for {
         kill $$$DeprecationWarned
+        // Set before the try because RestoreLogAfterCommand() runs after it on every path,
+        // including the ones that leave the try early, such as an empty command line.
+        set tCommandLogPath = ""
+        set tDisplacedLogPath = ""
         try {
             // Have intro message just for first entrance to shell
             // Ensure not displayed if its just one command
@@ -1065,17 +1069,19 @@ ClassMethod ShellInternal(
 			new $$$ZPMCommandToLog
 			set $$$ZPMCommandToLog = tCommand
 
-            // Handle -log-file modifier: start or redirect the session tee
+            // Handle -log-file modifier: tee this one command to the given file
             set tLogFile = $get(tCommandInfo("modifiers","log-file"))
             if tLogFile '= "" {
                 if ##class(%File).GetDirectory(tLogFile) = "" {
                     set tLogFile = ##class(%IPM.Repo.UniversalSettings).GetLogDirectory() _ tLogFile
                 }
                 if tLogFile '= ##class(%IPM.General.OutputLog).GetActivePath() {
+                    // Set aside a tee that is already running, from AutoLog or an outer
+                    // shell, and put it back when the command finishes.
+                    set tDisplacedLogPath = ##class(%IPM.General.OutputLog).GetActivePath()
                     do ##class(%IPM.General.OutputLog).Stop()
                     $$$ThrowOnError(##class(%IPM.General.OutputLog).Start(tLogFile))
-                    // Stop the log only if this frame started it, so that nested shells don't cut off the outer command's log.
-                    set tOwnsLog = 1
+                    set tCommandLogPath = tLogFile
                 }
             }
             if ##class(%IPM.General.OutputLog).IsActive() {
@@ -1083,6 +1089,7 @@ ClassMethod ShellInternal(
             }
 
             if (tCommandInfo = "quit") {
+                do ..RestoreLogAfterCommand(tCommandLogPath, tDisplacedLogPath)
                 if tOwnsLog {
                     do ##class(%IPM.General.OutputLog).Stop()
                 }
@@ -1153,6 +1160,7 @@ ClassMethod ShellInternal(
         } catch pException {
             if (pException.Code = $$$ERCTRLC) {
                 set pException = $$$NULLOREF
+                do ..RestoreLogAfterCommand(tCommandLogPath, tDisplacedLogPath)
                 if tOwnsLog {
                     do ##class(%IPM.General.OutputLog).Stop()
                 }
@@ -1160,10 +1168,12 @@ ClassMethod ShellInternal(
             }
             do ..DisplayError(pException.AsStatus())
         }
+        do ..RestoreLogAfterCommand(tCommandLogPath, tDisplacedLogPath)
 
         // Check if IPM has uninstalled itself - exit gracefully if so
         if $get(^||%IPM.SelfUninstallFlag, 0) {
             write !,!,$$$FormattedLine($$$Yellow, "IPM has been uninstalled from this namespace. Exiting shell..."),!
+            do ..RestoreLogAfterCommand(tCommandLogPath, tDisplacedLogPath)
             if tOwnsLog {
                 do ##class(%IPM.General.OutputLog).Stop()
             }
@@ -1178,6 +1188,27 @@ ClassMethod ShellInternal(
     }
     if tOwnsLog {
         do ##class(%IPM.General.OutputLog).Stop()
+    }
+}
+
+/// Ends the tee a `-log-file` command started and reopens the one it displaced, so the
+/// modifier covers a single command and an AutoLog session outlives it.
+ClassMethod RestoreLogAfterCommand(
+	commandLogPath As %String,
+	displacedLogPath As %String) [ Internal, Private ]
+{
+    if (commandLogPath = "") && (displacedLogPath = "") {
+        return
+    }
+    if (commandLogPath '= ""), ##class(%IPM.General.OutputLog).GetActivePath() = commandLogPath {
+        do ##class(%IPM.General.OutputLog).Stop()
+    }
+    // Also reached when Start() threw, leaving the displaced tee stopped but not replaced.
+    if (displacedLogPath '= ""), '##class(%IPM.General.OutputLog).IsActive() {
+        set sc = ##class(%IPM.General.OutputLog).Start(displacedLogPath, 1)
+        if $$$ISERR(sc) {
+            write !,$$$FormattedLine($$$Yellow,"WARNING: could not resume logging to "_displacedLogPath_": "),$system.Status.GetOneStatusText(sc),!
+        }
     }
 }
 

--- a/src/cls/IPM/Main.cls
+++ b/src/cls/IPM/Main.cls
@@ -1014,22 +1014,19 @@ ClassMethod ShellInternal(
     }
     set introMessageList = ..BuildIntroMessages(.outOfBoxMessage)
     set tInShell = 0
+    // Commands run nested shells (e.g. `test` runs `config set`), and only the frame that
+    // started a tee may stop it, or the inner shell would cut off the outer command's log.
+    set tOwnsLog = 0
 
-    // Start AutoLog session if configured and no log already active
-    if '##class(%IPM.General.OutputLog).IsActive() && ##class(%IPM.Repo.UniversalSettings).GetAutoLog() {
-        set tAutoLogDir = ##class(%IPM.Repo.UniversalSettings).GetLogDirectory()
-        set h = $horolog
-        set tAutoLogTs = $zdate(h,3) _ "-" _ $translate($ztime($piece(h,",",2)),":")
-        set tAutoLogStem = "ipm-" _ tAutoLogTs _ "-" _ $job
-        set tAutoLogPath = tAutoLogDir _ tAutoLogStem _ ".log"
-        set tAutoLogSuffix = 0
-        while ##class(%File).Exists(tAutoLogPath) {
-            set tAutoLogSuffix = tAutoLogSuffix + 1
-            set tAutoLogPath = tAutoLogDir _ tAutoLogStem _ "-" _ tAutoLogSuffix _ ".log"
-        }
-        set tAutoLogSC = ##class(%IPM.General.OutputLog).Start(tAutoLogPath, 0)
+    // AutoLog and LogDirectory are read once here, so logging stays put for the whole
+    // session; changing either from the prompt applies to the next shell, and
+    // UpdateOne() says so. Use -log-file to log a single command in this session.
+    if '##class(%IPM.General.OutputLog).IsActive(), ##class(%IPM.Repo.UniversalSettings).GetAutoLog() {
+        set tAutoLogSC = ##class(%IPM.General.OutputLog).StartAutoLog()
         if $$$ISERR(tAutoLogSC) {
             write !,$$$FormattedLine($$$Yellow,"WARNING: AutoLog failed: "),$system.Status.GetOneStatusText(tAutoLogSC),!
+        } else {
+            set tOwnsLog = 1
         }
     }
 
@@ -1077,6 +1074,8 @@ ClassMethod ShellInternal(
                 if tLogFile '= ##class(%IPM.General.OutputLog).GetActivePath() {
                     do ##class(%IPM.General.OutputLog).Stop()
                     $$$ThrowOnError(##class(%IPM.General.OutputLog).Start(tLogFile))
+                    // Stop the log only if this frame started it, so that nested shells don't cut off the outer command's log.
+                    set tOwnsLog = 1
                 }
             }
             if ##class(%IPM.General.OutputLog).IsActive() {
@@ -1084,7 +1083,9 @@ ClassMethod ShellInternal(
             }
 
             if (tCommandInfo = "quit") {
-                do ##class(%IPM.General.OutputLog).Stop()
+                if tOwnsLog {
+                    do ##class(%IPM.General.OutputLog).Stop()
+                }
                 return
             } elseif (tCommandInfo = "help") {
                 do ..%Help(.tCommandInfo)
@@ -1152,7 +1153,9 @@ ClassMethod ShellInternal(
         } catch pException {
             if (pException.Code = $$$ERCTRLC) {
                 set pException = $$$NULLOREF
-                do ##class(%IPM.General.OutputLog).Stop()
+                if tOwnsLog {
+                    do ##class(%IPM.General.OutputLog).Stop()
+                }
                 return
             }
             do ..DisplayError(pException.AsStatus())
@@ -1161,7 +1164,9 @@ ClassMethod ShellInternal(
         // Check if IPM has uninstalled itself - exit gracefully if so
         if $get(^||%IPM.SelfUninstallFlag, 0) {
             write !,!,$$$FormattedLine($$$Yellow, "IPM has been uninstalled from this namespace. Exiting shell..."),!
-            do ##class(%IPM.General.OutputLog).Stop()
+            if tOwnsLog {
+                do ##class(%IPM.General.OutputLog).Stop()
+            }
             return
         }
 
@@ -1171,7 +1176,9 @@ ClassMethod ShellInternal(
         }
         write !
     }
-    do ##class(%IPM.General.OutputLog).Stop()
+    if tOwnsLog {
+        do ##class(%IPM.General.OutputLog).Stop()
+    }
 }
 
 /// Warn for deprecated parameters/modifiers

--- a/src/cls/IPM/Repo/UniversalSettings.cls
+++ b/src/cls/IPM/Repo/UniversalSettings.cls
@@ -109,7 +109,7 @@ ClassMethod ResetToDefault(key As %String) As %Status
         // Computed directly rather than read from storage — older IPM versions did not seed this default node
         set defaultValue = ##class(%File).NormalizeDirectory(##class(%SYSTEM.Util).DataDirectory() _ "ipm/")
     } elseif key = ..#LogDirectory {
-        // Computed directly rather than read from storage — older IPM versions did not seed this default node
+        // Derived from the instance data directory rather than stored
         set defaultValue = ##class(%File).NormalizeDirectory(##class(%SYSTEM.Util).DataDirectory() _ "ipm/logs/")
     } elseif key = ..#AutoLog {
         // No factory default; empty string means AutoLog is disabled

--- a/src/cls/IPM/Repo/UniversalSettings.cls
+++ b/src/cls/IPM/Repo/UniversalSettings.cls
@@ -50,7 +50,11 @@ Parameter TestReportFormat = "TestReportFormat";
 
 Parameter ModuleRoot = "ModuleRoot";
 
-Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PipCaller,UseStandalonePip,SemVerPostRelease,DefaultLogEntryLimit,HistoryRetain,TestReportFormat,ModuleRoot";
+Parameter LogDirectory = "LogDirectory";
+
+Parameter AutoLog = "AutoLog";
+
+Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PipCaller,UseStandalonePip,SemVerPostRelease,DefaultLogEntryLimit,HistoryRetain,TestReportFormat,ModuleRoot,LogDirectory,AutoLog";
 
 /// Returns configArray, that includes all configurable settings
 ClassMethod GetAll(Output configArray) As %Status
@@ -97,6 +101,12 @@ ClassMethod ResetToDefault(key As %String) As %Status
     } elseif key = ..#ModuleRoot {
         // Computed directly rather than read from storage — older IPM versions did not seed this default node
         set defaultValue = ##class(%File).NormalizeDirectory(##class(%SYSTEM.Util).DataDirectory() _ "ipm/")
+    } elseif key = ..#LogDirectory {
+        // Computed directly rather than read from storage — older IPM versions did not seed this default node
+        set defaultValue = ##class(%File).NormalizeDirectory(##class(%SYSTEM.Util).DataDirectory() _ "ipm/logs/")
+    } elseif key = ..#AutoLog {
+        // No factory default; empty string means AutoLog is disabled
+        set defaultValue = ""
     } else {
         set defaultValue = ..GetDefaultValue($parameter(..%ClassName(1),key))
     }
@@ -130,6 +140,16 @@ ClassMethod UpdateOne(
                 }
                 set value = ##class(%File).NormalizeDirectory(value)
                 do ..EnsureWritableDirectory(value)
+            } elseif key = ..#LogDirectory {
+                if value = "" {
+                    $$$ThrowOnError($$$ERROR($$$GeneralError, "LogDirectory cannot be empty"))
+                }
+                set value = ##class(%File).NormalizeDirectory(value)
+                do ..EnsureWritableDirectory(value)
+            } elseif key = ..#AutoLog {
+                if '$listfind($lb("","0","1"), value) {
+                    $$$ThrowOnError($$$ERROR($$$GeneralError, "AutoLog must be 0 or 1"))
+                }
             }
             set sc = ..SetValue($parameter(..%ClassName(1),key), value)
         }
@@ -249,6 +269,22 @@ ClassMethod GetModuleRoot() As %String
         return ##class(%File).NormalizeDirectory(##class(%SYSTEM.Util).DataDirectory() _ "ipm/")
     }
     return value
+}
+
+/// Returns the configured LogDirectory. Falls back to an ipm/logs/ subdirectory under the IRIS data directory if not set.
+ClassMethod GetLogDirectory() As %String
+{
+    set value = ..GetValue(..#LogDirectory)
+    if value = "" {
+        return ##class(%File).NormalizeDirectory(##class(%SYSTEM.Util).DataDirectory() _ "ipm/logs/")
+    }
+    return value
+}
+
+/// Returns the AutoLog setting. Returns 1 if enabled, 0 otherwise.
+ClassMethod GetAutoLog() As %Boolean
+{
+    return +..GetValue(..#AutoLog)
 }
 
 /// Expects a normalized directory path (caller must call NormalizeDirectory first).

--- a/src/cls/IPM/Repo/UniversalSettings.cls
+++ b/src/cls/IPM/Repo/UniversalSettings.cls
@@ -1,3 +1,5 @@
+Include %IPM.Formatting
+
 /// IPM settings are placed in ^IPM.settings global in %SYS namespace
 /// Use this class to set or get settings
 ///
@@ -50,8 +52,13 @@ Parameter TestReportFormat = "TestReportFormat";
 
 Parameter ModuleRoot = "ModuleRoot";
 
+/// Directory holding `-log-file` logs given as a bare filename, AutoLog session logs,
+/// and CPF merge logs.
 Parameter LogDirectory = "LogDirectory";
 
+/// Possible values: "", 0, 1
+/// When 1, every shell session is logged to a file under <parameter>LogDirectory</parameter>.
+/// Read once when the shell starts, so a change applies to the next shell session.
 Parameter AutoLog = "AutoLog";
 
 Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt,PublishTimeout,PipCaller,UseStandalonePip,SemVerPostRelease,DefaultLogEntryLimit,HistoryRetain,TestReportFormat,ModuleRoot,LogDirectory,AutoLog";
@@ -155,6 +162,7 @@ ClassMethod UpdateOne(
         }
         if $$$ISOK(sc) {
             write !,"Key """_key_""" succesfully updated",!
+            do ..WarnLoggingUnchanged(key, value)
         } else {
             write !,$system.Status.GetErrorText(sc),!
         }
@@ -163,6 +171,29 @@ ClassMethod UpdateOne(
         write !,$system.Status.GetErrorText(sc),!
     }
     return sc
+}
+
+/// Warns that a new AutoLog or LogDirectory value will not change how the running shell
+/// logs, since both are read once when the shell starts. Silent when the new value
+/// matches what the session is already doing.
+ClassMethod WarnLoggingUnchanged(
+	key As %String,
+	value As %String) [ Internal, Private ]
+{
+    set active = ##class(%IPM.General.OutputLog).IsActive()
+    if key = ..#AutoLog {
+        if +value = active {
+            return
+        }
+    } elseif key = ..#LogDirectory {
+        if 'active && '..GetAutoLog() {
+            return
+        }
+    } else {
+        return
+    }
+    write !,$$$FormattedLine($$$Yellow,"This takes effect in your next IPM shell session; logging for the current one is unchanged."),!
+    write "Use the -log-file modifier to log a single command in this session.",!
 }
 
 /// Gets value from global array

--- a/src/cls/IPM/ResourceProcessor/CPF.cls
+++ b/src/cls/IPM/ResourceProcessor/CPF.cls
@@ -142,17 +142,20 @@ ClassMethod MergeCPF(
     set flags = "/SHELL/LOGCMD/STDOUT="""_logPath_"""/STDERR="""_logPath_""""
     set status = $zf(-100, flags, "iris", .args)
 
-    write !, "CPF merge log: ", logPath, !
-    if verbose && ##class(%File).Exists(logPath) {
-        set logStream = ##class(%Stream.FileCharacter).%New()
-        do logStream.LinkToFile(logPath)
-        while 'logStream.AtEnd {
-            write logStream.ReadLine(), !
+    if verbose {
+        write !, "CPF merge log: ", logPath, !
+        if ##class(%File).Exists(logPath) {
+            set logStream = ##class(%Stream.FileCharacter).%New()
+            do logStream.LinkToFile(logPath)
+            while 'logStream.AtEnd {
+                write logStream.ReadLine(), !
+            }
         }
     }
 
     if status '= 0 {
-        $$$ThrowStatus($$$ERROR($$$GeneralError, "Error merging CPF file. $zf(-100) exited with "_status))
+        set msg = "Error merging CPF file. $zf(-100) exited with "_status_". See "_logPath
+        $$$ThrowStatus($$$ERROR($$$GeneralError, msg))
     }
 }
 

--- a/src/cls/IPM/ResourceProcessor/CPF.cls
+++ b/src/cls/IPM/ResourceProcessor/CPF.cls
@@ -110,7 +110,7 @@ Method DoMerge(ByRef pParams) As %Status
             $$$ThrowOnError(outputStream.OutputToDevice())
         }
 
-        do ..MergeCPF(tempFile)
+        do ..MergeCPF(tempFile, verbose)
     } catch ex {
         set sc = ex.AsStatus()
     }
@@ -118,19 +118,39 @@ Method DoMerge(ByRef pParams) As %Status
     return sc
 }
 
-ClassMethod MergeCPF(file As %String)
+ClassMethod MergeCPF(
+	file As %String,
+	verbose As %Boolean = 0)
 {
     // TODO The $zf(-100) callout is much slower than ##class(Config.CPF).Merge()
     //      Figure out why ##class(Config.CPF).Merge() doesn't work
     //      c.f. https://github.com/intersystems/ipm/pull/703#discussion_r1917290136
 
+    // Capture merge output to a log file under LogDirectory; $zf(-100) child
+    // process output bypasses IRIS device redirection so we must bind it here.
+    set logDir = ##class(%IPM.Repo.UniversalSettings).GetLogDirectory()
+    $$$ThrowOnError(##class(%IPM.Utils.File).CreateDirectoryChain(logDir))
+    set h = $horolog
+    set logTs = $zdate(h,3) _ "-" _ $translate($ztime($piece(h,",",2)),":")
+    set logPath = logDir _ "cpf-merge-" _ logTs _ "-" _ $job _ ".log"
+
     set args($increment(args)) = "merge"
     set args($increment(args)) = ##class(%SYS.System).GetInstanceName()
     set args($increment(args)) = file
 
-    // Somehow, if the STDOUT is not set, the merge will silently fail
-    set flags = "/SHELL/LOGCMD/STDOUT=""zf100stdout""/STDERR=""zf100stderr"""
+    // Bind STDOUT and STDERR to logPath so merge output is captured
+    set flags = "/SHELL/LOGCMD/STDOUT="""_logPath_"""/STDERR="""_logPath_""""
     set status = $zf(-100, flags, "iris", .args)
+
+    write !, "CPF merge log: ", logPath, !
+    if verbose && ##class(%File).Exists(logPath) {
+        set logStream = ##class(%Stream.FileCharacter).%New()
+        do logStream.LinkToFile(logPath)
+        while 'logStream.AtEnd {
+            write logStream.ReadLine(), !
+        }
+    }
+
     if status '= 0 {
         $$$ThrowStatus($$$ERROR($$$GeneralError, "Error merging CPF file. $zf(-100) exited with "_status))
     }

--- a/src/cls/IPM/ResourceProcessor/CPF.cls
+++ b/src/cls/IPM/ResourceProcessor/CPF.cls
@@ -138,8 +138,11 @@ ClassMethod MergeCPF(
     set args($increment(args)) = ##class(%SYS.System).GetInstanceName()
     set args($increment(args)) = file
 
-    // Bind STDOUT and STDERR to logPath so merge output is captured
-    set flags = "/SHELL/LOGCMD/STDOUT="""_logPath_"""/STDERR="""_logPath_""""
+    // Bind STDOUT and STDERR to logPath so merge output is captured. STDIN is bound to the
+    // null device as well: the merge needs no input, and left unbound it tries to open the
+    // parent's terminal as its principal device and logs a failure to do so.
+    set nullDevice = $select($$$isWINDOWS: "NUL", 1: "/dev/null")
+    set flags = "/SHELL/LOGCMD/STDIN="""_nullDevice_"""/STDOUT="""_logPath_"""/STDERR="""_logPath_""""
     set status = $zf(-100, flags, "iris", .args)
 
     if verbose {

--- a/src/cls/IPM/ResourceProcessor/CSPApplication.cls
+++ b/src/cls/IPM/ResourceProcessor/CSPApplication.cls
@@ -250,7 +250,8 @@ Method CreateOrUpdateCSPApp(pVerbose As %Boolean = 0) As %Status [ Internal ]
         set tOrigNS = $namespace
         set dbDir = $$$defdir
         new $namespace
-        set $namespace="%SYS"
+        $$$SuspendRedirection(redirect)
+        set $namespace = "%SYS"
 
         // Map properties of this object (inherited from %Installer.CSPApplication) to subscripts of tProperties
         // In other cases, the default mapping is accepted.
@@ -378,6 +379,7 @@ Method CreateOrUpdateCSPApp(pVerbose As %Boolean = 0) As %Status [ Internal ]
     } catch ex {
         set tSC = ex.AsStatus()
     }
+    $$$RestoreRedirection(redirect)
     quit tSC
 }
 

--- a/src/cls/IPM/ResourceProcessor/WebApplication.cls
+++ b/src/cls/IPM/ResourceProcessor/WebApplication.cls
@@ -1,4 +1,4 @@
-Include (%sySecurity, %occErrors, %occReference)
+Include (%sySecurity, %occErrors, %occReference, %IPM.Common)
 
 Class %IPM.ResourceProcessor.WebApplication Extends (%IPM.ResourceProcessor.Abstract, %XML.Adaptor) [ PropertyClass = %IPM.ResourceProcessor.PropertyParameters ]
 {
@@ -108,58 +108,64 @@ Method OnBeforePhase(
 Method CreateOrUpdateWebApp(pVerbose As %Boolean = 0) [ Internal ]
 {
     new $namespace
+    $$$SuspendRedirection(redirect)
     set $namespace = "%SYS"
+    try {
+        merge properties = ..SecurityProperties
 
-    merge properties = ..SecurityProperties
-
-    if ##class(Security.Applications).Exists(..Name) {
-        write:pVerbose !,"Updating Web Application ",..Name
-        set sc = ##class(Security.Applications).Get(..Name,.oldProperties)
-        $$$ThrowOnError(sc)
-
-        kill changes
-        set key = ""
-        for {
-            set key = $order(properties(key),1,value)
-            quit:(key="")
-            set oldValue = $get(oldProperties(key))
-            if (value '= oldValue) {
-                if (value = "") {
-                    set value = "[missing]"
-                }
-                if (oldValue = "") {
-                    set oldValue = "[missing]"
-                }
-                set changes($increment(changes)) = key_": "_oldValue_" -> "_value
-            }
-        }
-
-        if $data(changes) {
-            if (pVerbose) {
-                for i=1:1:$get(changes) {
-                    write !,changes(i)
-                }
-            }
-            set sc = ##class(Security.Applications).Modify(..Name,.properties)
+        if ##class(Security.Applications).Exists(..Name) {
+            write:pVerbose !,"Updating Web Application ",..Name
+            set sc = ##class(Security.Applications).Get(..Name,.oldProperties)
             $$$ThrowOnError(sc)
-            write:pVerbose !,"Done."
-        } else {
-            write:pVerbose !,"No changes detected or made."
-        }
-    } else {
-        write:pVerbose !,"Creating Web Application ",..Name
-        set sc = ##class(Security.Applications).Create(..Name,.properties)
-        if (pVerbose) {
+
+            kill changes
             set key = ""
             for {
-                set key = $order(properties(key),1,tValue)
-                quit:key=""
-                write !,key,": ",tValue
+                set key = $order(properties(key),1,value)
+                quit:(key="")
+                set oldValue = $get(oldProperties(key))
+                if (value '= oldValue) {
+                    if (value = "") {
+                        set value = "[missing]"
+                    }
+                    if (oldValue = "") {
+                        set oldValue = "[missing]"
+                    }
+                    set changes($increment(changes)) = key_": "_oldValue_" -> "_value
+                }
             }
+
+            if $data(changes) {
+                if (pVerbose) {
+                    for i=1:1:$get(changes) {
+                        write !,changes(i)
+                    }
+                }
+                set sc = ##class(Security.Applications).Modify(..Name,.properties)
+                $$$ThrowOnError(sc)
+                write:pVerbose !,"Done."
+            } else {
+                write:pVerbose !,"No changes detected or made."
+            }
+        } else {
+            write:pVerbose !,"Creating Web Application ",..Name
+            set sc = ##class(Security.Applications).Create(..Name,.properties)
+            if (pVerbose) {
+                set key = ""
+                for {
+                    set key = $order(properties(key),1,tValue)
+                    quit:key=""
+                    write !,key,": ",tValue
+                }
+            }
+            $$$ThrowOnError(sc)
+            write:pVerbose !,"Done."
         }
-        $$$ThrowOnError(sc)
-        write:pVerbose !,"Done."
+    } catch ex {
+        $$$RestoreRedirection(redirect)
+        throw ex
     }
+    $$$RestoreRedirection(redirect)
 }
 
 /// This removes an existing CSP application

--- a/src/cls/IPM/Utils/Build.cls
+++ b/src/cls/IPM/Utils/Build.cls
@@ -1,4 +1,4 @@
-Include (%occErrors, %occOptions, %syPrompt)
+Include (%occErrors, %occOptions, %syPrompt, %IPM.Common)
 
 Class %IPM.Utils.Build
 {
@@ -162,9 +162,12 @@ ClassMethod PrepareDatabase(
 	pDBName As %String,
 	pVerbose As %Boolean = 1) As %Status
 {
-    new $namespace
     set tSC = $$$OK
     try {
+        // CompactDatabase() below is handed $io and writes its own progress from inside the
+        // excursion, so suspending redirection covers callee output as well as the writes here.
+        new $namespace
+        $$$SuspendRedirection(redirect)
         set $namespace = "%SYS"
 
         set tDB = ##class(Config.Databases).Open(pDBName,,.tSC)
@@ -191,6 +194,7 @@ ClassMethod PrepareDatabase(
     } catch e {
         set tSC = e.AsStatus()
     }
+    $$$RestoreRedirection(redirect)
     quit tSC
 }
 
@@ -440,10 +444,11 @@ ClassMethod DeleteNamespace(
 	pNSName As %String,
 	pVerbose As %Boolean = 0) As %Status
 {
-    new $namespace
     set tFinalStatus = $$$OK
     try {
-    if pVerbose write !,"Deleting namespace: " _ pNSName
+        if pVerbose write !,"Deleting namespace: " _ pNSName
+        new $namespace
+        $$$SuspendRedirection(redirect)
         set $namespace = "%SYS"
         set tLowerName = $zconvert(pNSName,"L")
         // The csp directory is lower case on unix but upper case on windows
@@ -507,6 +512,7 @@ ClassMethod DeleteNamespace(
     } catch e {
         set tFinalStatus = $$$ADDSC(tFinalStatus,e.AsStatus())
     }
+    $$$RestoreRedirection(redirect)
     quit tFinalStatus
 }
 
@@ -725,7 +731,6 @@ ClassMethod CleanBuild(
 
 ClassMethod Backup() As %Status [ Internal ]
 {
-    new $namespace
     set tSC = $$$OK
     set tFrozen = 0
     try {
@@ -735,6 +740,8 @@ ClassMethod Backup() As %Status [ Internal ]
         kill %objlasterror
         set tSC = ##class(%IPM.Utils.File).CreateDirectoryChain(tTargetDir)
         $$$ThrowOnError(tSC)
+        new $namespace
+        $$$SuspendRedirection(redirect)
         set $namespace = "%SYS"
         write !,"Freezing writes..."
         set tSC = ##class(Backup.General).ExternalFreeze()
@@ -757,6 +764,7 @@ ClassMethod Backup() As %Status [ Internal ]
         set $namespace = "%SYS"
         set tSC = $$$ADDSC(tSC,##class(Backup.General).ExternalThaw())
     }
+    $$$RestoreRedirection(redirect)
     quit tSC
 }
 

--- a/src/cls/IPM/Utils/Module.cls
+++ b/src/cls/IPM/Utils/Module.cls
@@ -1852,6 +1852,7 @@ ClassMethod PerformBatchActivation(
         }
 
         new $namespace
+        $$$SuspendRedirection(redirect)
         set $namespace = "%SYS"
         $$$ThrowOnError(##class(Config.CPF).Write())
         $$$ThrowOnError(##class(Config.Map).MoveToActive())
@@ -1875,6 +1876,7 @@ ClassMethod PerformBatchActivation(
     } catch ex {
         set sc = ex.AsStatus()
     }
+    $$$RestoreRedirection(redirect)
 
     while ($tlevel > initTLevel) {
         trollback 1

--- a/src/inc/IPM/Common.inc
+++ b/src/inc/IPM/Common.inc
@@ -93,3 +93,21 @@ ROUTINE %IPM.Common [Type=INC]
 #; Locking for module update framework
 #Define LockUpdateModule(%name) lock +^IPM.UpdateLock(%name):3
 #Define UnlockUpdateModule(%name) lock -^IPM.UpdateLock(%name)
+
+#; Suspends output redirection around a namespace excursion that produces output.
+#; The redirect handler is a routine name that re-resolves in the current namespace on
+#; every write, so a write from a namespace lacking the %IPM.* routine mapping (%SYS, or a
+#; namespace IPM is not installed in) raises <NOROUTINE>. Covers writes from system APIs
+#; handed $io as well as IPM's own. Output produced while suspended reaches the terminal but
+#; not an active log file.
+#; Macros, not methods: the restore runs while still in the target namespace, where a
+#; ##class(%IPM...) call is itself unresolvable.
+#; %flag holds the prior interception state. Pass it to $$$RestoreRedirection on every path
+#; out, error paths included, or logging stays off for the rest of the command.
+#; Only the first suspend records the state, so suspending once per iteration of a loop cannot
+#; overwrite the saved flag with the 0 that a second $zutil(82,12,0) returns.
+#Define SuspendRedirection(%flag) set:'$data(%flag) %flag = $zutil(82,12,0)
+#; No-op when %flag is undefined: redirection was never suspended, so there is nothing to
+#; restore and forcing interception off would stop an active log. Clearing %flag lets a method
+#; bracket several excursions in turn, each pair capturing the state afresh.
+#Define RestoreRedirection(%flag) do:$data(%flag) $zutil(82,12,%flag) kill %flag

--- a/tests/integration_tests/Test/PM/Integration/OutputLog.cls
+++ b/tests/integration_tests/Test/PM/Integration/OutputLog.cls
@@ -25,6 +25,8 @@ Method OnAfterOneTest(testname As %String) As %Status
 {
     // Clean up any leaked OutputLog state
     do ##class(%IPM.General.OutputLog).Stop()
+    // The AutoLog path is deliberately per-process, so it must be cleared between tests
+    do ##class(%IPM.General.OutputLog).ClearAutoLog()
     // Clean up any leaked BeginCaptureOutput state
     if $data(^||%capture) {
         set junk = ""
@@ -111,7 +113,7 @@ Method TestTeeEquivalence()
     }
 }
 
-/// ANSI stripping: log file must not contain ESC character.
+/// ANSI stripping: log file must not contain ESC or the printable tail of a CSI sequence.
 Method TestANSIStripping()
 {
     set logPath = ..TempDir _ "ansi.log"
@@ -119,8 +121,22 @@ Method TestANSIStripping()
     do $$$AssertStatusOK(sc, "version succeeded")
     if ##class(%File).Exists(logPath) {
         set content = ..ReadFile(logPath)
-        do $$$AssertTrue(content '[ $char(27), "No ANSI escape codes in log file")
+        do $$$AssertTrue(content '[ $char(27), "No ESC character in log file")
+        do $$$AssertTrue(content '[ "[0m", "No CSI reset residue in log file")
+        do $$$AssertTrue(content '[ "[39m", "No CSI color residue in log file")
     }
+}
+
+/// Column tracking: `write ?n` indentation and non-ASCII bullets survive into the log.
+Method TestIndentationAndEncoding()
+{
+    set logPath = ..TempDir _ "indent.log"
+    set sc = ##class(%IPM.Main).Shell("help help -log-file " _ logPath)
+    do $$$AssertStatusOK(sc, "help help succeeded")
+    set content = ..ReadFile(logPath)
+    do $$$AssertTrue(content [ ($char(10) _ "    " _ $char(9632)), "?n indentation present before bullet")
+    do $$$AssertTrue(content [ $char(9632), "Black square preserved (UTF8 translate table)")
+    do $$$AssertTrue(content [ $char(9675), "Bullet point preserved (UTF8 translate table)")
 }
 
 /// Append mode: second invocation grows the file.
@@ -174,10 +190,39 @@ Method TestAutoLog()
     do $$$AssertStatusOK(sc, "version under AutoLog succeeded")
     // ipm-*.log file should exist in TempDir
     set found = 0
-    set rs = ##class(%ResultSet).%New("%File:FileSet")
-    do rs.Execute(..TempDir, "ipm-*.log")
-    while rs.Next() { set found = found + 1 }
+    set rs = ##class(%SQL.Statement).%ExecDirect(,
+        "SELECT Name FROM %Library.File_FileSet(?, ?)",
+        ..TempDir, "ipm-*.log")
+    while rs.%Next() { set found = found + 1 }
     do $$$AssertTrue(found >= 1, "AutoLog created ipm-*.log file")
+}
+
+/// AutoLog: separate commands in one process share a single log file.
+Method TestAutoLogSharedFile()
+{
+    set sc = ##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#LogDirectory, ..TempDir)
+    $$$ThrowOnError(sc)
+    set sc = ##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#AutoLog, "1")
+    $$$ThrowOnError(sc)
+    for i = 1:1:3 {
+        set sc = ##class(%IPM.Main).Shell("version")
+        do $$$AssertStatusOK(sc, "version " _ i _ " under AutoLog succeeded")
+        do ##class(%IPM.General.OutputLog).Stop()
+    }
+    set found = 0
+    set path = ""
+    set rs = ##class(%SQL.Statement).%ExecDirect(,
+        "SELECT Name FROM %Library.File_FileSet(?, ?)",
+        ..TempDir, "ipm-*.log")
+    while rs.%Next() {
+        set found = found + 1
+        set path = rs.Name
+    }
+    do $$$AssertEquals(found, 1, "Three commands wrote one AutoLog file")
+    if found = 1 {
+        set content = ..ReadFile(path)
+        do $$$AssertEquals($length(content, "--- [") - 1, 3, "Log holds three command headers")
+    }
 }
 
 /// Config validation: AutoLog rejects non-boolean.

--- a/tests/integration_tests/Test/PM/Integration/OutputLog.cls
+++ b/tests/integration_tests/Test/PM/Integration/OutputLog.cls
@@ -12,12 +12,22 @@ Property SavedLogDir As %String;
 
 Property SavedAutoLog As %String;
 
+/// Path of a tee this suite inherited, e.g. when the shell running the tests has AutoLog on.
+Property InheritedLogPath As %String;
+
 Method OnBeforeOneTest(testname As %String) As %Status
 {
     set ..TempDir = ##class(%File).NormalizeDirectory(##class(%File).ManagerDirectory() _ "ipm-test-outputlog-" _ $job)
     do ##class(%File).CreateDirectoryChain(..TempDir)
     set ..SavedLogDir = ##class(%IPM.Repo.UniversalSettings).GetValue(##class(%IPM.Repo.UniversalSettings).#LogDirectory)
     set ..SavedAutoLog = ##class(%IPM.Repo.UniversalSettings).GetValue(##class(%IPM.Repo.UniversalSettings).#AutoLog)
+    // These tests start and stop tees of their own, so an inherited one is set aside and
+    // put back afterwards. %UnitTest.Manager snapshots the device redirect flag and fails
+    // the case if it does not match at the end.
+    set ..InheritedLogPath = ##class(%IPM.General.OutputLog).GetActivePath()
+    if ..InheritedLogPath '= "" {
+        do ##class(%IPM.General.OutputLog).Stop()
+    }
     return $$$OK
 }
 
@@ -44,6 +54,9 @@ Method OnAfterOneTest(testname As %String) As %Status
         do ##class(%IPM.Repo.UniversalSettings).ResetToDefault(##class(%IPM.Repo.UniversalSettings).#AutoLog)
     }
     do ##class(%File).RemoveDirectoryTree(..TempDir)
+    if ..InheritedLogPath '= "" {
+        do ##class(%IPM.General.OutputLog).Start(..InheritedLogPath, 1)
+    }
     return $$$OK
 }
 
@@ -51,6 +64,9 @@ ClassMethod ReadFile(path As %String) As %String
 {
     set s = ##class(%Stream.FileCharacter).%New()
     do s.LinkToFile(path)
+    // Match the /IOTABLE="UTF8" the log device is opened with, so multi-byte
+    // characters read back as single characters rather than raw bytes.
+    set s.TranslateTable = "UTF8"
     return s.Read(s.Size)
 }
 
@@ -85,13 +101,14 @@ Method TestTeeEquivalence()
     set rawFile = ..ReadFile(logPath)
     do $$$AssertTrue(rawFile '= "", "File copy non-empty")
 
-    // Build ANSI-stripped capture string
+    // Strip ANSI before control characters: $zstrip would remove the ESC and leave the
+    // printable tail of each sequence, which the file copy does not have.
     set strippedCapture = ""
     set i = ""
     for {
         set i = $order(captured(i), 1, line)
         quit:i=""
-        set strippedCapture = strippedCapture _ $zstrip(line,"*C")
+        set strippedCapture = strippedCapture _ $zstrip(##class(%IPM.General.OutputLog).StripAnsi(line),"*C")
     }
     do $$$AssertTrue(strippedCapture '= "", "Device output captured")
 
@@ -236,6 +253,33 @@ Method TestAutoLogValidation()
     do $$$AssertStatusOK(sc, "AutoLog=1 accepted")
     set sc = ##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#AutoLog, "0")
     do $$$AssertStatusOK(sc, "AutoLog=0 accepted")
+}
+
+/// -log-file covers one command and leaves an AutoLog session running afterwards.
+Method TestLogFileRestoresAutoLog()
+{
+    $$$ThrowOnError(##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#LogDirectory, ..TempDir))
+    $$$ThrowOnError(##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#AutoLog, "1"))
+    do ##class(%IPM.General.OutputLog).ClearAutoLog()
+    $$$ThrowOnError(##class(%IPM.General.OutputLog).StartAutoLog())
+    set autoPath = ##class(%IPM.General.OutputLog).GetActivePath()
+    do $$$AssertNotEquals(autoPath, "", "AutoLog tee started")
+
+    set oneOff = ..TempDir _ "oneoff.log"
+    do ##class(%IPM.Main).Shell("version -log-file " _ oneOff)
+    do $$$AssertEquals(##class(%IPM.General.OutputLog).GetActivePath(), autoPath, "AutoLog tee resumed after the -log-file command")
+    do $$$AssertTrue(##class(%File).Exists(oneOff), "-log-file wrote its own file")
+    do $$$AssertTrue(..ReadFile(oneOff) [ "-log-file", "One-off log holds the -log-file command header")
+
+    // A later command must land in the AutoLog transcript, and that transcript must not
+    // hold the -log-file command, which was teed elsewhere. The tee also captures the
+    // assertion lines %UnitTest writes to the device, so count command headers rather
+    // than searching for command text.
+    do ##class(%IPM.Main).Shell("version")
+    do ##class(%IPM.General.OutputLog).Stop()
+    set autoContent = ..ReadFile(autoPath)
+    do $$$AssertEquals($length(autoContent, "--- [") - 1, 1, "AutoLog transcript holds one command header")
+    do $$$AssertTrue(autoContent [ "] version ---", "AutoLog transcript header is the later plain command")
 }
 
 /// Zero-cost path: without -log-file and AutoLog off, OutputLog stays inactive.

--- a/tests/integration_tests/Test/PM/Integration/OutputLog.cls
+++ b/tests/integration_tests/Test/PM/Integration/OutputLog.cls
@@ -1,0 +1,206 @@
+Include (%IPM.Common, %IPM.Formatting)
+
+/// Integration tests for OutputLog tee functionality.
+Class Test.PM.Integration.OutputLog Extends %UnitTest.TestCase
+{
+
+Parameter NEEDSREGISTRY As BOOLEAN = 0;
+
+Property TempDir As %String;
+
+Property SavedLogDir As %String;
+
+Property SavedAutoLog As %String;
+
+Method OnBeforeOneTest(testname As %String) As %Status
+{
+    set ..TempDir = ##class(%File).NormalizeDirectory(##class(%File).ManagerDirectory() _ "ipm-test-outputlog-" _ $job)
+    do ##class(%File).CreateDirectoryChain(..TempDir)
+    set ..SavedLogDir = ##class(%IPM.Repo.UniversalSettings).GetValue(##class(%IPM.Repo.UniversalSettings).#LogDirectory)
+    set ..SavedAutoLog = ##class(%IPM.Repo.UniversalSettings).GetValue(##class(%IPM.Repo.UniversalSettings).#AutoLog)
+    return $$$OK
+}
+
+Method OnAfterOneTest(testname As %String) As %Status
+{
+    // Clean up any leaked OutputLog state
+    do ##class(%IPM.General.OutputLog).Stop()
+    // Clean up any leaked BeginCaptureOutput state
+    if $data(^||%capture) {
+        set junk = ""
+        do ##class(%IPM.Utils.Module).EndCaptureOutput(.junk, .junk)
+    }
+    // Restore settings
+    if ..SavedLogDir '= "" {
+        do ##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#LogDirectory, ..SavedLogDir)
+    } else {
+        do ##class(%IPM.Repo.UniversalSettings).ResetToDefault(##class(%IPM.Repo.UniversalSettings).#LogDirectory)
+    }
+    if ..SavedAutoLog '= "" {
+        do ##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#AutoLog, ..SavedAutoLog)
+    } else {
+        do ##class(%IPM.Repo.UniversalSettings).ResetToDefault(##class(%IPM.Repo.UniversalSettings).#AutoLog)
+    }
+    do ##class(%File).RemoveDirectoryTree(..TempDir)
+    return $$$OK
+}
+
+ClassMethod ReadFile(path As %String) As %String
+{
+    set s = ##class(%Stream.FileCharacter).%New()
+    do s.LinkToFile(path)
+    return s.Read(s.Size)
+}
+
+/// Explicit -log-file: file created with header and command output.
+Method TestExplicitLogFile()
+{
+    set logPath = ..TempDir _ "explicit.log"
+    set sc = ##class(%IPM.Main).Shell("version -log-file " _ logPath)
+    do $$$AssertStatusOK(sc, "version with -log-file succeeded")
+    do $$$AssertTrue(##class(%File).Exists(logPath), "Log file created")
+    set content = ..ReadFile(logPath)
+    do $$$AssertTrue(content '= "", "Log file not empty")
+    do $$$AssertTrue(content [ "---", "Log has header delimiter")
+    do $$$AssertTrue(content [ $namespace, "Log has namespace")
+}
+
+/// Tee equivalence: command output (beyond the file-only header) appears on the device.
+Method TestTeeEquivalence()
+{
+    set logPath = ..TempDir _ "tee-equiv.log"
+    set capSC = ##class(%IPM.Utils.Module).BeginCaptureOutput(.cookie)
+    if $$$ISERR(capSC) {
+        do $$$AssertStatusOK(capSC, "BeginCaptureOutput succeeded")
+        return
+    }
+    set sc = ##class(%IPM.Main).Shell("version -log-file " _ logPath)
+    do ##class(%IPM.General.OutputLog).Stop()
+    do ##class(%IPM.Utils.Module).EndCaptureOutput(cookie, .captured)
+
+    do $$$AssertStatusOK(sc, "version command succeeded")
+
+    set rawFile = ..ReadFile(logPath)
+    do $$$AssertTrue(rawFile '= "", "File copy non-empty")
+
+    // Build ANSI-stripped capture string
+    set strippedCapture = ""
+    set i = ""
+    for {
+        set i = $order(captured(i), 1, line)
+        quit:i=""
+        set strippedCapture = strippedCapture _ $zstrip(line,"*C")
+    }
+    do $$$AssertTrue(strippedCapture '= "", "Device output captured")
+
+    // Skip the file-only header by finding the second LF in the raw file.
+    // WriteCommandHeader writes: LF + "--- [...] ---" + LF + content
+    // Avoid line-by-line parsing which is fragile across CRLF/LF platforms.
+    set pos1 = $find(rawFile, $char(10))
+    set pos2 = $select(pos1 > 0: $find(rawFile, $char(10), pos1), 1: 0)
+    if pos2 > 0 {
+        set fileBody = $zstrip($extract(rawFile, pos2, *), "*C")
+        if fileBody '= "" {
+            set token = $extract(fileBody, 1, 15)
+            do $$$AssertTrue(strippedCapture [ token, "Tee body appears on device: "_token)
+        } else {
+            do $$$AssertTrue(0, "File has no content beyond header")
+        }
+    } else {
+        do $$$AssertTrue(0, "File missing expected header structure")
+    }
+}
+
+/// ANSI stripping: log file must not contain ESC character.
+Method TestANSIStripping()
+{
+    set logPath = ..TempDir _ "ansi.log"
+    set sc = ##class(%IPM.Main).Shell("version -log-file " _ logPath)
+    do $$$AssertStatusOK(sc, "version succeeded")
+    if ##class(%File).Exists(logPath) {
+        set content = ..ReadFile(logPath)
+        do $$$AssertTrue(content '[ $char(27), "No ANSI escape codes in log file")
+    }
+}
+
+/// Append mode: second invocation grows the file.
+Method TestAppendMode()
+{
+    set logPath = ..TempDir _ "append.log"
+    set sc = ##class(%IPM.Main).Shell("version -log-file " _ logPath)
+    do $$$AssertStatusOK(sc, "First version succeeded")
+    set size1 = ##class(%File).GetFileSize(logPath)
+    do $$$AssertTrue(size1 > 0, "File created after first run")
+
+    set sc = ##class(%IPM.Main).Shell("version -log-file " _ logPath)
+    do $$$AssertStatusOK(sc, "Second version succeeded")
+    set size2 = ##class(%File).GetFileSize(logPath)
+    do $$$AssertTrue(size2 > size1, "File grew (append mode)")
+}
+
+/// Bare-name resolution: bare filename resolves under LogDirectory.
+Method TestBareNameResolution()
+{
+    set sc = ##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#LogDirectory, ..TempDir)
+    $$$ThrowOnError(sc)
+    set sc = ##class(%IPM.Main).Shell("version -log-file bare.log")
+    do $$$AssertStatusOK(sc, "version with bare name succeeded")
+    set expectedPath = ..TempDir _ "bare.log"
+    do $$$AssertTrue(##class(%File).Exists(expectedPath), "Bare name resolved under LogDirectory")
+}
+
+/// Header format: log header contains timestamp brackets, namespace, and command.
+Method TestHeaderFormat()
+{
+    set logPath = ..TempDir _ "header.log"
+    set sc = ##class(%IPM.Main).Shell("version -log-file " _ logPath)
+    do $$$AssertStatusOK(sc, "version succeeded")
+    set content = ..ReadFile(logPath)
+    do $$$AssertTrue(content [ "--- [", "Header has opening delimiter")
+    do $$$AssertTrue(content [ "] [", "Header has namespace bracket")
+    do $$$AssertTrue(content [ "version", "Header contains command name")
+    do $$$AssertTrue(content [ $namespace, "Header contains namespace")
+}
+
+/// AutoLog: session log created automatically when AutoLog=1.
+Method TestAutoLog()
+{
+    set sc = ##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#LogDirectory, ..TempDir)
+    $$$ThrowOnError(sc)
+    set sc = ##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#AutoLog, "1")
+    $$$ThrowOnError(sc)
+    set sc = ##class(%IPM.Main).Shell("version")
+    do ##class(%IPM.General.OutputLog).Stop()
+    do $$$AssertStatusOK(sc, "version under AutoLog succeeded")
+    // ipm-*.log file should exist in TempDir
+    set found = 0
+    set rs = ##class(%ResultSet).%New("%File:FileSet")
+    do rs.Execute(..TempDir, "ipm-*.log")
+    while rs.Next() { set found = found + 1 }
+    do $$$AssertTrue(found >= 1, "AutoLog created ipm-*.log file")
+}
+
+/// Config validation: AutoLog rejects non-boolean.
+Method TestAutoLogValidation()
+{
+    set sc = ##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#AutoLog, "2")
+    do $$$AssertStatusNotOK(sc, "AutoLog=2 rejected")
+    set sc = ##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#AutoLog, "abc")
+    do $$$AssertStatusNotOK(sc, "AutoLog=abc rejected")
+    set sc = ##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#AutoLog, "1")
+    do $$$AssertStatusOK(sc, "AutoLog=1 accepted")
+    set sc = ##class(%IPM.Repo.UniversalSettings).UpdateOne(##class(%IPM.Repo.UniversalSettings).#AutoLog, "0")
+    do $$$AssertStatusOK(sc, "AutoLog=0 accepted")
+}
+
+/// Zero-cost path: without -log-file and AutoLog off, OutputLog stays inactive.
+Method TestZeroCostPath()
+{
+    do ##class(%IPM.General.OutputLog).Stop()
+    do $$$AssertTrue('##class(%IPM.General.OutputLog).IsActive(), "No log active before command")
+    set sc = ##class(%IPM.Main).Shell("version")
+    do $$$AssertStatusOK(sc, "version without log succeeded")
+    do $$$AssertTrue('##class(%IPM.General.OutputLog).IsActive(), "OutputLog inactive after plain version")
+}
+
+}

--- a/tests/unit_tests/Test/PM/Unit/NamespaceExcursions.cls
+++ b/tests/unit_tests/Test/PM/Unit/NamespaceExcursions.cls
@@ -1,0 +1,162 @@
+Include %IPM.Common
+
+/// Enforces the rule that IPM code producing output inside a namespace excursion suspends
+/// device redirection first, since the redirect handler is a routine name the kernel
+/// re-resolves in the current namespace on every write.
+Class Test.PM.Unit.NamespaceExcursions Extends %UnitTest.TestCase
+{
+
+Parameter NEEDSREGISTRY As BOOLEAN = 0;
+
+/// Scans saved method sources rather than generated code, so the macros are still visible as
+/// written. A method edited on disk but not loaded into the namespace is scanned as it was
+/// last compiled.
+/// Catches only writes IPM issues itself; output a system API produces from inside an
+/// excursion after being handed $io is invisible to a source scan.
+Method TestExcursionsSuspendRedirection()
+{
+    set rs = ##class(%SQL.Statement).%ExecDirect(
+        ,
+        "SELECT parent, Name FROM %Dictionary.MethodDefinition "_
+            "WHERE parent %STARTSWITH '%IPM.' ORDER BY parent, Name")
+    do $$$AssertEquals(rs.%SQLCODE, 0, "Method definition query succeeded: "_rs.%Message)
+    set scanned = 0
+    while rs.%Next() {
+        set class = rs.%Get("parent")
+        set method = rs.%Get("Name")
+        set def = ##class(%Dictionary.MethodDefinition).%OpenId(class_"||"_method)
+        if '$isobject(def) {
+            continue
+        }
+        set scanned = scanned + 1
+        set source = ..MethodSource(def)
+        if 'source.Suspicious {
+            continue
+        }
+        do $$$AssertFailure(class_":"_method_" writes at source line "_source.WriteLine_" inside a namespace excursion without $$$SuspendRedirection")
+    }
+    do $$$AssertTrue(scanned > 100, "Scanned "_scanned_" IPM methods")
+}
+
+/// Suspending redirection and never restoring it leaves logging off for the rest of the
+/// command, so the two macros have to appear in the same method. Scoped to the macros: the
+/// raw $zutil form is also used to switch redirection off for good, as Stop() does.
+Method TestSuspendIsPairedWithRestore()
+{
+    set rs = ##class(%SQL.Statement).%ExecDirect(
+        ,
+        "SELECT parent, Name FROM %Dictionary.MethodDefinition "_
+            "WHERE parent %STARTSWITH '%IPM.' ORDER BY parent, Name")
+    do $$$AssertEquals(rs.%SQLCODE, 0, "Method definition query succeeded: "_rs.%Message)
+    while rs.%Next() {
+        set class = rs.%Get("parent")
+        set method = rs.%Get("Name")
+        set def = ##class(%Dictionary.MethodDefinition).%OpenId(class_"||"_method)
+        if '$isobject(def) {
+            continue
+        }
+        set text = ..FlattenSource(def)
+        if text '[ "$$$SuspendRedirection" {
+            continue
+        }
+        do $$$AssertTrue(text [ "$$$RestoreRedirection", class_":"_method_" suspends redirection without restoring it")
+    }
+}
+
+/// True when the line suspends redirection, by macro or by the raw call the macro expands to.
+/// %IPM.Main.LanguageExtensions() has to spell it out, since its body is emitted into
+/// %ZLANGC00.mac and compiled without IPM's include file.
+ClassMethod IsSuspend(line As %String) As %Boolean [ Private ]
+{
+    return (line [ "$$$SuspendRedirection") || ($zconvert(line, "L") [ "$zutil(82,12,0)")
+}
+
+/// Returns an object with Suspicious set when a write follows a namespace switch, and
+/// WriteLine holding the source line it was found on.
+ClassMethod MethodSource(def As %Dictionary.MethodDefinition) As %DynamicObject [ Private ]
+{
+    set result = {"Suspicious": 0, "WriteLine": 0}
+    set suspended = 0
+    set switched = 0
+    set lineNumber = 0
+    do def.Implementation.Rewind()
+    while 'def.Implementation.AtEnd {
+        set line = ..StripComment(def.Implementation.ReadLine())
+        set lineNumber = lineNumber + 1
+        if ..IsSuspend(line) {
+            set suspended = 1
+        }
+        // Remember the variables holding the namespace the method started in, so that
+        // switching back to one of them counts as ending the excursion.
+        if $match(line, ".*set +[^ ]+ *= *\$namespace *$") {
+            set entryVars($zstrip($piece($piece(line, "=", 1), "set ", 2), "<>W")) = ""
+        }
+        if $match(line, ".*set +\$namespace *=.*") {
+            set switched = '$data(entryVars($zstrip($piece(line, "=", 2), "<>W")))
+        }
+        if switched, 'suspended, ..HasWriteCommand(line) {
+            set result.Suspicious = 1
+            set result.WriteLine = lineNumber
+            quit
+        }
+    }
+    return result
+}
+
+ClassMethod FlattenSource(def As %Dictionary.MethodDefinition) As %String [ Private ]
+{
+    do def.Implementation.Rewind()
+    set text = ""
+    while 'def.Implementation.AtEnd {
+        set text = text_..StripComment(def.Implementation.ReadLine())_$char(10)
+    }
+    return text
+}
+
+/// Drops a trailing comment so prose about writing is not read as code, and so a commented
+/// out macro does not count as a real one. Handles `//`, `;` and `#;`, and ignores both
+/// markers inside string literals, where a doubled "" toggles twice and nets out.
+ClassMethod StripComment(line As %String) As %String [ Private ]
+{
+    set inString = 0
+    for i = 1:1:$length(line) {
+        set char = $extract(line, i)
+        if char = """" {
+            set inString = 'inString
+            continue
+        }
+        if inString {
+            continue
+        }
+        if (char = ";") || ((char = "/") && ($extract(line, i + 1) = "/")) {
+            return $extract(line, 1, i - 1)
+        }
+    }
+    return line
+}
+
+/// True when the line contains `write` as a command: at the start of the line or after a
+/// delimiter, and not followed by more of an identifier (so `.WriteLine` and `Overwrite`
+/// do not count).
+ClassMethod HasWriteCommand(line As %String) As %Boolean [ Private ]
+{
+    set lower = $zconvert(line, "L")
+    set delimiters = $listbuild(" ", $char(9), "{", "}", ";", ":")
+    set pos = 1
+    for {
+        set after = $find(lower, "write", pos)
+        if 'after {
+            return 0
+        }
+        set pos = after
+        if (after > 6) && '$listfind(delimiters, $extract(lower, after - 6)) {
+            continue
+        }
+        if $extract(lower, after)?1(1A,1N,1"_") {
+            continue
+        }
+        return 1
+    }
+}
+
+}

--- a/tests/unit_tests/Test/PM/Unit/StripAnsi.cls
+++ b/tests/unit_tests/Test/PM/Unit/StripAnsi.cls
@@ -1,0 +1,47 @@
+Include %IPM.Common
+
+/// Unit tests for %IPM.General.OutputLog:StripAnsi.
+Class Test.PM.Unit.StripAnsi Extends %UnitTest.TestCase
+{
+
+Parameter NEEDSREGISTRY As BOOLEAN = 0;
+
+Method TestPlainTextUnchanged()
+{
+    do $$$AssertEquals(##class(%IPM.General.OutputLog).StripAnsi(""), "", "Empty string")
+    do $$$AssertEquals(##class(%IPM.General.OutputLog).StripAnsi("hello"), "hello", "No escapes")
+    do $$$AssertEquals(##class(%IPM.General.OutputLog).StripAnsi("a[0mb"), "a[0mb", "Bracket text without ESC kept")
+}
+
+Method TestColorSequencesRemoved()
+{
+    set esc = $char(27)
+    do $$$AssertEquals(##class(%IPM.General.OutputLog).StripAnsi(esc_"[39mhelp"_esc_"[0m"), "help", "Single-parameter color codes")
+    do $$$AssertEquals(##class(%IPM.General.OutputLog).StripAnsi(esc_"[1;31mred"_esc_"[0m"), "red", "Multi-parameter color code")
+    do $$$AssertEquals(##class(%IPM.General.OutputLog).StripAnsi("a"_esc_"[0mb"_esc_"[0mc"), "abc", "Interleaved with text")
+}
+
+/// Two-byte escapes such as ESC M (reverse index) are consumed whole.
+Method TestNonCSIEscapes()
+{
+    set esc = $char(27)
+    do $$$AssertEquals(##class(%IPM.General.OutputLog).StripAnsi(esc_"Mtext"), "text", "ESC M consumed")
+    do $$$AssertEquals(##class(%IPM.General.OutputLog).StripAnsi("a"_esc_"7b"), "ab", "ESC 7 consumed")
+}
+
+/// A sequence cut off mid-parameter must not leave the ESC or spill past the end.
+Method TestTruncatedSequence()
+{
+    set esc = $char(27)
+    do $$$AssertEquals(##class(%IPM.General.OutputLog).StripAnsi("text"_esc_"[1;3"), "text", "Unterminated CSI consumed")
+    do $$$AssertEquals(##class(%IPM.General.OutputLog).StripAnsi("text"_esc), "text", "Trailing ESC consumed")
+}
+
+Method TestPreservesNonAscii()
+{
+    set esc = $char(27)
+    set square = $char(9632)
+    do $$$AssertEquals(##class(%IPM.General.OutputLog).StripAnsi(esc_"[39m"_square_" Flags:"), square_" Flags:", "Wide characters kept")
+}
+
+}


### PR DESCRIPTION
## Description

Closes #1213.

### Overview

Debugging a failing install or a long test run usually means wanting a file copy of what IPM printed, so it can be searched, diffed, or attached to an issue. Terminal scrollback is lossy, and the ANSI color codes IPM emits make copied text awkward to grep.

This PR tees IPM session output: the terminal shows exactly what it showed before, and a parallel ANSI-stripped copy goes to a file. Two entry points, one for ad-hoc use and one for always-on:

- `-log-file <path>`, a modifier injected into every command.
- `AutoLog`, a setting that starts a tee for every IPM shell.

Two supporting settings are added to `%IPM.Repo.UniversalSettings`: `LogDirectory` (default `<IRIS data dir>/ipm/logs/`) and `AutoLog`.

The CPF change belongs to the same theme. `$zf(-100)` runs the merge in a child process whose output bypasses IRIS device redirection, so it could never be teed and was previously discarded entirely (`STDOUT="zf100stdout"`). It now binds STDOUT and STDERR to a timestamped file under `LogDirectory`, echoes that file to the terminal under `-verbose`, and names the path in the error when the merge fails. STDIN is bound to the null device at the same time, since unbound it tries to open the parent's terminal as its principal device and logs a failure to do so.

### Using it

Pass `-log-file` to any command. Absolute paths are used as given; a bare filename resolves under `LogDirectory`:

```
zpm "install mypackage -log-file /tmp/install.log"
zpm "test mypackage -log-file test-run.log"
```

For always-on logging:

```
zpm "config set AutoLog 1"
zpm "config set LogDirectory /var/log/ipm/"
```

Every shell then logs to `LogDirectory` under a name like `ipm-2026-09-04-143201-12345.log` (date, time, `$job`).

Both settings are read once when the shell starts, so changing either mid-session does not relocate the running log. `UpdateOne()` says so, and points at `-log-file` for logging a single command in the current session.

### Behavior

#### What it covers

The `-log-file` modifier is injected into every command's structure at compile time, so every command accepts it. It covers that one command end to end, including any nested shell the command runs internally. `AutoLog` covers a whole process instead, and applies equally to an interactive `zpm` shell and to a one-shot `zpm "install foo"`, since both go through `ShellInternal`.

#### Which one wins when both are on

Exactly one tee runs at a time. A `-log-file` command sets the AutoLog tee aside, writes to its own file, and puts AutoLog back afterwards, so the one-off file holds that command and the AutoLog transcript continues without it. If the two paths name the same file, nothing is switched and both write to it.

#### Appending or starting fresh

`-log-file` always appends, so re-running a command with the same path grows one file rather than overwriting the previous run. AutoLog always starts a new file: it derives `ipm-<date>-<time>-<job>.log`, and if that name is somehow taken it adds a `-N` suffix rather than appending to a file another run may own. Every write after the first in that process appends, so one process is one transcript.

#### What lands in the file

Everything IPM writes to the device, as UTF-8, with ANSI escapes and carriage returns stripped and `write ?n` rendered as spaces from a tracked column. Output is line-buffered and flushed at `write !`, so the file gets whole lines. Each command is preceded by a header that appears only in the file:

```
--- [2026-09-04 14:32:01] [USER] test mypackage ---
```

Three things do not land in it: text typed at a prompt, since reads go straight to the real device; output produced while redirection is suspended for a namespace excursion, discussed below; and child-process output, since `$zf(-100)` bypasses IRIS redirection entirely. The CPF merge is the only case of the last kind and gets its own `cpf-merge-*.log` under the same directory.

#### Relation to the history log

None, deliberately. `%IPM.General.History` records structured, per-namespace rows for installs, uninstalls, and loads, and answers "what is in this namespace and how did it get there". A log file is an unstructured transcript of one session's terminal output. Neither reads the other, and the log file is not pruned by `HistoryRetain`.

#### Relation to existing output redirection

The tee layers onto whatever redirection is already installed rather than replacing it, in both directions: starting a tee inside `%IPM.Utils.Module.BeginCaptureOutput()` leaves the capture intact, and a capture started while a tee is running is not stolen from. This is what makes the tee usable during `zpm test`, where the test harness captures output for its own report.

### Implementation choices

#### State in a process-private global, not an object

Tee state (path, pending buffer, column, prior redirect) lives in the process-private global `^||%IPM.log` rather than in an object. The redirect entry points are routine labels that IRIS calls from arbitrary write sites, with no `$this` and no object context, so instance properties are unreachable from them.

#### Reuse of the existing redirection idiom

The label set and `$zutil` protocol are the same ones `%IPM.Utils.Module.BeginCaptureOutput()` already uses, extended with buffering, ANSI stripping, and chaining.

#### Chaining a prior redirect instead of replacing it

If redirection is already active, `Start()` records the current handler (`$zutil(96,12)`) and forwards through it, and `Stop()` restores it rather than switching redirection off, so starting a tee inside `BeginCaptureOutput()` does not break the capture. One guard is required: if the recorded prior handler is this routine, forwarding would re-enter `wstr()` until `<FRAMESTACK>`, so that value is discarded.

#### Flush on newline, not per write

One logical IPM line arrives as many `write` calls (color escape, label, status text). The buffer accumulates and flushes at `write !`, so the file gets whole lines and each line costs one append.

#### Explicit ownership of the single tee

The single-tee rule needs explicit ownership, because commands run nested shells (`test` internally runs `config set`) and an inner `ShellInternal` seeing an active tee must not stop it. `tOwnsLog` marks the shell-lifetime AutoLog tee as belonging to the frame that started it, and inner frames skip `StartAutoLog()`. A `-log-file` tee is per-command instead, tracked by `tCommandLogPath`, with the tee it displaced in `tDisplacedLogPath`; `RestoreLogAfterCommand()` closes the former and reopens the latter on every path out of a command, including the error and early-return paths.

#### Redirect entry points must not be able to fault

An error inside a handler is reported by writing, and that write re-enters the handler, so any fault becomes an unbounded recursion ending in `<FRAMESTACK>` rather than a diagnosable error. Every state read therefore goes through `$get`, and `detach()` covers the case where redirection still points here but the state is gone. That case is reachable in practice: `%UnitTest.Manager` snapshots the device redirect flag when a suite starts and restores it afterwards, so running `zpm verify` from a shell with AutoLog on had the Manager switch redirection back on after the run had legitimately stopped the tee.

#### Never assume this tee is the installed handler

The prior handler recorded at `Start()` is only the top of the chain until someone else installs one, as `BeginCaptureOutput()` does. So `Stop()` releases the file and clears its state but leaves the chain alone when the installed handler is no longer ours. `FlushBuffer()` follows the same rule: it has to switch interception off to write the log, and it restores whichever handler was installed rather than reinstalling itself.

#### Stripping ANSI in the file only

ANSI stripping happens in `buf()`, after `out()` has already sent the original bytes onward, so the terminal keeps its color and only the file is plain text.

### Namespace excursions

Installing a redirect names a handler *routine*, and the kernel re-resolves that name in the current namespace on every intercepted write. `%IPM.General.OutputLog.1` resolves only where the `%IPM.*` routine mapping exists, so any write issued while parked in a namespace without it (`%SYS`, or a namespace IPM is not installed in) raises `<NOROUTINE>`. IPM makes such excursions routinely, and fifteen brackets across thirteen methods cover the ones that write from inside: web and CSP application configuration, database preparation, namespace deletion, backup, history cleanup, batch activation, default registry lookup, the two install loops in `enable`, the two in the `namespace` command, `repo`, the language extension fallback, and the Studio menu extension lookup. Not having the mapping in `%SYS` is the normal state of an instance, not a broken one, so the tee has to cope rather than require the mapping.

#### The bracket macros

Two macros in `%IPM.Common` bracket the excursion:

```
$$$SuspendRedirection(redirect)   // set:'$data(redirect) redirect = $zutil(82,12,0)
$$$RestoreRedirection(redirect)   // do:$data(redirect) $zutil(82,12,redirect) kill redirect
```

Macros and not utility methods, because the restore has to run while still inside the target namespace, where a `##class(%IPM...)` call is exactly the thing that cannot be resolved. The macros expand inline at compile time in a mapped namespace, so the generated code carries no `%IPM` name to resolve. `RestoreRedirection` is a no-op on an undefined flag, so an exception thrown before the excursion was entered cannot switch interception off and kill a tee that was never suspended. It also clears the flag, and `SuspendRedirection` records state only when the flag is undefined. Together those make the pair safe both inside a loop that switches namespace per iteration, where a second `$zutil(82,12,0)` would otherwise overwrite the saved 1 with 0, and in a method that brackets several excursions in turn.

Restoring on the error path means the bracketed methods that did not already have one gained a `try`/`catch` that restores and rethrows.

#### Narrowing the bracket where the destination is known safe

Where a suspension is in force, the write that follows is either genuinely unsafe or the switch is known to land somewhere IPM is mapped. In the latter case the bracket closes immediately after the switch, so the output still reaches the log. `%IPM.Main.Namespace()` is the example: `IsIPMEnabled()` has already vouched for the destination, so only the switch itself sits inside the bracket. Where the excursion exists only to read something, the read result is hoisted into a variable and the namespace switched back before the write; two skip messages in `enable` are handled that way.

#### Why not relocate the writes instead

Relocating IPM's own `write` statements out of the excursions was the alternative and is not sufficient in general. The fault is namespace-based, not caller-based: `PrepareDatabase()` hands `$io` to `CompactDatabase()`, which writes its own progress from inside the excursion and faults identically. Suspending covers callee output too.

The accepted cost is that output produced while suspended reaches the terminal but not the log file. These are configuration excursions, not the output users are logging, and the alternative is a hard error.

#### Backstops

Two backstops, since a missed restore leaves interception off for the rest of the session rather than for one statement:

- `OutputLog.Resume()`, called from `RestoreLogAfterCommand()` at every command boundary, reinstalls the tee when it is active but interception has been switched off. Caps the damage at one command's output.
- `Test.PM.Unit.NamespaceExcursions` scans `%Dictionary.MethodDefinition` source for every `%IPM.*` method and fails on a write that follows a `set $namespace` without a preceding `$$$SuspendRedirection`, and on a suspend with no matching restore. It reads saved method source, so the macros are still visible as written rather than expanded. There is no allowlist: every site conforms, so there are no exemption entries to go stale. Comments are stripped before scanning, in `//`, `;` and `#;` form and quote-aware, so a commented out macro does not read as a real one.

#### Known gap: the scan guards writes, not switches

> The scan enforces "no `write` inside an unbracketed excursion". The invariant that actually matters is "no *output* inside an unbracketed excursion", and those differ whenever the output comes from a callee. A method that switches namespace, writes nothing itself, and calls something that writes passes the scan and faults at runtime.

`PrepareDatabase()` is the shape of the problem, and it only conforms because it happens to write directly as well; a version that just handed `$io` to `CompactDatabase()` would have gone unflagged. `CreateDatabase()` right below it is an unbracketed `%SYS` excursion of exactly that form.

No source scan can close this. The writing callee may be closed system code (`SYS.Database`), reached through dynamic dispatch, or several frames down. Two things bound the risk rather than remove it:

- The failure is loud. An unguarded excursion raises `<NOROUTINE>` at the write, so any path that gets exercised with a tee active reports itself immediately. That is how `Test.PM.Integration.InstallApplication` surfaced.
- Every excursion that writes at all today is bracketed, and the bracket covers callee output as well, so the known sites are covered.

The complete fix is to enforce the invariant on the switch instead of on the write: bind the suspend and the `set $namespace` into one macro and have the scan require that every switch uses it. That is callee-independent by construction, but it is a much larger change (118 `set $namespace` sites against the 15 brackets here), it needs an opt-out for the narrow brackets described above, and it costs log fidelity everywhere it widens a bracket. Left as a follow-up issue.

Running the suites with `AutoLog` on is the only check that covers callee output, and it stays a manual step rather than a CI leg: it means a second full `zpm verify -only` run at 15-25 minutes, and it still only covers the paths the suites happen to exercise.

#### Other scan limits

The scan reads what is compiled in the namespace, not the working tree, so `zpm test` (which loads the module first) sees current source, but a local edit-then-test cycle can pass against stale code.

#### The one site that cannot use the macros

`%IPM.Main.LanguageExtensions()` has its body emitted verbatim into `%ZLANGC00.mac`, which is compiled without IPM's include file, so it spells out `$zutil(82,12,0)` and `do:$data(redirect) $zutil(82,12,redirect)` instead. The scan accepts that raw form as a suspend for exactly this reason. The suspend/restore pairing check stays scoped to the macros, since the raw form is also how redirection gets switched off for good, as `Stop()` does.

#### A latent bug this turned up

In `%IPM.Main.LanguageExtensions()`, `new $namespace` restores at method exit rather than at the end of the `while` loop, so the "IPM is not installed" message and the newlines before `Terminate`/`halt` all ran in whichever namespace the loop last visited. It is only unreachable today because that fallback runs where IPM is absent, so no tee is active; the suspension now covers the whole tail of the method regardless.

`%IPM.Utils.Module.BeginCaptureOutput()` has the same latent flaw and is left for a follow-up issue; it predates this PR and is not reached by the tee paths.

### Technical details: the redirect entry points

IRIS device redirection lets a process intercept every `write` to a device. `use $io::("^"_$zname)` names the handling routine and `$zutil(82,12,1)` switches interception on; `$zutil(82,12,0)` switches it off and returns the prior state. While it is on, the kernel calls a fixed set of labels in that routine instead of touching the device. This is why `Start()` is `[ ProcedureBlock = 0 ]`: the labels have to be routine-level entry points in the generated code for `^routine` to reach them.

The labels IRIS calls, one per kind of write:

| Label | Called for | Behavior |
|---|---|---|
| `wstr(s)` | `write <string>` | `out(s)` to the device, `buf(s)` to the log buffer |
| `wnl()` | `write !` | `outctl("!")`, then flush the buffer with a trailing LF |
| `wff()` | `write #` | `outctl("#")`, then flush with a form feed |
| `wchr(s)` | `write *<code>` | Always echoes; buffers only if the code is printable, so a partial escape sequence written a character at a time cannot land in the file |
| `wtab(s)` | `write ?n` | Pads from the tracked column, since `$x` is not maintained under redirection |
| `rstr(sz,to)` | `read` | Reads from the real device and returns the value |
| `rchr(to)` | `read *1` | Same, single character |

The rest are internal helpers, not part of the IRIS contract:

- `out(s)` gets a string to the terminal. With a prior handler recorded it installs that handler and writes, letting the chain run; otherwise it disables interception, writes to the raw device, and restores the previous interception state.
- `outctl(c)` is `out()` for `!` and `#`. It exists because a prior handler has to receive these as `write !` / `write #` to reach its own `wnl()`/`wff()`, which it would not if they were passed as a string to `wstr()`.
- `detach(s)` uninstalls redirection and writes `s` to the raw device. Used when the state is gone, where there is nothing left to forward through.
- `reattach(rd)` reinstalls this routine and restores the interception flag, or leaves redirection off when there is no handler name to reinstall, rather than installing `"^"`.
- `buf(s)` strips ANSI and CR, appends to `^||%IPM.log("buf")`, and advances the column counter. Because the buffer is stripped on the way in, flushes and column math never rescan it. It no-ops when no tee is active so it cannot resurrect a half-populated one.
- `flush(tail)` appends the physical LF or form feed and calls `FlushBuffer()`, which turns interception off around its own `write` so writing the log does not recurse into the tee, then restores the handler that was installed. If that write fails, it clears the stored path rather than throwing, since throwing here would surface as a failure of whatever unrelated code happened to be writing; the tee degrades to terminal-only.

`StripAnsi()` walks the string with `$find` on `$char(27)`. For a CSI sequence (`ESC [`) it consumes parameter and intermediate bytes (`0x20`-`0x3F`) through the final byte (`0x40`-`0x7E`); other escapes are consumed as two bytes. A sequence truncated at the end of the string is dropped rather than leaving a bare ESC.

## Testing

`Test.PM.Unit.StripAnsi` covers `StripAnsi()` directly: plain text, text containing `[0m` with no ESC, single- and multi-parameter CSI sequences, non-CSI two-byte escapes (`ESC M`, `ESC 7`), truncated sequences, and non-ASCII characters.

`Test.PM.Integration.OutputLog` drives real commands through `%IPM.Main.Shell()` and inspects the resulting file:

- `TestExplicitLogFile`, `TestBareNameResolution`, `TestAppendMode`, `TestHeaderFormat` for the `-log-file` surface.
- `TestTeeEquivalence` wraps a logged command in `BeginCaptureOutput()` and compares the captured device output against the file past the header, which also exercises the chaining path.
- `TestANSIStripping`, `TestIndentationAndEncoding` for file content fidelity.
- `TestAutoLog`, `TestAutoLogSharedFile` (three commands in one process produce one file with three headers), `TestAutoLogValidation`.
- `TestLogFileRestoresAutoLog` checks the per-command contract: the AutoLog tee is the active one again after a `-log-file` command, the one-off file holds that command, and the AutoLog transcript holds the following command and only it.
- `TestZeroCostPath` asserts no tee is installed when the modifier is absent and `AutoLog` is off.

`OnAfterOneTest` restores `LogDirectory` and `AutoLog`, stops any leaked tee, and drops any leaked `BeginCaptureOutput()` state, since a test that fails mid-redirect would otherwise corrupt the output of every test after it. It also puts back a tee the suite inherited, because `%UnitTest.Manager` fails the case if the device redirect flag does not match the value it snapshotted. `ClearAutoLog()` exists for the same reason: the AutoLog path is deliberately per-process, so tests have to reset it between cases.

`Test.PM.Unit.NamespaceExcursions` enforces the excursion rule described above. `Test.PM.Integration.InstallApplication` is the case that surfaced the problem; it passes with `%SYS` unmapped and `AutoLog` on.

The suites need to be run in all three configurations: AutoLog off, AutoLog on, and AutoLog on with a tee already active before the run. AutoLog on is the one that matters most, for two reasons. The whole run then happens with a tee installed underneath every capture the tests do, and it is the only check that covers output written from inside an excursion by a callee, which the source scan cannot see. CI runs with AutoLog off, so this is a manual pre-merge step.

Not covered by automated tests: the `tOwnsLog` nested-shell guard is exercised indirectly whenever a logged command runs a nested shell, but there is no test that asserts it directly.

## Checklist
<!-- You can select a checkbox by changing "[ ]" to "[x]" -->
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] Changelog entry added.
- [x] Unit (`zpm test -only`) and integration tests (`zpm verify -only`) pass.
- [x] Style matches the style guide in the [contributing guide](https://github.com/intersystems/ipm/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Documentation has been/will be updated
  - Source controlled docs, e.g. README.md, should be included in this PR and Wiki changes should be made after this PR is merged (add an extra issue for this if needed)
- [x] Pull request correctly renders in the "Preview" tab.
